### PR TITLE
Add Swift DocC API reference to the docs site

### DIFF
--- a/bindings/swift/Package.resolved
+++ b/bindings/swift/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "6b181ea5d0b7656d85a05d0f1adf0f50c8f0572119b37633d230cffd48ce6eec",
+  "pins" : [
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
+      "state" : {
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/bindings/swift/Package.swift
+++ b/bindings/swift/Package.swift
@@ -83,5 +83,11 @@ let package = Package(
   name: "maplibre-native-swift",
   platforms: [.macOS("14.3"), .iOS("14.3")],
   products: products,
+  dependencies: [
+    .package(
+      url: "https://github.com/swiftlang/swift-docc-plugin",
+      from: "1.4.3"
+    ),
+  ],
   targets: targets
 )

--- a/bindings/swift/mise.toml
+++ b/bindings/swift/mise.toml
@@ -1,6 +1,24 @@
 [tools]
 "core:swift" = { version = "{{vars.swift_version}}", os = ["linux/x64"] }
 
+[tasks.api]
+description = "Generate DocC HTML API reference for the Swift binding."
+usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
+depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
+run = '''
+native_install_dir="$MISE_MONOREPO_ROOT/build/$usage_preset/install"
+export PKG_CONFIG_PATH="$native_install_dir/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+rm -rf build/docc
+mkdir -p build
+swift package --scratch-path ".build/$usage_preset" \
+  --allow-writing-to-directory build/docc \
+  generate-documentation \
+  --target MaplibreNative \
+  --output-path build/docc \
+  --transform-for-static-hosting \
+  --hosting-base-path maplibre-native-ffi/reference/swift
+'''
+
 [tasks.build]
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -71,6 +71,11 @@ export default defineConfig({
               link: "/reference/dart/",
               attrs: { target: "_blank", rel: "noopener noreferrer" },
             },
+            {
+              label: "Swift API",
+              link: "/reference/swift/documentation/maplibrenative/",
+              attrs: { target: "_blank", rel: "noopener noreferrer" },
+            },
           ],
         },
         {

--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -45,6 +45,14 @@ mkdir -p public/reference
 cp -a ../bindings/dart/.dart_tool/api-docs/. public/reference/dart/
 '''
 
+[tasks."api:swift"]
+depends = ["//bindings/swift:api"]
+run = '''
+rm -rf public/reference/swift
+mkdir -p public/reference
+cp -a ../bindings/swift/build/docc/. public/reference/swift/
+'''
+
 [tasks.api]
 run = [
   { task = "api:c" },
@@ -52,6 +60,7 @@ run = [
   { task = "api:zig" },
   { task = "api:kotlin" },
   { task = "api:dart" },
+  { task = "api:swift" },
 ]
 
 [tasks.install]

--- a/docs/src/content/docs/guides/installation.mdx
+++ b/docs/src/content/docs/guides/installation.mdx
@@ -90,8 +90,9 @@ Each binding wraps the runtime, map, and render session model these guides
 describe. Read on in C, then consult the
 [Rust](/maplibre-native-ffi/reference/rust/maplibre_native/),
 [Zig](/maplibre-native-ffi/reference/zig/),
-[Kotlin](/maplibre-native-ffi/reference/kotlin/), or
-[Dart](/maplibre-native-ffi/reference/dart/) API reference for the spelling in
-those languages.
+[Kotlin](/maplibre-native-ffi/reference/kotlin/),
+[Dart](/maplibre-native-ffi/reference/dart/), or
+[Swift](/maplibre-native-ffi/reference/swift/documentation/maplibrenative/) API
+reference for the spelling in those languages.
 
 Next: [Create and Run a Map](/maplibre-native-ffi/guides/create-and-run-a-map/).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a DocC-generated Swift API reference under `/reference/swift/` and links it from the docs sidebar.

## Test plan

Run `mise run //docs:api:swift` and open the Swift API sidebar link on a local docs build.

## AI assistance

- **Tools:** Cursor
- **Context:** Uses `swift-docc-plugin` on Linux with `--transform-for-static-hosting`.

<a href="https://cursor.com/agents/bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswift-api-reference-demo.mp4"><img src="https://cursor.com/artifacts/c/art-2aaf062b-ce53-4471-b287-ed15f155223d" alt="swift-api-reference-demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

