### PR TITLE
compose <> metal texture interop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build*/
+.gradle/
+hs_err_pid*.log
 .zig-cache/
 zig-out/
 zig-pkg/

--- a/examples/compose-map/build.gradle.kts
+++ b/examples/compose-map/build.gradle.kts
@@ -53,7 +53,6 @@ compose.desktop {
 
 tasks.withType<JavaExec>().configureEach {
   dependsOn("compileNativeMetal")
-  systemProperty("skiko.renderApi", System.getProperty("skiko.renderApi") ?: "METAL")
   systemProperty("java.library.path", nativeOutputDir.get().asFile.absolutePath)
 }
 

--- a/examples/compose-map/build.gradle.kts
+++ b/examples/compose-map/build.gradle.kts
@@ -1,0 +1,62 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+  kotlin("jvm") version "2.3.21"
+  id("org.jetbrains.kotlin.plugin.compose") version "2.3.21"
+  id("org.jetbrains.compose") version "1.10.3"
+}
+
+kotlin {
+  jvmToolchain(21)
+}
+
+dependencies {
+  implementation(compose.desktop.currentOs)
+}
+
+val nativeOutputDir = layout.buildDirectory.dir("native")
+val nativeLibrary = nativeOutputDir.map { it.file("libcompose_map_metal.dylib") }
+
+tasks.register<Exec>("compileNativeMetal") {
+  onlyIf { org.gradle.internal.os.OperatingSystem.current().isMacOsX }
+  val javaHome = providers.systemProperty("java.home")
+  inputs.file("src/main/native/NativeMetalBridge.mm")
+  outputs.file(nativeLibrary)
+  doFirst { nativeOutputDir.get().asFile.mkdirs() }
+  commandLine(
+    "xcrun",
+    "--sdk", "macosx",
+    "clang++",
+    "-std=c++17",
+    "-dynamiclib",
+    "-fobjc-arc",
+    "-I${javaHome.get()}/include",
+    "-I${javaHome.get()}/include/darwin",
+    "-framework", "Foundation",
+    "-framework", "Metal",
+    "-framework", "QuartzCore",
+    "src/main/native/NativeMetalBridge.mm",
+    "-o", nativeLibrary.get().asFile.absolutePath,
+  )
+}
+
+compose.desktop {
+  application {
+    mainClass = "MainKt"
+    nativeDistributions {
+      targetFormats(TargetFormat.Dmg)
+      packageName = "compose-map-poc"
+      packageVersion = "1.0.0"
+    }
+  }
+}
+
+tasks.withType<JavaExec>().configureEach {
+  dependsOn("compileNativeMetal")
+  systemProperty("skiko.renderApi", System.getProperty("skiko.renderApi") ?: "METAL")
+  systemProperty("java.library.path", nativeOutputDir.get().asFile.absolutePath)
+}
+
+tasks.named("build") {
+  dependsOn("compileNativeMetal")
+}

--- a/examples/compose-map/gradle.properties
+++ b/examples/compose-map/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8

--- a/examples/compose-map/settings.gradle.kts
+++ b/examples/compose-map/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+  repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
+
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+  }
+}
+
+rootProject.name = "compose-map-poc"

--- a/examples/compose-map/src/main/kotlin/Main.kt
+++ b/examples/compose-map/src/main/kotlin/Main.kt
@@ -45,7 +45,10 @@ import org.jetbrains.skia.SurfaceOrigin
 import org.jetbrains.skiko.SkiaLayer
 import java.awt.Component
 import java.awt.Container
+import kotlin.math.PI
+import kotlin.math.cos
 import kotlin.math.roundToInt
+import kotlin.math.sin
 
 fun main() {
   application {
@@ -61,11 +64,11 @@ private fun App(window: ComposeWindow) {
   val windowReport = remember(window) { ComposeWindowReport.collect(window) }
   val renderer = remember(window) { ExternalGpuRenderer(windowReport.skiaLayer) }
   var status by remember { mutableStateOf("Waiting for first Compose canvas") }
-  var alpha by remember { mutableStateOf(1f) }
-  var rotation by remember { mutableStateOf(0f) }
-  var scale by remember { mutableStateOf(1f) }
-  var cornerRadius by remember { mutableStateOf(0f) }
-  var translationX by remember { mutableStateOf(0f) }
+  var minAlpha by remember { mutableStateOf(0.68f) }
+  var rotationAmplitude by remember { mutableStateOf(18f) }
+  var scaleAmplitude by remember { mutableStateOf(0.16f) }
+  var scaleXAmplitude by remember { mutableStateOf(0.12f) }
+  var cornerRadius by remember { mutableStateOf(44f) }
 
   LaunchedEffect(Unit) {
     while (isActive) {
@@ -86,18 +89,24 @@ private fun App(window: ComposeWindow) {
       verticalArrangement = Arrangement.Center,
       horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-      val shape = RoundedCornerShape(cornerRadius.dp)
+      val phase = frame * (2.0 * PI / 180.0)
+      val animatedAlpha = minAlpha + (1f - minAlpha) * ((sin(phase) + 1.0) / 2.0).toFloat()
+      val animatedRotation = (sin(phase * 0.7) * rotationAmplitude).toFloat()
+      val animatedScale = 1f + (cos(phase * 0.9) * scaleAmplitude).toFloat()
+      val animatedScaleX = animatedScale * (1f + (sin(phase * 1.3) * scaleXAmplitude).toFloat())
+      val animatedCornerRadius = (cornerRadius * (0.35f + 0.65f * ((cos(phase * 0.8) + 1.0) / 2.0).toFloat()))
+        .coerceAtLeast(0f)
+      val shape = RoundedCornerShape(animatedCornerRadius.dp)
       Box(
         modifier = Modifier
           .size(560.dp, 360.dp)
           .graphicsLayer {
-            this.alpha = alpha
-            rotationZ = rotation
-            scaleX = scale
-            scaleY = scale
-            this.translationX = translationX
+            this.alpha = animatedAlpha
+            rotationZ = animatedRotation
+            scaleX = animatedScaleX
+            scaleY = animatedScale
             this.shape = shape
-            clip = cornerRadius > 0f
+            clip = animatedCornerRadius > 0f
           }
           .background(Color.Black, shape)
           .border(1.dp, Color(0xFF555555), shape),
@@ -121,11 +130,11 @@ private fun App(window: ComposeWindow) {
       verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
       Text("Native Metal texture in Compose", color = Color.White)
-      ControlSlider("alpha", alpha, 0.2f..1f) { alpha = it }
-      ControlSlider("rotationZ", rotation, -35f..35f) { rotation = it }
-      ControlSlider("scale", scale, 0.65f..1.2f) { scale = it }
+      ControlSlider("min alpha", minAlpha, 0.2f..1f) { minAlpha = it }
+      ControlSlider("rotation amplitude", rotationAmplitude, 0f..35f) { rotationAmplitude = it }
+      ControlSlider("scale amplitude", scaleAmplitude, 0f..0.35f) { scaleAmplitude = it }
+      ControlSlider("scaleX amplitude", scaleXAmplitude, 0f..0.35f) { scaleXAmplitude = it }
       ControlSlider("corner radius", cornerRadius, 0f..96f) { cornerRadius = it }
-      ControlSlider("translationX", translationX, -180f..180f) { translationX = it }
       Text(status, color = Color(0xFFB8B8B8))
       Text("Skiko: ${windowReport.summary}", color = Color(0xFF777777))
     }

--- a/examples/compose-map/src/main/kotlin/Main.kt
+++ b/examples/compose-map/src/main/kotlin/Main.kt
@@ -1,0 +1,314 @@
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Slider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import kotlinx.coroutines.isActive
+import org.jetbrains.skia.BackendRenderTarget
+import org.jetbrains.skia.ContentChangeMode
+import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.SamplingMode
+import org.jetbrains.skia.Surface
+import org.jetbrains.skia.SurfaceColorFormat
+import org.jetbrains.skia.SurfaceOrigin
+import org.jetbrains.skiko.SkiaLayer
+import java.awt.Component
+import java.awt.Container
+import kotlin.math.roundToInt
+
+fun main() {
+  application {
+    Window(onCloseRequest = ::exitApplication, title = "Compose GPU Texture PoC") {
+      App(window)
+    }
+  }
+}
+
+@Composable
+private fun App(window: ComposeWindow) {
+  var frame by remember { mutableIntStateOf(0) }
+  val windowReport = remember(window) { ComposeWindowReport.collect(window) }
+  val renderer = remember(window) { ExternalGpuRenderer(windowReport.skiaLayer) }
+  var status by remember { mutableStateOf("Waiting for first Compose canvas") }
+  var alpha by remember { mutableStateOf(1f) }
+  var rotation by remember { mutableStateOf(0f) }
+  var scale by remember { mutableStateOf(1f) }
+  var cornerRadius by remember { mutableStateOf(0f) }
+  var translationX by remember { mutableStateOf(0f) }
+
+  LaunchedEffect(Unit) {
+    while (isActive) {
+      withFrameMillis { frame = (frame + 1) % 3600 }
+    }
+  }
+
+  Row(
+    modifier = Modifier.fillMaxSize().background(Color(0xFF101010)).padding(24.dp),
+    horizontalArrangement = Arrangement.spacedBy(24.dp),
+  ) {
+    Column(
+      modifier = Modifier.weight(1f).fillMaxSize(),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      val shape = RoundedCornerShape(cornerRadius.dp)
+      Box(
+        modifier = Modifier
+          .size(560.dp, 360.dp)
+          .graphicsLayer {
+            this.alpha = alpha
+            rotationZ = rotation
+            scaleX = scale
+            scaleY = scale
+            this.translationX = translationX
+            this.shape = shape
+            clip = cornerRadius > 0f
+          }
+          .background(Color.Black, shape)
+          .border(1.dp, Color(0xFF555555), shape),
+      ) {
+        Canvas(Modifier.fillMaxSize()) {
+          drawIntoCanvas { composeCanvas ->
+            val result = renderer.renderAndDraw(
+              composeCanvas.nativeCanvas,
+              targetWidth = size.width.roundToInt().coerceAtLeast(1),
+              targetHeight = size.height.roundToInt().coerceAtLeast(1),
+              frame = frame,
+            )
+            status = result
+          }
+        }
+      }
+    }
+
+    Column(
+      modifier = Modifier.width(320.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Text("Native Metal texture in Compose", color = Color.White)
+      ControlSlider("alpha", alpha, 0.2f..1f) { alpha = it }
+      ControlSlider("rotationZ", rotation, -35f..35f) { rotation = it }
+      ControlSlider("scale", scale, 0.65f..1.2f) { scale = it }
+      ControlSlider("corner radius", cornerRadius, 0f..96f) { cornerRadius = it }
+      ControlSlider("translationX", translationX, -180f..180f) { translationX = it }
+      Text(status, color = Color(0xFFB8B8B8))
+      Text("Skiko: ${windowReport.summary}", color = Color(0xFF777777))
+    }
+  }
+}
+
+@Composable
+private fun ControlSlider(label: String, value: Float, range: ClosedFloatingPointRange<Float>, onChange: (Float) -> Unit) {
+  Column {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Text(label, color = Color.White)
+      Text("%.2f".format(value), color = Color(0xFFB8B8B8))
+    }
+    Slider(value = value, onValueChange = onChange, valueRange = range)
+  }
+}
+
+private class ExternalGpuRenderer(private val skiaLayer: SkiaLayer?) {
+  private var surface: Surface? = null
+  private var renderTarget: BackendRenderTarget? = null
+  private var nativeTextureHandle = 0L
+  private var width = 0
+  private var height = 0
+  private var contextIdentity = 0
+  private var lastResult: String? = null
+  private val retainedImages = ArrayDeque<Image>()
+
+  fun renderAndDraw(canvas: org.jetbrains.skia.Canvas, targetWidth: Int, targetHeight: Int, frame: Int): String {
+    val owner = canvas.ownerForProbe()
+    val contextProbe = SkikoContextProbe.from(skiaLayer)
+    val context = contextProbe.context
+      ?: return report(
+        "Waiting for Skiko GPU DirectContext. Compose canvas owner=${owner?.javaClass?.name ?: "null"}; ${contextProbe.status}",
+      )
+
+    val identity = System.identityHashCode(context)
+    ensureSurface(context, identity, targetWidth, targetHeight)
+    val gpuSurface = surface ?: return report("Failed to create GPU offscreen surface")
+
+    NativeMetalBridge.render(nativeTextureHandle, frame)
+    gpuSurface.notifyContentWillChange(ContentChangeMode.DISCARD)
+    val image = gpuSurface.makeImageSnapshot()
+    retainImageForRecordedFrame(image)
+    drawImage(canvas, image, targetWidth, targetHeight)
+
+    return report(
+      "GPU path active: canvas owner=${owner?.javaClass?.simpleName}, " +
+        "renderApi=${skiaLayer?.renderApi}, native Metal texture=${targetWidth}x$targetHeight",
+    )
+  }
+
+  private fun report(result: String): String {
+    if (result != lastResult) {
+      lastResult = result
+      println(result)
+    }
+    return result
+  }
+
+  private fun ensureSurface(context: DirectContext, identity: Int, targetWidth: Int, targetHeight: Int) {
+    if (surface != null && width == targetWidth && height == targetHeight && contextIdentity == identity) return
+
+    surface?.close()
+    renderTarget?.close()
+    if (nativeTextureHandle != 0L) NativeMetalBridge.dispose(nativeTextureHandle)
+    width = targetWidth
+    height = targetHeight
+    contextIdentity = identity
+    nativeTextureHandle = NativeMetalBridge.create(targetWidth, targetHeight)
+    check(nativeTextureHandle != 0L) { "Native Metal texture creation failed" }
+    renderTarget = BackendRenderTarget.makeMetal(
+      width = targetWidth,
+      height = targetHeight,
+      texturePtr = NativeMetalBridge.texturePtr(nativeTextureHandle),
+    )
+    surface = Surface.makeFromBackendRenderTarget(
+      context = context,
+      rt = renderTarget!!,
+      origin = SurfaceOrigin.TOP_LEFT,
+      colorFormat = SurfaceColorFormat.BGRA_8888,
+      colorSpace = null,
+      surfaceProps = null,
+    ) ?: error("Skia could not wrap native Metal texture")
+  }
+
+  private fun drawImage(canvas: org.jetbrains.skia.Canvas, image: Image, targetWidth: Int, targetHeight: Int) {
+    canvas.drawImageRect(
+      image = image,
+      src = Rect.makeWH(image.width.toFloat(), image.height.toFloat()),
+      dst = Rect.makeWH(targetWidth.toFloat(), targetHeight.toFloat()),
+      samplingMode = SamplingMode.LINEAR,
+      paint = null,
+      strict = true,
+    )
+  }
+
+  private fun retainImageForRecordedFrame(image: Image) {
+    retainedImages.addLast(image)
+    while (retainedImages.size > 8) {
+      retainedImages.removeFirst().close()
+    }
+  }
+}
+
+private object NativeMetalBridge {
+  init {
+    System.loadLibrary("compose_map_metal")
+  }
+
+  external fun create(width: Int, height: Int): Long
+  external fun dispose(handle: Long)
+  external fun texturePtr(handle: Long): Long
+  external fun render(handle: Long, frame: Int)
+}
+
+private fun org.jetbrains.skia.Canvas.ownerForProbe(): Any? {
+  val field = org.jetbrains.skia.Canvas::class.java.getDeclaredField("_owner")
+  field.isAccessible = true
+  return field.get(this)
+}
+
+private data class ComposeWindowReport(val skiaLayer: SkiaLayer?, val summary: String) {
+  companion object {
+    fun collect(window: ComposeWindow): ComposeWindowReport {
+      val skiaLayer = window.findSkiaLayer()
+        ?: return ComposeWindowReport(null, "no SkiaLayer")
+      return ComposeWindowReport(skiaLayer, "renderApi=${skiaLayer.renderApi}")
+    }
+  }
+}
+
+private data class SkikoContextProbe(val context: DirectContext?, val status: String) {
+  companion object {
+    fun from(skiaLayer: SkiaLayer?): SkikoContextProbe {
+      if (skiaLayer == null) return SkikoContextProbe(null, "no SkiaLayer")
+      return runCatching {
+        val redrawer = skiaLayer.javaClass.getMethod("getRedrawer\$skiko").invoke(skiaLayer)
+          ?: return SkikoContextProbe(null, "SkiaLayer has no redrawer yet")
+        val contextHandler = redrawer.findFieldValue("contextHandler")
+          ?: return SkikoContextProbe(null, "${redrawer.javaClass.name} has no contextHandler")
+        val context = contextHandler.findFieldValue("context") as? DirectContext
+          ?: return SkikoContextProbe(null, "${contextHandler.javaClass.name} has no DirectContext yet")
+        SkikoContextProbe(context, "found ${contextHandler.javaClass.simpleName}")
+      }.getOrElse { error ->
+        SkikoContextProbe(null, "reflection failed: ${error.javaClass.simpleName}: ${error.message}")
+      }
+    }
+  }
+}
+
+private fun Any.findFieldValue(name: String): Any? {
+  var type: Class<*>? = javaClass
+  while (type != null) {
+    val field = type.declaredFields.firstOrNull { it.name == name }
+    if (field != null) {
+      field.isAccessible = true
+      return field.get(this)
+    }
+    type = type.superclass
+  }
+  return null
+}
+
+private fun ComposeWindow.findSkiaLayer(): SkiaLayer? {
+  findSkiaLayerIn(this)?.let { return it }
+
+  var type: Class<*>? = javaClass
+  while (type != null) {
+    val field = type.declaredFields.firstOrNull { SkiaLayer::class.java.isAssignableFrom(it.type) }
+    if (field != null) {
+      field.isAccessible = true
+      return field.get(this) as? SkiaLayer
+    }
+    type = type.superclass
+  }
+  return null
+}
+
+private fun findSkiaLayerIn(component: Component): SkiaLayer? {
+  if (component is SkiaLayer) return component
+  if (component is Container) {
+    component.components.forEach { child ->
+      findSkiaLayerIn(child)?.let { return it }
+    }
+  }
+  return null
+}

--- a/examples/compose-map/src/main/kotlin/Main.kt
+++ b/examples/compose-map/src/main/kotlin/Main.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Slider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -70,6 +71,10 @@ private fun App(window: ComposeWindow) {
     while (isActive) {
       withFrameMillis { frame = (frame + 1) % 3600 }
     }
+  }
+
+  DisposableEffect(renderer) {
+    onDispose { renderer.close() }
   }
 
   Row(
@@ -142,26 +147,26 @@ private fun ControlSlider(label: String, value: Float, range: ClosedFloatingPoin
   }
 }
 
-private class ExternalGpuRenderer(private val skiaLayer: SkiaLayer?) {
+private class ExternalGpuRenderer(private val skiaLayer: SkiaLayer?) : AutoCloseable {
   private var surface: Surface? = null
   private var renderTarget: BackendRenderTarget? = null
   private var nativeTextureHandle = 0L
   private var width = 0
   private var height = 0
   private var contextIdentity = 0
+  private var metalDevicePtr = 0L
   private var lastResult: String? = null
   private val retainedImages = ArrayDeque<Image>()
 
   fun renderAndDraw(canvas: org.jetbrains.skia.Canvas, targetWidth: Int, targetHeight: Int, frame: Int): String {
-    val owner = canvas.ownerForProbe()
-    val contextProbe = SkikoContextProbe.from(skiaLayer)
-    val context = contextProbe.context
+    val metalAccess = ComposeMetalAccess.from(skiaLayer)
+    val context = metalAccess.context
       ?: return report(
-        "Waiting for Skiko GPU DirectContext. Compose canvas owner=${owner?.javaClass?.name ?: "null"}; ${contextProbe.status}",
+        "Waiting for Skiko Metal context: ${metalAccess.status}",
       )
 
     val identity = System.identityHashCode(context)
-    ensureSurface(context, identity, targetWidth, targetHeight)
+    ensureSurface(context, identity, metalAccess.devicePtr, targetWidth, targetHeight)
     val gpuSurface = surface ?: return report("Failed to create GPU offscreen surface")
 
     NativeMetalBridge.render(nativeTextureHandle, frame)
@@ -171,8 +176,7 @@ private class ExternalGpuRenderer(private val skiaLayer: SkiaLayer?) {
     drawImage(canvas, image, targetWidth, targetHeight)
 
     return report(
-      "GPU path active: canvas owner=${owner?.javaClass?.simpleName}, " +
-        "renderApi=${skiaLayer?.renderApi}, native Metal texture=${targetWidth}x$targetHeight",
+      "GPU path active: renderApi=${skiaLayer?.renderApi}, native Metal texture=${targetWidth}x$targetHeight",
     )
   }
 
@@ -184,16 +188,20 @@ private class ExternalGpuRenderer(private val skiaLayer: SkiaLayer?) {
     return result
   }
 
-  private fun ensureSurface(context: DirectContext, identity: Int, targetWidth: Int, targetHeight: Int) {
-    if (surface != null && width == targetWidth && height == targetHeight && contextIdentity == identity) return
+  private fun ensureSurface(context: DirectContext, identity: Int, devicePtr: Long, targetWidth: Int, targetHeight: Int) {
+    if (surface != null &&
+      width == targetWidth &&
+      height == targetHeight &&
+      contextIdentity == identity &&
+      metalDevicePtr == devicePtr
+    ) return
 
-    surface?.close()
-    renderTarget?.close()
-    if (nativeTextureHandle != 0L) NativeMetalBridge.dispose(nativeTextureHandle)
+    closeGpuResources()
     width = targetWidth
     height = targetHeight
     contextIdentity = identity
-    nativeTextureHandle = NativeMetalBridge.create(targetWidth, targetHeight)
+    metalDevicePtr = devicePtr
+    nativeTextureHandle = NativeMetalBridge.create(devicePtr, targetWidth, targetHeight)
     check(nativeTextureHandle != 0L) { "Native Metal texture creation failed" }
     renderTarget = BackendRenderTarget.makeMetal(
       width = targetWidth,
@@ -227,6 +235,28 @@ private class ExternalGpuRenderer(private val skiaLayer: SkiaLayer?) {
       retainedImages.removeFirst().close()
     }
   }
+
+  override fun close() {
+    closeGpuResources()
+    width = 0
+    height = 0
+    contextIdentity = 0
+    metalDevicePtr = 0L
+  }
+
+  private fun closeGpuResources() {
+    while (retainedImages.isNotEmpty()) {
+      retainedImages.removeFirst().close()
+    }
+    surface?.close()
+    surface = null
+    renderTarget?.close()
+    renderTarget = null
+    if (nativeTextureHandle != 0L) {
+      NativeMetalBridge.dispose(nativeTextureHandle)
+      nativeTextureHandle = 0L
+    }
+  }
 }
 
 private object NativeMetalBridge {
@@ -234,16 +264,10 @@ private object NativeMetalBridge {
     System.loadLibrary("compose_map_metal")
   }
 
-  external fun create(width: Int, height: Int): Long
+  external fun create(skikoMetalDevicePtr: Long, width: Int, height: Int): Long
   external fun dispose(handle: Long)
   external fun texturePtr(handle: Long): Long
   external fun render(handle: Long, frame: Int)
-}
-
-private fun org.jetbrains.skia.Canvas.ownerForProbe(): Any? {
-  val field = org.jetbrains.skia.Canvas::class.java.getDeclaredField("_owner")
-  field.isAccessible = true
-  return field.get(this)
 }
 
 private data class ComposeWindowReport(val skiaLayer: SkiaLayer?, val summary: String) {
@@ -256,20 +280,28 @@ private data class ComposeWindowReport(val skiaLayer: SkiaLayer?, val summary: S
   }
 }
 
-private data class SkikoContextProbe(val context: DirectContext?, val status: String) {
+// This is the demo's only intentional Skiko gap: public access to the live Metal
+// DirectContext and device backing the current Compose scene.
+private data class ComposeMetalAccess(val context: DirectContext?, val devicePtr: Long, val status: String) {
   companion object {
-    fun from(skiaLayer: SkiaLayer?): SkikoContextProbe {
-      if (skiaLayer == null) return SkikoContextProbe(null, "no SkiaLayer")
+    fun from(skiaLayer: SkiaLayer?): ComposeMetalAccess {
+      if (skiaLayer == null) return ComposeMetalAccess(null, 0L, "no SkiaLayer")
       return runCatching {
         val redrawer = skiaLayer.javaClass.getMethod("getRedrawer\$skiko").invoke(skiaLayer)
-          ?: return SkikoContextProbe(null, "SkiaLayer has no redrawer yet")
+          ?: return ComposeMetalAccess(null, 0L, "SkiaLayer has no redrawer yet")
         val contextHandler = redrawer.findFieldValue("contextHandler")
-          ?: return SkikoContextProbe(null, "${redrawer.javaClass.name} has no contextHandler")
+          ?: return ComposeMetalAccess(null, 0L, "${redrawer.javaClass.name} has no contextHandler")
         val context = contextHandler.findFieldValue("context") as? DirectContext
-          ?: return SkikoContextProbe(null, "${contextHandler.javaClass.name} has no DirectContext yet")
-        SkikoContextProbe(context, "found ${contextHandler.javaClass.simpleName}")
+          ?: return ComposeMetalAccess(null, 0L, "${contextHandler.javaClass.name} has no DirectContext yet")
+        val device = contextHandler.findFieldValue("device")
+          ?: return ComposeMetalAccess(null, 0L, "${contextHandler.javaClass.name} has no Metal device")
+        val devicePtr = when (device) {
+          is Long -> device
+          else -> device.findFieldValue("ptr") as? Long
+        } ?: return ComposeMetalAccess(null, 0L, "${device.javaClass.name} has no native pointer")
+        ComposeMetalAccess(context, devicePtr, "found ${contextHandler.javaClass.simpleName}")
       }.getOrElse { error ->
-        SkikoContextProbe(null, "reflection failed: ${error.javaClass.simpleName}: ${error.message}")
+        ComposeMetalAccess(null, 0L, "reflection failed: ${error.javaClass.simpleName}: ${error.message}")
       }
     }
   }
@@ -289,18 +321,7 @@ private fun Any.findFieldValue(name: String): Any? {
 }
 
 private fun ComposeWindow.findSkiaLayer(): SkiaLayer? {
-  findSkiaLayerIn(this)?.let { return it }
-
-  var type: Class<*>? = javaClass
-  while (type != null) {
-    val field = type.declaredFields.firstOrNull { SkiaLayer::class.java.isAssignableFrom(it.type) }
-    if (field != null) {
-      field.isAccessible = true
-      return field.get(this) as? SkiaLayer
-    }
-    type = type.superclass
-  }
-  return null
+  return findSkiaLayerIn(this)
 }
 
 private fun findSkiaLayerIn(component: Component): SkiaLayer? {

--- a/examples/compose-map/src/main/native/NativeMetalBridge.mm
+++ b/examples/compose-map/src/main/native/NativeMetalBridge.mm
@@ -4,6 +4,12 @@
 #import <Metal/Metal.h>
 #include <jni.h>
 
+// Mirrors the Skiko runtime object's Metal-facing properties used by this demo.
+@interface SkikoMetalDevice : NSObject
+@property(nonatomic, strong) id<MTLDevice> adapter;
+@property(nonatomic, strong) id<MTLCommandQueue> queue;
+@end
+
 namespace {
 
 struct MetalTextureState {
@@ -61,9 +67,14 @@ auto makePipeline(id<MTLDevice> device) -> id<MTLRenderPipelineState> {
   return pipeline;
 }
 
-auto createState(uint32_t width, uint32_t height) -> MetalTextureState* {
+auto createState(void* skikoMetalDevicePtr, uint32_t width, uint32_t height)
+  -> MetalTextureState* {
   @autoreleasepool {
-    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    SkikoMetalDevice* skikoMetalDevice =
+      (__bridge SkikoMetalDevice*)skikoMetalDevicePtr;
+    if (skikoMetalDevice == nil) return nullptr;
+
+    id<MTLDevice> device = skikoMetalDevice.adapter;
     if (device == nil) return nullptr;
 
     MTLTextureDescriptor* descriptor = [MTLTextureDescriptor
@@ -75,7 +86,10 @@ auto createState(uint32_t width, uint32_t height) -> MetalTextureState* {
     descriptor.storageMode = MTLStorageModePrivate;
 
     id<MTLTexture> texture = [device newTextureWithDescriptor:descriptor];
-    id<MTLCommandQueue> queue = [device newCommandQueue];
+    id<MTLCommandQueue> queue = skikoMetalDevice.queue;
+    if (queue == nil) {
+      queue = [device newCommandQueue];
+    }
     id<MTLRenderPipelineState> pipeline = makePipeline(device);
     if (texture == nil || queue == nil || pipeline == nil) return nullptr;
 
@@ -94,12 +108,14 @@ auto createState(uint32_t width, uint32_t height) -> MetalTextureState* {
 
 }  // namespace
 
-extern "C" JNIEXPORT jlong JNICALL
-Java_NativeMetalBridge_create(JNIEnv*, jclass, jint width, jint height) {
-  if (width <= 0 || height <= 0) return 0;
-  return reinterpret_cast<jlong>(
-    createState(static_cast<uint32_t>(width), static_cast<uint32_t>(height))
-  );
+extern "C" JNIEXPORT jlong JNICALL Java_NativeMetalBridge_create(
+  JNIEnv*, jclass, jlong skikoMetalDevicePtr, jint width, jint height
+) {
+  if (skikoMetalDevicePtr == 0 || width <= 0 || height <= 0) return 0;
+  return reinterpret_cast<jlong>(createState(
+    reinterpret_cast<void*>(skikoMetalDevicePtr), static_cast<uint32_t>(width),
+    static_cast<uint32_t>(height)
+  ));
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/examples/compose-map/src/main/native/NativeMetalBridge.mm
+++ b/examples/compose-map/src/main/native/NativeMetalBridge.mm
@@ -1,0 +1,147 @@
+#include <cstdint>
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#include <jni.h>
+
+namespace {
+
+struct MetalTextureState {
+  id<MTLDevice> device;
+  id<MTLCommandQueue> queue;
+  id<MTLTexture> texture;
+  id<MTLLibrary> library;
+  id<MTLRenderPipelineState> pipeline;
+  uint32_t width;
+  uint32_t height;
+};
+
+auto shaderSource() -> NSString* {
+  return @"#include <metal_stdlib>\n"
+          "using namespace metal;\n"
+          "struct VertexOut { float4 position [[position]]; float3 color; };\n"
+          "vertex VertexOut vertex_main(uint vertex_id [[vertex_id]], constant "
+          "float& phase [[buffer(0)]]) {\n"
+          "  float2 positions[3] = { float2(-0.82, -0.70), float2(0.86, "
+          "-0.54), float2(0.20, 0.78) };\n"
+          "  float3 colors[3] = { float3(0.12 + phase * 0.35, 0.92, 0.74), "
+          "float3(1.0, 0.76, 0.18), float3(0.28, 0.55, 1.0) };\n"
+          "  VertexOut out;\n"
+          "  out.position = float4(positions[vertex_id], 0.0, 1.0);\n"
+          "  out.color = colors[vertex_id];\n"
+          "  return out;\n"
+          "}\n"
+          "fragment float4 fragment_main(VertexOut in [[stage_in]]) { return "
+          "float4(in.color, 1.0); }\n";
+}
+
+auto makePipeline(id<MTLDevice> device) -> id<MTLRenderPipelineState> {
+  NSError* error = nil;
+  id<MTLLibrary> library = [device newLibraryWithSource:shaderSource()
+                                                options:nil
+                                                  error:&error];
+  if (library == nil) {
+    NSLog(@"Failed to create Metal library: %@", error);
+    return nil;
+  }
+
+  id<MTLFunction> vertex = [library newFunctionWithName:@"vertex_main"];
+  id<MTLFunction> fragment = [library newFunctionWithName:@"fragment_main"];
+  MTLRenderPipelineDescriptor* descriptor =
+    [[MTLRenderPipelineDescriptor alloc] init];
+  descriptor.vertexFunction = vertex;
+  descriptor.fragmentFunction = fragment;
+  descriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+
+  id<MTLRenderPipelineState> pipeline =
+    [device newRenderPipelineStateWithDescriptor:descriptor error:&error];
+  if (pipeline == nil) {
+    NSLog(@"Failed to create Metal pipeline: %@", error);
+  }
+  return pipeline;
+}
+
+auto createState(uint32_t width, uint32_t height) -> MetalTextureState* {
+  @autoreleasepool {
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    if (device == nil) return nullptr;
+
+    MTLTextureDescriptor* descriptor = [MTLTextureDescriptor
+      texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+                                   width:width
+                                  height:height
+                               mipmapped:NO];
+    descriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+    descriptor.storageMode = MTLStorageModePrivate;
+
+    id<MTLTexture> texture = [device newTextureWithDescriptor:descriptor];
+    id<MTLCommandQueue> queue = [device newCommandQueue];
+    id<MTLRenderPipelineState> pipeline = makePipeline(device);
+    if (texture == nil || queue == nil || pipeline == nil) return nullptr;
+
+    auto* state = new MetalTextureState{
+      .device = device,
+      .queue = queue,
+      .texture = texture,
+      .library = nil,
+      .pipeline = pipeline,
+      .width = width,
+      .height = height,
+    };
+    return state;
+  }
+}
+
+}  // namespace
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_NativeMetalBridge_create(JNIEnv*, jclass, jint width, jint height) {
+  if (width <= 0 || height <= 0) return 0;
+  return reinterpret_cast<jlong>(
+    createState(static_cast<uint32_t>(width), static_cast<uint32_t>(height))
+  );
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_NativeMetalBridge_dispose(JNIEnv*, jclass, jlong handle) {
+  auto* state = reinterpret_cast<MetalTextureState*>(handle);
+  delete state;
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_NativeMetalBridge_texturePtr(JNIEnv*, jclass, jlong handle) {
+  auto* state = reinterpret_cast<MetalTextureState*>(handle);
+  if (state == nullptr) return 0;
+  return reinterpret_cast<jlong>((__bridge void*)state->texture);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_NativeMetalBridge_render(JNIEnv*, jclass, jlong handle, jint frame) {
+  auto* state = reinterpret_cast<MetalTextureState*>(handle);
+  if (state == nullptr) return;
+
+  @autoreleasepool {
+    const auto phase = static_cast<float>((frame % 240) / 239.0f);
+    MTLRenderPassDescriptor* pass =
+      [MTLRenderPassDescriptor renderPassDescriptor];
+    pass.colorAttachments[0].texture = state->texture;
+    pass.colorAttachments[0].loadAction = MTLLoadActionClear;
+    pass.colorAttachments[0].storeAction = MTLStoreActionStore;
+    pass.colorAttachments[0].clearColor = MTLClearColorMake(
+      0.04 + 0.18 * phase, 0.08, 0.18 + 0.36 * (1.0 - phase), 1.0
+    );
+
+    id<MTLCommandBuffer> commandBuffer = [state->queue commandBuffer];
+    id<MTLRenderCommandEncoder> encoder =
+      [commandBuffer renderCommandEncoderWithDescriptor:pass];
+    [encoder setRenderPipelineState:state->pipeline];
+    float phaseCopy = phase;
+    [encoder setVertexBytes:&phaseCopy length:sizeof(phaseCopy) atIndex:0];
+    [encoder drawPrimitives:MTLPrimitiveTypeTriangle
+                vertexStart:0
+                vertexCount:3];
+    [encoder endEncoding];
+    [commandBuffer commit];
+    [commandBuffer waitUntilCompleted];
+  }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -47,7 +47,7 @@ run = "zig build run"
 
 [tasks."example:compose-map"]
 description = "Run Compose map texture demo"
-run = "gradle -p examples/compose-map run -Dskiko.renderApi=METAL"
+run = "gradle -p examples/compose-map run"
 
 [tasks.check]
 description = "Run all checks"

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,8 @@ dprint = "0.53.2"
 cmake = "3.31.6"
 "github:blankspruce/gersemi" = "0.27.2"
 zig = "0.16.0"
+java = "21.0.2"
+gradle = "8.14.3"
 
 [tools."github:llvm/llvm-project"]
 version = "22.1.4"
@@ -42,6 +44,10 @@ run = "zig build test --summary all"
 description = "Run Zig map example"
 depends = ["build"]
 run = "zig build run"
+
+[tasks."example:compose-map"]
+description = "Run Compose map texture demo"
+run = "gradle -p examples/compose-map run -Dskiko.renderApi=METAL"
 
 [tasks.check]
 description = "Run all checks"


### PR DESCRIPTION
> [!WARNING]  
> This is a vibe coded slop experiment

Adds a Compose Desktop demo that renders a native Metal texture into a Compose Box through Skia and exposes compositor controls for alpha, rotation, scale, clipping, and translation. This is a technical proof for texture sampling inside Compose without SwingPanel/native-window embedding or CPU readback.

Intention is to validate whether we can embed a MapLibre map in Compose without SwingPanel interop / window embedding.