### PR TITLE
Make mise task shells explicit

### DIFF
--- a/bindings/dotnet/mise.toml
+++ b/bindings/dotnet/mise.toml
@@ -11,9 +11,11 @@ dotnet tool restore --tool-manifest bindings/dotnet/dotnet-tools.json --verbosit
 '''
 
 [tasks.generate]
+extends = "bash"
 run = "scripts/generate-clangsharp.sh"
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 # Visual Studio exports Platform=x64 on Windows; the .NET solution uses Any CPU.
@@ -26,6 +28,7 @@ MaplibreNativeCInstallDir="$MISE_MONOREPO_ROOT/build/$usage_preset/install" \
 '''
 
 [tasks.test]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."

--- a/bindings/go/mise.toml
+++ b/bindings/go/mise.toml
@@ -3,6 +3,7 @@
 "aqua:mvdan/gofumpt" = "{{vars.gofumpt_version}}"
 
 [tasks._gofumpt-check]
+extends = "bash"
 description = "List Go files that require gofumpt."
 hide = true
 raw_args = true
@@ -10,6 +11,7 @@ dir = "../.."
 run = "gofumpt -l"
 
 [tasks._gofumpt-fix]
+extends = "bash"
 description = "Format Go files with gofumpt."
 hide = true
 raw_args = true
@@ -17,6 +19,7 @@ dir = "../.."
 run = "gofumpt -w"
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = '''
@@ -31,6 +34,7 @@ PKG_CONFIG_PATH="$native_install_dir/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CO
 '''
 
 [tasks.test]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = '''

--- a/bindings/kotlin/mise.toml
+++ b/bindings/kotlin/mise.toml
@@ -4,6 +4,7 @@
 "aqua:google/google-java-format" = "{{vars.google_java_format_version}}"
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -26,6 +27,7 @@ fi
 '''
 
 [tasks.test]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -48,6 +50,7 @@ fi
 '''
 
 [tasks.jvmTest]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -58,6 +61,7 @@ run = '''
 '''
 
 [tasks.nativeTest]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -79,6 +83,7 @@ esac
 '''
 
 [tasks.iosBuild]
+extends = "bash"
 description = "Build the Kotlin binding and embedded Metal runtime for an iOS target."
 usage = '''
 arg "<preset>" {
@@ -100,6 +105,7 @@ esac
 '''
 
 [tasks.androidBuild]
+extends = "bash"
 description = "Build the Kotlin Android binding."
 usage = '''
 arg "[backend]" default="opengl" {

--- a/bindings/python/mise.toml
+++ b/bindings/python/mise.toml
@@ -1,4 +1,5 @@
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = '''
@@ -7,6 +8,7 @@ MAPLIBRE_NATIVE_C_INSTALL_DIR="$MISE_MONOREPO_ROOT/build/$usage_preset/install" 
 '''
 
 [tasks._install-extension]
+extends = "bash"
 description = "Build and install the Python extension for local tests."
 hide = true
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
@@ -19,6 +21,7 @@ uv pip install --python "$MISE_MONOREPO_ROOT/.venv" --reinstall --no-index --fin
 '''
 
 [tasks.test]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = ":_install-extension", args = ["{{usage.preset}}"] }]
 run = '''

--- a/bindings/rust/mise.toml
+++ b/bindings/rust/mise.toml
@@ -1,4 +1,5 @@
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -20,6 +21,7 @@ MAPLIBRE_NATIVE_C_INSTALL_DIR="$native_install_dir" \
 '''
 
 [tasks.test]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -65,6 +67,7 @@ cargo clippy \
 '''
 
 [tasks."build:ohos"]
+extends = "bash"
 usage = '''
 arg "<preset>" {
   choices "ohos-arm64-egl" "ohos-arm64-vulkan"

--- a/bindings/swift/mise.toml
+++ b/bindings/swift/mise.toml
@@ -2,6 +2,7 @@
 "core:swift" = { version = "{{vars.swift_version}}", os = ["linux/x64"] }
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = '''
@@ -13,6 +14,7 @@ swift build --target MaplibreNative "${swift_args[@]}"
 '''
 
 [tasks.test]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = ":build", args = ["{{usage.preset}}"] }]
 run = '''
@@ -26,6 +28,7 @@ swift package describe --type json >/dev/null
 '''
 
 [tasks."build:ios-simulator"]
+extends = "bash"
 depends = [{ task = "//:build", args = ["ios-simulator-arm64-metal"] }]
 run = '''
 native_install_dir="$MISE_MONOREPO_ROOT/build/ios-simulator-arm64-metal/install"
@@ -44,6 +47,7 @@ PKG_CONFIG_PATH="$native_install_dir/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CO
 '''
 
 [tasks."build:ios"]
+extends = "bash"
 depends = [{ task = "//:build", args = ["ios-arm64-metal"] }]
 run = '''
 native_install_dir="$MISE_MONOREPO_ROOT/build/ios-arm64-metal/install"

--- a/bindings/zig/mise.toml
+++ b/bindings/zig/mise.toml
@@ -14,6 +14,7 @@ timeout = "10m"
 run = "zig build --fetch=needed"
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = '''
@@ -23,6 +24,7 @@ zig build \
 '''
 
 [tasks.test]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = ":build", args = ["{{usage.preset}}"] }]
 run = '''
@@ -45,6 +47,7 @@ zig build test \
 '''
 
 [tasks."test:ios-simulator"]
+extends = "bash"
 depends = [{ task = "//:build", args = ["ios-simulator-arm64-metal"] }]
 run = '''
 native_install_dir="$MISE_MONOREPO_ROOT/build/ios-simulator-arm64-metal/install"

--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -3,6 +3,7 @@
 "core:zig" = { version = "{{vars.zig_version}}", os = ["linux", "macos", "windows/x64"] }
 
 [tasks."api:c"]
+extends = "bash"
 run = [
   "rm -rf doxygen/gen public/reference/c",
   "mkdir -p doxygen/gen public/reference",
@@ -11,6 +12,7 @@ run = [
 ]
 
 [tasks."api:rust"]
+extends = "bash"
 depends = ["//:build"]
 dir = ".."
 run = '''
@@ -22,6 +24,7 @@ cp -a target/doc/. docs/public/reference/rust/
 '''
 
 [tasks."api:zig"]
+extends = "bash"
 dir = "../bindings/zig"
 run = '''
 rm -rf ../../docs/public/reference/zig
@@ -30,6 +33,7 @@ zig build docs -Dinclude-dir=../../include --prefix ../../docs/public/reference/
 '''
 
 [tasks.api]
+extends = "bash"
 run = [
   { task = "api:c" },
   { task = "api:rust" },
@@ -37,26 +41,33 @@ run = [
 ]
 
 [tasks.install]
+extends = "bash"
 run = "pnpm exec astro sync"
 
 [tasks.dev]
+extends = "bash"
 depends = ["api", "install", "generate-support-matrix"]
 run = "pnpm run dev"
 
 [tasks.start]
+extends = "bash"
 depends = ["api", "install", "generate-support-matrix"]
 run = "pnpm run start"
 
 [tasks.build]
+extends = "bash"
 depends = ["api", "install", "generate-support-matrix"]
 run = "pnpm run build"
 
 [tasks.preview]
+extends = "bash"
 depends = ["api", "install", "generate-support-matrix"]
 run = "pnpm run preview"
 
 [tasks.astro]
+extends = "bash"
 run = "pnpm exec astro"
 
 [tasks.generate-support-matrix]
+extends = "bash"
 run = "pnpm run generate-support-matrix"

--- a/examples/android-map/mise.toml
+++ b/examples/android-map/mise.toml
@@ -2,6 +2,7 @@
 "core:java" = "{{vars.java_version}}"
 
 [tasks.build]
+extends = "bash"
 description = "Build the Android map example."
 usage = '''
 arg "[backend]" default="opengl" {
@@ -25,6 +26,7 @@ fi
 '''
 
 [tasks.run]
+extends = "bash"
 description = "Build, install, and start the Android map example."
 usage = '''
 arg "[backend]" default="opengl" {

--- a/examples/compose-map/mise.toml
+++ b/examples/compose-map/mise.toml
@@ -2,6 +2,7 @@
 "core:java" = "{{vars.java_version}}"
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -12,6 +13,7 @@ run = '''
 '''
 
 [tasks.run]
+extends = "bash"
 depends = ["//:build"]
 dir = "../.."
 run = '''

--- a/examples/dotnet-map/mise.toml
+++ b/examples/dotnet-map/mise.toml
@@ -2,6 +2,7 @@
 "core:dotnet" = "{{vars.dotnet_version}}"
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -13,6 +14,7 @@ MaplibreNativeCInstallDir="$MISE_MONOREPO_ROOT/build/$usage_preset/install" \
 '''
 
 [tasks.run]
+extends = "bash"
 depends = ["//:build"]
 dir = "../.."
 usage = '''
@@ -29,10 +31,13 @@ MaplibreNativeCInstallDir="$MISE_MONOREPO_ROOT/build/{{vars.host_native_preset}}
 '''
 
 [tasks."run:owned-texture"]
+extends = "bash"
 run = [{ task = "run", args = ["owned-texture"] }]
 
 [tasks."run:borrowed-texture"]
+extends = "bash"
 run = [{ task = "run", args = ["borrowed-texture"] }]
 
 [tasks."run:native-surface"]
+extends = "bash"
 run = [{ task = "run", args = ["native-surface"] }]

--- a/examples/lwjgl-map/mise.toml
+++ b/examples/lwjgl-map/mise.toml
@@ -2,6 +2,7 @@
 "core:java" = "{{vars.java_version}}"
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -12,6 +13,7 @@ run = '''
 '''
 
 [tasks.run]
+extends = "bash"
 depends = ["//:build"]
 dir = "../.."
 usage = '''
@@ -27,10 +29,13 @@ run = '''
 '''
 
 [tasks."run:owned-texture"]
+extends = "bash"
 run = [{ task = "run", args = ["owned-texture"] }]
 
 [tasks."run:borrowed-texture"]
+extends = "bash"
 run = [{ task = "run", args = ["borrowed-texture"] }]
 
 [tasks."run:native-surface"]
+extends = "bash"
 run = [{ task = "run", args = ["native-surface"] }]

--- a/examples/rust-map/mise.toml
+++ b/examples/rust-map/mise.toml
@@ -1,4 +1,5 @@
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -9,6 +10,7 @@ MAPLIBRE_NATIVE_C_INSTALL_DIR="$MISE_MONOREPO_ROOT/build/$usage_preset/install" 
 '''
 
 [tasks.check]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = ":build", args = ["{{usage.preset}}"] }]
 dir = "../.."
@@ -19,6 +21,7 @@ MAPLIBRE_NATIVE_C_INSTALL_DIR="$MISE_MONOREPO_ROOT/build/$usage_preset/install" 
 '''
 
 [tasks.run]
+extends = "bash"
 depends = ["//:build"]
 dir = "../.."
 usage = '''
@@ -40,10 +43,13 @@ MAPLIBRE_NATIVE_C_INSTALL_DIR="$native_install_dir" \
 '''
 
 [tasks."run:owned-texture"]
+extends = "bash"
 run = [{ task = "run", args = ["owned-texture"] }]
 
 [tasks."run:borrowed-texture"]
+extends = "bash"
 run = [{ task = "run", args = ["borrowed-texture"] }]
 
 [tasks."run:native-surface"]
+extends = "bash"
 run = [{ task = "run", args = ["native-surface"] }]

--- a/examples/swift-map/mise.toml
+++ b/examples/swift-map/mise.toml
@@ -3,6 +3,7 @@
 "github:xtool-org/xtool" = { version = "{{vars.xtool_version}}", os = ["linux"] }
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = '''
@@ -14,6 +15,7 @@ swift build "${swift_args[@]}"
 '''
 
 [tasks.run]
+extends = "bash"
 depends = [":build"]
 usage = '''
 arg "[render-target]" default="owned-texture" {
@@ -26,15 +28,19 @@ exec ".build/{{vars.host_native_preset}}/debug/swift-map" \
 '''
 
 [tasks."run:owned-texture"]
+extends = "bash"
 run = [{ task = "run", args = ["owned-texture"] }]
 
 [tasks."run:borrowed-texture"]
+extends = "bash"
 run = [{ task = "run", args = ["borrowed-texture"] }]
 
 [tasks."run:native-surface"]
+extends = "bash"
 run = [{ task = "run", args = ["native-surface"] }]
 
 [tasks."build:ios-simulator"]
+extends = "bash"
 depends = [{ task = "//:build", args = ["ios-simulator-arm64-metal"] }]
 run = '''
 native_install_dir="$MISE_MONOREPO_ROOT/build/ios-simulator-arm64-metal/install"
@@ -47,6 +53,7 @@ swift build \
 '''
 
 [tasks."build:ios"]
+extends = "bash"
 depends = [{ task = "//:build", args = ["ios-arm64-metal"] }]
 run = '''
 native_install_dir="$MISE_MONOREPO_ROOT/build/ios-arm64-metal/install"
@@ -63,6 +70,7 @@ swift build \
 '''
 
 [tasks."run:ios"]
+extends = "bash"
 depends = [{ task = "//:build", args = ["ios-arm64-metal"] }]
 run = '''
 {% if os() == "linux" %}

--- a/examples/zig-map/mise.toml
+++ b/examples/zig-map/mise.toml
@@ -15,6 +15,7 @@ timeout = "10m"
 run = "zig build --fetch=needed"
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = '''
@@ -24,6 +25,7 @@ zig build \
 '''
 
 [tasks.run]
+extends = "bash"
 depends = ["//:build"]
 usage = '''
 arg "[render-target]" default="owned-texture" {
@@ -46,10 +48,13 @@ zig build run \
 '''
 
 [tasks."run:owned-texture"]
+extends = "bash"
 run = [{ task = "run", args = ["owned-texture"] }]
 
 [tasks."run:borrowed-texture"]
+extends = "bash"
 run = [{ task = "run", args = ["borrowed-texture"] }]
 
 [tasks."run:native-surface"]
+extends = "bash"
 run = [{ task = "run", args = ["native-surface"] }]

--- a/examples/zig-readback/mise.toml
+++ b/examples/zig-readback/mise.toml
@@ -15,6 +15,7 @@ timeout = "10m"
 run = "zig build --fetch=needed"
 
 [tasks.build]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = '''
@@ -24,6 +25,7 @@ zig build \
 '''
 
 [tasks.run]
+extends = "bash"
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = '''

--- a/mise.linux.toml
+++ b/mise.linux.toml
@@ -40,6 +40,7 @@ glibc_floor = "2.39"
 "dnf:vulkan-loader-devel" = "latest"
 
 [tasks.check-glibc-floor]
+extends = "bash"
 description = "Verify a built Linux native requires no glibc newer than the floor."
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 run = '''

--- a/mise.macos.toml
+++ b/mise.macos.toml
@@ -15,6 +15,7 @@ MLN_FFI_VULKAN_LOADER_DIR = "/opt/homebrew/opt/vulkan-loader/lib"
 VK_DRIVER_FILES = "/opt/homebrew/opt/molten-vk/etc/vulkan/icd.d/MoltenVK_icd.json"
 
 [tasks."ios-simulator:boot"]
+extends = "bash"
 description = "Boot an available iPhone simulator and wait until it is ready."
 run = '''
 device=$(xcrun simctl list devices available iOS | awk -F '[()]' '/ iPhone / && /Shutdown|Booted/ { print $2; exit }')

--- a/mise.toml
+++ b/mise.toml
@@ -19,10 +19,6 @@ lockfile_platforms = [
 ]
 pin = true
 experimental = true
-windows_default_file_shell_args = '"C:/Program Files/Git/bin/bash.exe"'
-windows_default_inline_shell_args = '"C:/Program Files/Git/bin/bash.exe" -e -lc'
-unix_default_file_shell_args = "bash"
-unix_default_inline_shell_args = "bash -e -c"
 # On Windows, the Microsoft Store Python alias in WindowsApps can appear before
 # mise-managed Python. Keep mise tool paths first so file tasks run pinned tools.
 activate_aggressive = true
@@ -35,6 +31,7 @@ config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 lockfile = true
 
 [vars]
+task_shell = "bash -e -c"
 actionlint_version = "1.7.8"
 cmake_version = "4.3.3"
 dotnet_version = "10.0.203"
@@ -102,6 +99,10 @@ CMAKE_C_COMPILER_LAUNCHER = "sccache"
 CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
 RUSTC_WRAPPER = "sccache"
 
+[task_templates.bash]
+# Task-level shells remain repository-owned and trusted in mise 2026.7.14+.
+shell = "{{vars.task_shell}}"
+
 [deps.uv]
 auto = true
 run = "uv sync --locked --all-packages --all-groups --no-install-workspace"
@@ -122,11 +123,13 @@ postinstall = [
 ]
 
 [tasks.configure]
+extends = "bash"
 description = "Configure a native CMake preset."
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 run = 'cmake --preset "$usage_preset"'
 
 [tasks.build]
+extends = "bash"
 description = "Configure, build, and install a native CMake preset."
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 sources = [
@@ -145,22 +148,26 @@ outputs = { auto = true }
 run = 'cmake --workflow --preset "$usage_preset"'
 
 [tasks.clean]
+extends = "bash"
 description = "Remove one native preset build tree."
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 run = 'rm -rf "$MISE_MONOREPO_ROOT/build/$usage_preset"'
 
 [tasks.package-native]
+extends = "bash"
 description = "Build and archive a native CMake preset."
 usage = 'arg "<preset>"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = [{ task = "//:archive-native", args = ["{{usage.preset}}"] }]
 
 [tasks.archive-native]
+extends = "bash"
 description = "Archive an already-built native CMake preset."
 usage = 'arg "<preset>"'
 run = 'cpack --preset "$usage_preset"'
 
 [tasks.test]
+extends = "bash"
 description = "Build and run C API tests for a CMake preset."
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
@@ -172,6 +179,7 @@ ctest --preset "$usage_preset"
 '''
 
 [tasks.check]
+extends = "bash"
 tools = { "core:java" = "{{vars.java_version}}", "aqua:facebook/ktfmt" = "{{vars.ktfmt_version}}", "aqua:google/google-java-format" = "{{vars.google_java_format_version}}", "core:dotnet" = "{{vars.dotnet_version}}", "core:go" = "{{vars.go_version}}", "core:zig" = { version = "{{vars.zig_version}}", os = ["linux", "macos", "windows/x64"] } }
 env = { MLN_DPRINT_SCOPED_TOOLS = "1" }
 run = '''
@@ -181,6 +189,7 @@ hk check --all
 '''
 
 [tasks.fix]
+extends = "bash"
 tools = { "core:java" = "{{vars.java_version}}", "aqua:facebook/ktfmt" = "{{vars.ktfmt_version}}", "aqua:google/google-java-format" = "{{vars.google_java_format_version}}", "core:dotnet" = "{{vars.dotnet_version}}", "core:go" = "{{vars.go_version}}", "core:zig" = { version = "{{vars.zig_version}}", os = ["linux", "macos", "windows/x64"] } }
 env = { MLN_DPRINT_SCOPED_TOOLS = "1" }
 run = '''
@@ -190,5 +199,6 @@ hk fix --all
 '''
 
 [tasks.actions-up]
+extends = "bash"
 description = "Update and pin GitHub Actions steps."
 run = "pnpm dlx actions-up"

--- a/mise.windows.toml
+++ b/mise.windows.toml
@@ -1,5 +1,6 @@
 [vars]
 host_native_preset = "windows-{{ arch() }}-vulkan"
+task_shell = '"C:/Program Files/Git/bin/bash.exe" -e -lc'
 
 [env]
 # Mise tasks use non-interactive Git Bash on Windows. Source VsDevCmd before each


### PR DESCRIPTION
## Summary

Makes every TOML mise task select the repository-owned Bash shell explicitly because mise 2026.7.14 no longer honors the project-local default-shell setting.

## Test plan

Validated all 79 inline tasks resolve to `bash -e -c` under mise 2026.7.14, all file tasks retain shebangs, and `mise run check` passes.

## AI assistance

- **Tools:** Codex
- **Context:** Diagnosed the shared CI regression, implemented the task-template migration, and validated task resolution.