### PR TITLE
Add .NET DocFX API reference to the docs site.

### DIFF
--- a/bindings/dotnet/docfx/.config/dotnet-tools.json
+++ b/bindings/dotnet/docfx/.config/dotnet-tools.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "docfx": {
+      "version": "2.78.4",
+      "commands": ["docfx"],
+      "rollForward": false
+    }
+  }
+}

--- a/bindings/dotnet/docfx/docfx.json
+++ b/bindings/dotnet/docfx/docfx.json
@@ -1,0 +1,32 @@
+{
+  "metadata": [
+    {
+      "src": [
+        { "files": ["src/Maplibre.Native/Maplibre.Native.csproj"], "src": ".." }
+      ],
+      "dest": "../build/docfx-api",
+      "filter": "filterConfig.yml",
+      "properties": {
+        "TargetFramework": "net10.0",
+        "GenerateDocumentationFile": "true",
+        "NoWarn": "1591;0649"
+      }
+    }
+  ],
+  "build": {
+    "content": [
+      { "files": ["**/*.yml"], "src": "../build/docfx-api", "dest": "api" },
+      { "files": ["index.md"] }
+    ],
+    "dest": "../build/docfx",
+    "globalMetadata": {
+      "_appTitle": "Maplibre.Native",
+      "_enableSearch": true,
+      "_disableContribution": true
+    },
+    "template": ["default", "modern"],
+    "sitemap": {
+      "baseUrl": "https://maplibre.org/maplibre-native-ffi/reference/dotnet/"
+    }
+  }
+}

--- a/bindings/dotnet/docfx/filterConfig.yml
+++ b/bindings/dotnet/docfx/filterConfig.yml
@@ -1,0 +1,3 @@
+apiRules:
+  - exclude:
+      uidRegex: ^Maplibre\.Native\.Internal

--- a/bindings/dotnet/docfx/index.md
+++ b/bindings/dotnet/docfx/index.md
@@ -1,0 +1,5 @@
+# Maplibre.Native
+
+.NET API reference for the MapLibre Native FFI binding.
+
+Browse the [Maplibre.Native](api/Maplibre.Native.html) namespace.

--- a/bindings/dotnet/mise.toml
+++ b/bindings/dotnet/mise.toml
@@ -18,6 +18,20 @@ run = "scripts/generate-clangsharp.sh"
 [tasks.generate-check]
 run = "scripts/generate-clangsharp.sh --check"
 
+[tasks.api]
+description = "Generate DocFX HTML API reference for the .NET binding."
+# DocFX lives in a separate tool manifest from ClangSharp: restoring both in one
+# manifest hits a .NET SDK bug that reports DocFX's commands as ClangSharp's.
+run = '''
+rm -rf build/docfx build/docfx-api
+mkdir -p build
+(
+  cd docfx
+  dotnet tool restore --verbosity quiet
+  dotnet tool run docfx docfx.json
+)
+'''
+
 [tasks.build]
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -72,6 +72,11 @@ export default defineConfig({
               attrs: { target: "_blank", rel: "noopener noreferrer" },
             },
             {
+              label: ".NET API",
+              link: "/reference/dotnet/",
+              attrs: { target: "_blank", rel: "noopener noreferrer" },
+            },
+            {
               label: "Swift API",
               link: "/reference/swift/documentation/maplibrenative/",
               attrs: { target: "_blank", rel: "noopener noreferrer" },

--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -45,6 +45,14 @@ mkdir -p public/reference
 cp -a ../bindings/dart/.dart_tool/api-docs/. public/reference/dart/
 '''
 
+[tasks."api:dotnet"]
+depends = ["//bindings/dotnet:api"]
+run = '''
+rm -rf public/reference/dotnet
+mkdir -p public/reference
+cp -a ../bindings/dotnet/build/docfx/. public/reference/dotnet/
+'''
+
 [tasks."api:swift"]
 depends = ["//bindings/swift:api"]
 run = '''
@@ -60,6 +68,7 @@ run = [
   { task = "api:zig" },
   { task = "api:kotlin" },
   { task = "api:dart" },
+  { task = "api:dotnet" },
   { task = "api:swift" },
 ]
 

--- a/docs/src/content/docs/guides/installation.mdx
+++ b/docs/src/content/docs/guides/installation.mdx
@@ -91,7 +91,8 @@ describe. Read on in C, then consult the
 [Rust](/maplibre-native-ffi/reference/rust/maplibre_native/),
 [Zig](/maplibre-native-ffi/reference/zig/),
 [Kotlin](/maplibre-native-ffi/reference/kotlin/),
-[Dart](/maplibre-native-ffi/reference/dart/), or
+[Dart](/maplibre-native-ffi/reference/dart/),
+[.NET](/maplibre-native-ffi/reference/dotnet/), or
 [Swift](/maplibre-native-ffi/reference/swift/documentation/maplibrenative/) API
 reference for the spelling in those languages.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a DocFX-generated .NET API reference under `/reference/dotnet/` and links it from the docs sidebar.

## Test plan

Run `mise run //docs:api:dotnet` and open `/reference/dotnet/` on a local docs build; confirm `Maplibre.Native.Map.MapHandle` is present and `Internal.*` is filtered out.

## AI assistance

- **Tools:** Cursor
- **Context:** DocFX is restored from a separate `docfx/.config/dotnet-tools.json` so it is not restored in the same manifest as ClangSharp (hits a .NET SDK tool-restore bug).

<a href="https://cursor.com/agents/bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdotnet-api-reference-demo.mp4"><img src="https://cursor.com/artifacts/c/art-2bb8f88b-7d60-4755-94e5-b56c1b4afe8d" alt="dotnet-api-reference-demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eed7b2a6-7e46-40dd-b7cf-7b75aaa34cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

