### PR TITLE
Keep Dart in the docs support matrix as build-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
       - run: mise run //bindings/python:test linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -203,6 +206,9 @@ jobs:
       - run: mise run //bindings/python:test linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -280,6 +286,9 @@ jobs:
       - run: mise run //bindings/python:test linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -354,6 +363,9 @@ jobs:
         env:
           MISE_TASK_SKIP: "//:build"
       - run: mise run //bindings/python:test linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -438,6 +450,9 @@ jobs:
       - run: mise run //bindings/python:test macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -516,6 +531,9 @@ jobs:
       - run: mise run //bindings/python:test macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -589,6 +607,9 @@ jobs:
         env:
           MISE_TASK_SKIP: "//:build"
       - run: mise run //bindings/python:test macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -910,6 +931,9 @@ jobs:
       - run: mise run //bindings/python:test windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -979,6 +1003,9 @@ jobs:
       - run: mise run //bindings/python:test windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -1038,6 +1065,9 @@ jobs:
       - run: mise run //bindings/python:test windows-arm64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build windows-arm64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -1086,6 +1116,9 @@ jobs:
         env:
           MISE_TASK_SKIP: "//:build"
       - run: mise run //bindings/python:test windows-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dart:build windows-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact

--- a/ci/workflow.toml
+++ b/ci/workflow.toml
@@ -44,5 +44,10 @@ commands = [{ task = "//bindings/go:test" }]
 platforms = ["linux", "macos", "windows"]
 commands = [{ task = "//bindings/python:test" }]
 
-# TODO(#412): Re-enable Dart CI after thread-affine ownership is safe across
-# isolate migration; affected test processes can otherwise wedge until timeout.
+# TODO(#412): Re-enable //bindings/dart:test after thread-affine ownership is
+# safe across isolate migration; affected test processes can otherwise wedge
+# until timeout. Keep analyze/build in CI so the binding still appears in the
+# generated support matrix as build-only.
+[[suites]]
+platforms = ["linux", "macos", "windows"]
+commands = [{ task = "//bindings/dart:build" }]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restore `//bindings/dart:build` in CI so the generated docs status table still lists Dart as build-only while `#412` keeps tests quarantined.

## Test plan

Ran `mise run //bindings/dart:build`, regenerated the workflow, and confirmed Dart appears as build-only in the generated support matrix.

## AI assistance

- **Tools:** Cursor
- **Context:** Investigated why Dart disappeared from the docs Status table after #418 removed the suite entirely rather than downgrading it to build-only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-957778c1-4fef-484b-9d97-5966e92674f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-957778c1-4fef-484b-9d97-5966e92674f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

