### PR TITLE
Run Gradle on JDK 17 for Windows ARM64 CI

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -325,9 +325,15 @@ runs:
       id: toolchain-key
       shell: bash
       run: |
+        gradle_key=""
+        if [[ "${RUNNER_OS}" == "Windows" &&
+              "${RUNNER_ARCH}" == "ARM64" &&
+              "${{ inputs.gradle }}" == "true" ]]; then
+          gradle_key="-gradle-zulu17.68.17.0"
+        fi
         prefix="toolchains-v1-${{ runner.os }}-${{ runner.arch }}-${ImageOS:-unknown}"
         echo "prefix=${prefix}" >> "$GITHUB_OUTPUT"
-        echo "key=${prefix}-${{ hashFiles('mise.toml', 'mise.lock', 'mise.linux.toml', 'mise.macos.toml', 'mise.windows.toml', '.devcontainer/mise.toml', 'bindings/*/mise.toml', 'examples/*/mise.toml', 'docs/mise.toml') }}" >> "$GITHUB_OUTPUT"
+        echo "key=${prefix}${gradle_key}-${{ hashFiles('mise.toml', 'mise.lock', 'mise.linux.toml', 'mise.macos.toml', 'mise.windows.toml', '.devcontainer/mise.toml', 'bindings/*/mise.toml', 'examples/*/mise.toml', 'docs/mise.toml') }}" >> "$GITHUB_OUTPUT"
 
     - name: Restore toolchains
       id: toolchains
@@ -447,6 +453,40 @@ runs:
           }
         }
         exit 1
+
+    # JDK-8371740 affects JDK 21 through 25 and can make Gradle miss
+    # completed concurrent work at shutdown. Keep the project and application
+    # toolchain on JDK 25, but run Gradle itself on JDK 17 for Windows ARM64.
+    # The build logic targets that runtime only in this CI environment.
+    # GRADLE_OPTS avoids changing JAVA_HOME or PATH, which mise tasks use to
+    # expose the project JDK 25 toolchain.
+    - name: Use Java 17 for Gradle on Windows ARM64
+      if: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' && inputs.gradle == 'true' }}
+      shell: pwsh
+      run: |
+        $env:MISE_NO_HOOKS = "1"
+        $gradleJavaVersion = "zulu-17.68.17.0"
+        mise install "java@$gradleJavaVersion"
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+        $gradleJavaHome = mise where "java@$gradleJavaVersion"
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+        $gradleJavaHome = $gradleJavaHome -replace '\\', '/'
+        $gradleJava = Join-Path $gradleJavaHome "bin/java.exe"
+        if (-not (Test-Path $gradleJava)) {
+          throw "Gradle Java executable not found at $gradleJava"
+        }
+
+        $gradleOptions = "-Dorg.gradle.java.home=$gradleJavaHome"
+        if ($env:GRADLE_OPTS) {
+          $gradleOptions = "$env:GRADLE_OPTS $gradleOptions"
+        }
+        "GRADLE_OPTS=$gradleOptions" >> $env:GITHUB_ENV
+        "ORG_GRADLE_PROJECT_maplibreBuildJvmRelease=17" >> $env:GITHUB_ENV
 
     # Every job restores; one job per runner label saves. Otherwise a miss has
     # every job archive the toolchain tree for one of them to win the key, and

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,8 +15,13 @@ dependencies {
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")
 }
 
-kotlin { compilerOptions { jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.release.get())) } }
+val buildJvmRelease =
+  providers
+    .gradleProperty("maplibreBuildJvmRelease")
+    .orElse(libs.versions.java.release)
+    .get()
+    .toInt()
 
-tasks.withType<JavaCompile>().configureEach {
-  options.release = libs.versions.java.release.get().toInt()
-}
+kotlin { compilerOptions { jvmTarget.set(JvmTarget.fromTarget(buildJvmRelease.toString())) } }
+
+tasks.withType<JavaCompile>().configureEach { options.release = buildJvmRelease }


### PR DESCRIPTION
## Summary

Run Gradle on pinned Zulu 17 in Windows ARM64 CI to avoid JDK-8371740 while retaining JDK 25 project and application toolchains.

## Test plan

Ran the LWJGL Kotlin compilation with a Zulu 17 Gradle daemon and Zulu 25 project toolchain, targeted `hk check`, and `mise run ci:generate-workflow --check`.

## AI assistance

- **Tools:** Codex
- **Context:** Used to investigate JDK-8371740, inspect the failing Windows ARM64 workflow, implement the CI override, and run the listed checks.