### PR TITLE
Add Kotlin Dokka API reference to the docs site

### DIFF
--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -41,6 +41,7 @@ jobs:
           path: pins
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
       - uses: jakoch/install-vulkan-sdk-action@37effcfa045411f8bfbbda26df2fd1b3bf3436fa # v1.6.0
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-ci-deps
         with:
-          gradle: false
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+        with:
+          packages: platform-tools platforms;android-36
       - run: mise run //docs:build
 
   target-linux-x64-egl:

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -24,9 +24,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-ci-deps
         with:
-          gradle: false
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+        with:
+          packages: platform-tools platforms;android-36
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - run: mise run //docs:build
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -5,6 +5,7 @@
 import argparse
 import difflib
 import pathlib
+import re
 import sys
 
 
@@ -21,6 +22,15 @@ CHECKOUT = PINS["actions/checkout"]
 CACHE_SAVE = PINS["actions/cache/save"]
 DOWNLOAD = PINS["actions/download-artifact"]
 UPLOAD = PINS["actions/upload-artifact"]
+SETUP_ANDROID = PINS["android-actions/setup-android"]
+
+
+def android_compile_sdk() -> str:
+    text = (ROOT / "gradle" / "libs.versions.toml").read_text(encoding="utf-8")
+    match = re.search(r'^android-compileSdk = "(\d+)"\s*$', text, re.MULTILINE)
+    if match is None:
+        raise SystemExit("android-compileSdk missing from gradle/libs.versions.toml")
+    return match.group(1)
 
 # Environment secrets for R2 writes live in the GitHub Environment `sccache`
 # (main only). PRs omit the environment and fall back to public read-only.
@@ -202,7 +212,12 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "    timeout-minutes: 60",
         SCCACHE_ENVIRONMENT,
         "    steps:",
-        *setup(gradle=False),
+        # Dokka configures the Kotlin Multiplatform project, including the
+        # Android target, so docs generation needs Gradle and an SDK platform.
+        *setup(),
+        f"      - uses: {SETUP_ANDROID}",
+        "        with:",
+        f"          packages: platform-tools platforms;android-{android_compile_sdk()}",
         "      - run: mise run //docs:build",
         "",
     ]

--- a/bindings/kotlin/mise.toml
+++ b/bindings/kotlin/mise.toml
@@ -3,6 +3,32 @@
 "aqua:facebook/ktfmt" = "{{vars.ktfmt_version}}"
 "aqua:google/google-java-format" = "{{vars.google_java_format_version}}"
 
+[tasks.api]
+description = "Generate Dokka HTML API reference for the Kotlin binding."
+dir = "../.."
+run = '''
+# Dokka configures every KMP target, including Android, so the SDK must exist.
+# AGP downloads build-tools on demand once platforms/android-<compileSdk> is present.
+compile_sdk="$(
+  sed -n 's/^android-compileSdk = "\([0-9][0-9]*\)"/\1/p' gradle/libs.versions.toml | head -n1
+)"
+if [[ -z "$compile_sdk" ]]; then
+  echo "Could not read android-compileSdk from gradle/libs.versions.toml" >&2
+  exit 1
+fi
+if [[ -z "${ANDROID_HOME:-}" ]]; then
+  echo "ANDROID_HOME is unset; point it at an Android SDK install." >&2
+  exit 1
+fi
+platform_dir="$ANDROID_HOME/platforms/android-$compile_sdk"
+if [[ ! -d "$platform_dir" ]]; then
+  echo "Android SDK platform android-$compile_sdk is missing under $ANDROID_HOME." >&2
+  echo "Install it (sdkmanager \"platforms;android-$compile_sdk\") and rerun." >&2
+  exit 1
+fi
+./gradlew :bindings:kotlin:dokkaGeneratePublicationHtml
+'''
+
 [tasks.build]
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -61,6 +61,11 @@ export default defineConfig({
               link: "/reference/zig/",
               attrs: { target: "_blank", rel: "noopener noreferrer" },
             },
+            {
+              label: "Kotlin API",
+              link: "/reference/kotlin/",
+              attrs: { target: "_blank", rel: "noopener noreferrer" },
+            },
           ],
         },
         {

--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -29,11 +29,20 @@ mkdir -p ../../docs/public/reference
 zig build docs -Dinclude-dir=../../include --prefix ../../docs/public/reference/zig
 '''
 
+[tasks."api:kotlin"]
+depends = ["//bindings/kotlin:api"]
+run = '''
+rm -rf public/reference/kotlin
+mkdir -p public/reference
+cp -a ../bindings/kotlin/build/dokka/html/. public/reference/kotlin/
+'''
+
 [tasks.api]
 run = [
   { task = "api:c" },
   { task = "api:rust" },
   { task = "api:zig" },
+  { task = "api:kotlin" },
 ]
 
 [tasks.install]

--- a/docs/src/content/docs/guides/installation.mdx
+++ b/docs/src/content/docs/guides/installation.mdx
@@ -88,8 +88,9 @@ build at a native install prefix.
 
 Each binding wraps the runtime, map, and render session model these guides
 describe. Read on in C, then consult the
-[Rust](/maplibre-native-ffi/reference/rust/maplibre_native/) or
-[Zig](/maplibre-native-ffi/reference/zig/) API reference for the spelling in
-those languages.
+[Rust](/maplibre-native-ffi/reference/rust/maplibre_native/),
+[Zig](/maplibre-native-ffi/reference/zig/), or
+[Kotlin](/maplibre-native-ffi/reference/kotlin/) API reference for the spelling
+in those languages.
 
 Next: [Create and Run a Map](/maplibre-native-ffi/guides/create-and-run-a-map/).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Publish Dokka-generated Kotlin API HTML under `docs/public/reference/kotlin/` and link it from the docs sidebar, matching the existing C/Rust/Zig reference pattern.

## Test plan

Run `mise run //docs:api:kotlin` (with Android SDK platform 36 available) and open `/reference/kotlin/` on a local docs build; confirm `mise run ci:generate-workflow --check` passes.

## AI assistance

- **Tools:** Cursor
- **Context:** Followed the existing `docs/mise.toml` `api:*` install-into-`public/reference/` pattern used for C, Rust, and Zig; docs CI setup is expressed in `ci:generate-workflow` because `ci.yml` is generated.

<a href="https://cursor.com/agents/bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkotlin-dokka-api-reference-demo.mp4"><img src="https://cursor.com/artifacts/c/art-9da47a10-d82f-436d-a98e-e964b2223555" alt="kotlin-dokka-api-reference-demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

