### PR TITLE
Add Dart API reference to the docs site

### DIFF
--- a/bindings/dart/mise.toml
+++ b/bindings/dart/mise.toml
@@ -50,6 +50,14 @@ if ! diff -u lib/src/internal/c/maplibre_native_c.g.dart .dart_tool/maplibre_nat
 fi
 """
 
+[tasks.api]
+description = "Generate Dart API reference HTML with dart doc."
+run = '''
+rm -rf .dart_tool/api-docs
+mkdir -p .dart_tool
+dart doc -o .dart_tool/api-docs
+'''
+
 [tasks.format]
 run = "dart format lib test tool"
 

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -66,6 +66,11 @@ export default defineConfig({
               link: "/reference/kotlin/",
               attrs: { target: "_blank", rel: "noopener noreferrer" },
             },
+            {
+              label: "Dart API",
+              link: "/reference/dart/",
+              attrs: { target: "_blank", rel: "noopener noreferrer" },
+            },
           ],
         },
         {

--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -37,12 +37,21 @@ mkdir -p public/reference
 cp -a ../bindings/kotlin/build/dokka/html/. public/reference/kotlin/
 '''
 
+[tasks."api:dart"]
+depends = ["//bindings/dart:api"]
+run = '''
+rm -rf public/reference/dart
+mkdir -p public/reference
+cp -a ../bindings/dart/.dart_tool/api-docs/. public/reference/dart/
+'''
+
 [tasks.api]
 run = [
   { task = "api:c" },
   { task = "api:rust" },
   { task = "api:zig" },
   { task = "api:kotlin" },
+  { task = "api:dart" },
 ]
 
 [tasks.install]

--- a/docs/src/content/docs/guides/installation.mdx
+++ b/docs/src/content/docs/guides/installation.mdx
@@ -89,8 +89,9 @@ build at a native install prefix.
 Each binding wraps the runtime, map, and render session model these guides
 describe. Read on in C, then consult the
 [Rust](/maplibre-native-ffi/reference/rust/maplibre_native/),
-[Zig](/maplibre-native-ffi/reference/zig/), or
-[Kotlin](/maplibre-native-ffi/reference/kotlin/) API reference for the spelling
-in those languages.
+[Zig](/maplibre-native-ffi/reference/zig/),
+[Kotlin](/maplibre-native-ffi/reference/kotlin/), or
+[Dart](/maplibre-native-ffi/reference/dart/) API reference for the spelling in
+those languages.
 
 Next: [Create and Run a Map](/maplibre-native-ffi/guides/create-and-run-a-map/).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `dart doc` HTML under `docs/public/reference/dart/` and link it from the docs sidebar.

## Test plan

Run `mise run //docs:api:dart` and open `/reference/dart/` on a local docs build.

## AI assistance

- **Tools:** Cursor
- **Context:** Same `docs/public/reference/<lang>/` install pattern as C/Rust/Zig/Kotlin; generator is `dart doc` into `.dart_tool/api-docs`.

<a href="https://cursor.com/agents/bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdart-api-reference-demo.mp4"><img src="https://cursor.com/artifacts/c/art-5bfb314e-4198-45e4-a30c-476a0ef41fb0" alt="dart-api-reference-demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

