### PR TITLE
Disable Gradle build result capture due to windows arm64 flakiness

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -235,7 +235,14 @@ runs:
       if: ${{ inputs.gradle == 'true' }}
       uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
-        add-job-summary: on-failure
+        add-job-summary: never
+
+    # setup-gradle's build-result listener only supplies reporting metadata.
+    # Keep its Gradle User Home caching without adding a listener to every build.
+    - name: Disable Gradle build result capture
+      if: ${{ inputs.gradle == 'true' }}
+      shell: pwsh
+      run: '"GRADLE_ACTIONS_SKIP_BUILD_RESULT_CAPTURE=true" >> $env:GITHUB_ENV'
 
     - name: Trim Windows PATH before mise activation
       if: ${{ runner.os == 'Windows' }}
@@ -325,15 +332,9 @@ runs:
       id: toolchain-key
       shell: bash
       run: |
-        gradle_key=""
-        if [[ "${RUNNER_OS}" == "Windows" &&
-              "${RUNNER_ARCH}" == "ARM64" &&
-              "${{ inputs.gradle }}" == "true" ]]; then
-          gradle_key="-gradle-zulu17.68.17.0"
-        fi
         prefix="toolchains-v1-${{ runner.os }}-${{ runner.arch }}-${ImageOS:-unknown}"
         echo "prefix=${prefix}" >> "$GITHUB_OUTPUT"
-        echo "key=${prefix}${gradle_key}-${{ hashFiles('mise.toml', 'mise.lock', 'mise.linux.toml', 'mise.macos.toml', 'mise.windows.toml', '.devcontainer/mise.toml', 'bindings/*/mise.toml', 'examples/*/mise.toml', 'docs/mise.toml') }}" >> "$GITHUB_OUTPUT"
+        echo "key=${prefix}-${{ hashFiles('mise.toml', 'mise.lock', 'mise.linux.toml', 'mise.macos.toml', 'mise.windows.toml', '.devcontainer/mise.toml', 'bindings/*/mise.toml', 'examples/*/mise.toml', 'docs/mise.toml') }}" >> "$GITHUB_OUTPUT"
 
     - name: Restore toolchains
       id: toolchains
@@ -453,40 +454,6 @@ runs:
           }
         }
         exit 1
-
-    # JDK-8371740 affects JDK 21 through 25 and can make Gradle miss
-    # completed concurrent work at shutdown. Keep the project and application
-    # toolchain on JDK 25, but run Gradle itself on JDK 17 for Windows ARM64.
-    # The build logic targets that runtime only in this CI environment.
-    # GRADLE_OPTS avoids changing JAVA_HOME or PATH, which mise tasks use to
-    # expose the project JDK 25 toolchain.
-    - name: Use Java 17 for Gradle on Windows ARM64
-      if: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' && inputs.gradle == 'true' }}
-      shell: pwsh
-      run: |
-        $env:MISE_NO_HOOKS = "1"
-        $gradleJavaVersion = "zulu-17.68.17.0"
-        mise install "java@$gradleJavaVersion"
-        if ($LASTEXITCODE -ne 0) {
-          exit $LASTEXITCODE
-        }
-
-        $gradleJavaHome = mise where "java@$gradleJavaVersion"
-        if ($LASTEXITCODE -ne 0) {
-          exit $LASTEXITCODE
-        }
-        $gradleJavaHome = $gradleJavaHome -replace '\\', '/'
-        $gradleJava = Join-Path $gradleJavaHome "bin/java.exe"
-        if (-not (Test-Path $gradleJava)) {
-          throw "Gradle Java executable not found at $gradleJava"
-        }
-
-        $gradleOptions = "-Dorg.gradle.java.home=$gradleJavaHome"
-        if ($env:GRADLE_OPTS) {
-          $gradleOptions = "$env:GRADLE_OPTS $gradleOptions"
-        }
-        "GRADLE_OPTS=$gradleOptions" >> $env:GITHUB_ENV
-        "ORG_GRADLE_PROJECT_maplibreBuildJvmRelease=17" >> $env:GITHUB_ENV
 
     # Every job restores; one job per runner label saves. Otherwise a miss has
     # every job archive the toolchain tree for one of them to win the key, and

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,13 +15,8 @@ dependencies {
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")
 }
 
-val buildJvmRelease =
-  providers
-    .gradleProperty("maplibreBuildJvmRelease")
-    .orElse(libs.versions.java.release)
-    .get()
-    .toInt()
+kotlin { compilerOptions { jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.release.get())) } }
 
-kotlin { compilerOptions { jvmTarget.set(JvmTarget.fromTarget(buildJvmRelease.toString())) } }
-
-tasks.withType<JavaCompile>().configureEach { options.release = buildJvmRelease }
+tasks.withType<JavaCompile>().configureEach {
+  options.release = libs.versions.java.release.get().toInt()
+}


### PR DESCRIPTION
## Summary

Disable setup-gradle build-result reporting while retaining its cache management, and remove the ineffective Windows ARM64 JDK 17 workaround.

## Test plan

Validated the composite action with actionlint, dprint, and `git diff --check`.

## AI assistance

- **Tools:** Codex
- **Context:** Used to inspect the Windows ARM64 failure logs, trace the Gradle listener timeout, and implement and validate the focused CI change.