### PR TITLE
Preserve the renderer across render target changes

### DIFF
--- a/bindings/dart/lib/src/internal/c/maplibre_native_c.g.dart
+++ b/bindings/dart/lib/src/internal/c/maplibre_native_c.g.dart
@@ -5124,6 +5124,75 @@ class MaplibreNativeC {
         )
       >();
 
+  mln_status mln_metal_surface_set_target(
+    Dartmln_render_session session,
+    ffi.Pointer<mln_metal_surface_descriptor> descriptor,
+  ) {
+    return mln_status.fromValue(
+      _mln_metal_surface_set_target(session, descriptor),
+    );
+  }
+
+  late final _mln_metal_surface_set_targetPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            mln_render_session,
+            ffi.Pointer<mln_metal_surface_descriptor>,
+          )
+        >
+      >('mln_metal_surface_set_target');
+  late final _mln_metal_surface_set_target = _mln_metal_surface_set_targetPtr
+      .asFunction<
+        int Function(int, ffi.Pointer<mln_metal_surface_descriptor>)
+      >();
+
+  mln_status mln_vulkan_surface_set_target(
+    Dartmln_render_session session,
+    ffi.Pointer<mln_vulkan_surface_descriptor> descriptor,
+  ) {
+    return mln_status.fromValue(
+      _mln_vulkan_surface_set_target(session, descriptor),
+    );
+  }
+
+  late final _mln_vulkan_surface_set_targetPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            mln_render_session,
+            ffi.Pointer<mln_vulkan_surface_descriptor>,
+          )
+        >
+      >('mln_vulkan_surface_set_target');
+  late final _mln_vulkan_surface_set_target = _mln_vulkan_surface_set_targetPtr
+      .asFunction<
+        int Function(int, ffi.Pointer<mln_vulkan_surface_descriptor>)
+      >();
+
+  mln_status mln_opengl_surface_set_target(
+    Dartmln_render_session session,
+    ffi.Pointer<mln_opengl_surface_descriptor> descriptor,
+  ) {
+    return mln_status.fromValue(
+      _mln_opengl_surface_set_target(session, descriptor),
+    );
+  }
+
+  late final _mln_opengl_surface_set_targetPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            mln_render_session,
+            ffi.Pointer<mln_opengl_surface_descriptor>,
+          )
+        >
+      >('mln_opengl_surface_set_target');
+  late final _mln_opengl_surface_set_target = _mln_opengl_surface_set_targetPtr
+      .asFunction<
+        int Function(int, ffi.Pointer<mln_opengl_surface_descriptor>)
+      >();
+
   mln_metal_owned_texture_descriptor
   mln_metal_owned_texture_descriptor_default() {
     return _mln_metal_owned_texture_descriptor_default();
@@ -5391,6 +5460,87 @@ class MaplibreNativeC {
               int,
               ffi.Pointer<mln_opengl_borrowed_texture_descriptor>,
               ffi.Pointer<mln_render_session>,
+            )
+          >();
+
+  mln_status mln_metal_borrowed_texture_set_target(
+    Dartmln_render_session session,
+    ffi.Pointer<mln_metal_borrowed_texture_descriptor> descriptor,
+  ) {
+    return mln_status.fromValue(
+      _mln_metal_borrowed_texture_set_target(session, descriptor),
+    );
+  }
+
+  late final _mln_metal_borrowed_texture_set_targetPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            mln_render_session,
+            ffi.Pointer<mln_metal_borrowed_texture_descriptor>,
+          )
+        >
+      >('mln_metal_borrowed_texture_set_target');
+  late final _mln_metal_borrowed_texture_set_target =
+      _mln_metal_borrowed_texture_set_targetPtr
+          .asFunction<
+            int Function(
+              int,
+              ffi.Pointer<mln_metal_borrowed_texture_descriptor>,
+            )
+          >();
+
+  mln_status mln_vulkan_borrowed_texture_set_target(
+    Dartmln_render_session session,
+    ffi.Pointer<mln_vulkan_borrowed_texture_descriptor> descriptor,
+  ) {
+    return mln_status.fromValue(
+      _mln_vulkan_borrowed_texture_set_target(session, descriptor),
+    );
+  }
+
+  late final _mln_vulkan_borrowed_texture_set_targetPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            mln_render_session,
+            ffi.Pointer<mln_vulkan_borrowed_texture_descriptor>,
+          )
+        >
+      >('mln_vulkan_borrowed_texture_set_target');
+  late final _mln_vulkan_borrowed_texture_set_target =
+      _mln_vulkan_borrowed_texture_set_targetPtr
+          .asFunction<
+            int Function(
+              int,
+              ffi.Pointer<mln_vulkan_borrowed_texture_descriptor>,
+            )
+          >();
+
+  mln_status mln_opengl_borrowed_texture_set_target(
+    Dartmln_render_session session,
+    ffi.Pointer<mln_opengl_borrowed_texture_descriptor> descriptor,
+  ) {
+    return mln_status.fromValue(
+      _mln_opengl_borrowed_texture_set_target(session, descriptor),
+    );
+  }
+
+  late final _mln_opengl_borrowed_texture_set_targetPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            mln_render_session,
+            ffi.Pointer<mln_opengl_borrowed_texture_descriptor>,
+          )
+        >
+      >('mln_opengl_borrowed_texture_set_target');
+  late final _mln_opengl_borrowed_texture_set_target =
+      _mln_opengl_borrowed_texture_set_targetPtr
+          .asFunction<
+            int Function(
+              int,
+              ffi.Pointer<mln_opengl_borrowed_texture_descriptor>,
             )
           >();
 

--- a/bindings/dart/lib/src/runtime/runtime_render_handles.dart
+++ b/bindings/dart/lib/src/runtime/runtime_render_handles.dart
@@ -141,11 +141,162 @@ final class RenderSessionHandle {
   NativeRenderSession get _handle => _state.handle;
 
   /// Resizes an attached render session.
+  ///
+  /// Surface and session-owned texture targets resize in place. A caller-owned
+  /// texture is sized by its owner and is rejected here: allocate one at the
+  /// new size and hand it over with [setMetalBorrowedTextureTarget] or its
+  /// Vulkan or OpenGL counterpart, which keeps this session.
   void resize(int width, int height, {double scaleFactor = 1}) {
     _checkNoActiveTextureFrame('resize render session');
     _check(
       _c.raw.mln_render_session_resize(_handle.raw, width, height, scaleFactor),
     );
+  }
+
+  /// Presents this attached surface session through a new Metal surface.
+  ///
+  /// A host surface can be destroyed and recreated while the map goes on
+  /// living, which is what Android rotation, a Flutter `SurfaceProducer`
+  /// lifecycle change, and a window resize that reallocates all look like from
+  /// here. Replacing the surface in place keeps this session's renderer, and
+  /// with it the tile pyramid, glyph and image atlases, symbol placement, and
+  /// feature state.
+  ///
+  /// [descriptor] names the same graphics context this session attached with,
+  /// and its extent applies as [resize] applies one. A target on a different
+  /// context throws an [InvalidArgumentException], and one this session's
+  /// compiled state cannot serve throws an [UnsupportedFeatureException]. Both leave
+  /// this session rendering into the surface it has; [close] it and attach
+  /// again to take that target.
+  void setMetalSurfaceTarget(MetalSurfaceDescriptor descriptor) {
+    _checkNoActiveTextureFrame('set Metal surface target');
+    withNativeArena((arena) {
+      final nativeDescriptor = arena<raw.mln_metal_surface_descriptor>();
+      nativeDescriptor.ref = _metalSurfaceDescriptorToNative(descriptor);
+      _check(
+        _c.raw.mln_metal_surface_set_target(_handle.raw, nativeDescriptor),
+      );
+    });
+  }
+
+  /// Presents this attached surface session through a new Vulkan surface.
+  ///
+  /// See [setMetalSurfaceTarget] for what replacing a surface preserves. The
+  /// outgoing `VkSurfaceKHR` must still be valid: this session holds a
+  /// swapchain built from it, and Vulkan destroys every swapchain before its
+  /// surface.
+  void setVulkanSurfaceTarget(VulkanSurfaceDescriptor descriptor) {
+    _checkNoActiveTextureFrame('set Vulkan surface target');
+    withNativeArena((arena) {
+      final nativeDescriptor = arena<raw.mln_vulkan_surface_descriptor>();
+      nativeDescriptor.ref = _vulkanSurfaceDescriptorToNative(descriptor);
+      _check(
+        _c.raw.mln_vulkan_surface_set_target(_handle.raw, nativeDescriptor),
+      );
+    });
+  }
+
+  /// Presents this attached surface session through a new OpenGL surface.
+  ///
+  /// See [setMetalSurfaceTarget] for what replacing a surface preserves. The
+  /// new surface is made current on the next render, so a host may hand over a
+  /// replacement for one it has already destroyed. A surface accepted here can
+  /// still prove unusable, which the next [renderUpdate] reports rather than
+  /// this call.
+  void setOpenGLSurfaceTarget(OpenGLSurfaceDescriptor descriptor) {
+    _checkNoActiveTextureFrame('set OpenGL surface target');
+    withNativeArena((arena) {
+      final nativeDescriptor = arena<raw.mln_opengl_surface_descriptor>();
+      nativeDescriptor.ref = _openglSurfaceDescriptorToNative(descriptor);
+      _check(
+        _c.raw.mln_opengl_surface_set_target(_handle.raw, nativeDescriptor),
+      );
+    });
+  }
+
+  /// Renders this attached texture session into a new caller-owned Metal
+  /// texture.
+  ///
+  /// A caller-owned texture is sized by its owner, so a host that follows a
+  /// resize reallocates rather than resizing and [resize] rejects the attempt.
+  /// Handing the replacement over here keeps this session's renderer instead,
+  /// so the map does not go cold on every resize.
+  ///
+  /// The replacement belongs to the device this session attached with and
+  /// carries the pixel format it attached with; one that does not is rejected
+  /// with this session still rendering into the texture it has. The caller owns
+  /// the replacement and keeps it valid until the next replacement, [detach],
+  /// or [close]. This session never retained the outgoing texture and never
+  /// releases it, but reads from it during this call, so keep that one valid
+  /// until the call returns.
+  void setMetalBorrowedTextureTarget(
+    MetalBorrowedTextureDescriptor descriptor,
+  ) {
+    _checkNoActiveTextureFrame('set Metal borrowed texture target');
+    withNativeArena((arena) {
+      final nativeDescriptor =
+          arena<raw.mln_metal_borrowed_texture_descriptor>();
+      nativeDescriptor.ref = _metalBorrowedTextureDescriptorToNative(
+        descriptor,
+      );
+      _check(
+        _c.raw.mln_metal_borrowed_texture_set_target(
+          _handle.raw,
+          nativeDescriptor,
+        ),
+      );
+    });
+  }
+
+  /// Renders this attached texture session into a new caller-owned Vulkan
+  /// image.
+  ///
+  /// See [setMetalBorrowedTextureTarget] for what replacing a target preserves.
+  /// The replacement carries the format and both layouts this session attached
+  /// with, since its render pass was built around them.
+  void setVulkanBorrowedTextureTarget(
+    VulkanBorrowedTextureDescriptor descriptor,
+  ) {
+    _checkNoActiveTextureFrame('set Vulkan borrowed texture target');
+    withNativeArena((arena) {
+      final nativeDescriptor =
+          arena<raw.mln_vulkan_borrowed_texture_descriptor>();
+      nativeDescriptor.ref = _vulkanBorrowedTextureDescriptorToNative(
+        descriptor,
+      );
+      _check(
+        _c.raw.mln_vulkan_borrowed_texture_set_target(
+          _handle.raw,
+          nativeDescriptor,
+        ),
+      );
+    });
+  }
+
+  /// Renders this attached texture session into a new caller-owned OpenGL
+  /// texture.
+  ///
+  /// See [setMetalBorrowedTextureTarget] for what replacing a target preserves.
+  /// The replacement belongs to the context this session attached with, or one
+  /// in its share group, and that context must be current on this isolate's
+  /// thread.
+  void setOpenGLBorrowedTextureTarget(
+    OpenGLBorrowedTextureDescriptor descriptor,
+  ) {
+    _checkNoActiveTextureFrame('set OpenGL borrowed texture target');
+    withNativeArena((arena) {
+      final nativeDescriptor =
+          arena<raw.mln_opengl_borrowed_texture_descriptor>();
+      nativeDescriptor.ref = _openglBorrowedTextureDescriptorToNative(
+        descriptor,
+      );
+      _check(
+        _c.raw.mln_opengl_borrowed_texture_set_target(
+          _handle.raw,
+          nativeDescriptor,
+        ),
+      );
+    });
   }
 
   /// Processes the latest map render update and reports whether it rendered.

--- a/bindings/dart/lib/src/runtime/runtime_render_handles.dart
+++ b/bindings/dart/lib/src/runtime/runtime_render_handles.dart
@@ -163,11 +163,11 @@ final class RenderSessionHandle {
   /// feature state.
   ///
   /// [descriptor] names the same graphics context this session attached with,
-  /// and its extent applies as [resize] applies one. A target on a different
-  /// context throws an [InvalidArgumentException], and one this session's
-  /// compiled state cannot serve throws an [UnsupportedFeatureException]. Both leave
-  /// this session rendering into the surface it has; [close] it and attach
-  /// again to take that target.
+  /// and its extent applies as [resize] applies one. A layer on a different
+  /// device throws an [InvalidArgumentException] and leaves this session
+  /// rendering into the surface it has, so [close] it and attach again to take
+  /// that one. The session sets the layer's pixel format itself, so there is
+  /// nothing else here for a replacement to mismatch.
   void setMetalSurfaceTarget(MetalSurfaceDescriptor descriptor) {
     _checkNoActiveTextureFrame('set Metal surface target');
     withNativeArena((arena) {

--- a/bindings/dart/lib/src/runtime/runtime_render_handles.dart
+++ b/bindings/dart/lib/src/runtime/runtime_render_handles.dart
@@ -234,9 +234,9 @@ final class RenderSessionHandle {
   /// format it attached with, which throws an [UnsupportedFeatureException]
   /// otherwise. Both leave this session rendering into the texture it has. The caller owns
   /// the replacement and keeps it valid until the next replacement, [detach],
-  /// or [close]. This session never retained the outgoing texture and never
-  /// releases it, but reads from it during this call, so keep that one valid
-  /// until the call returns.
+  /// or [close]. This session never retained the outgoing texture, never
+  /// releases it, and never reads it here, so a host that already released it
+  /// hands over the replacement all the same.
   void setMetalBorrowedTextureTarget(
     MetalBorrowedTextureDescriptor descriptor,
   ) {

--- a/bindings/dart/lib/src/runtime/runtime_render_handles.dart
+++ b/bindings/dart/lib/src/runtime/runtime_render_handles.dart
@@ -222,9 +222,10 @@ final class RenderSessionHandle {
   /// Handing the replacement over here keeps this session's renderer instead,
   /// so the map does not go cold on every resize.
   ///
-  /// The replacement belongs to the device this session attached with and
-  /// carries the pixel format it attached with; one that does not is rejected
-  /// with this session still rendering into the texture it has. The caller owns
+  /// The replacement belongs to the device this session attached with, which
+  /// throws an [InvalidArgumentException] otherwise, and carries the pixel
+  /// format it attached with, which throws an [UnsupportedFeatureException]
+  /// otherwise. Both leave this session rendering into the texture it has. The caller owns
   /// the replacement and keeps it valid until the next replacement, [detach],
   /// or [close]. This session never retained the outgoing texture and never
   /// releases it, but reads from it during this call, so keep that one valid

--- a/bindings/dart/lib/src/runtime/runtime_render_handles.dart
+++ b/bindings/dart/lib/src/runtime/runtime_render_handles.dart
@@ -146,6 +146,13 @@ final class RenderSessionHandle {
   /// texture is sized by its owner and is rejected here: allocate one at the
   /// new size and hand it over with [setMetalBorrowedTextureTarget] or its
   /// Vulkan or OpenGL counterpart, which keeps this session.
+  ///
+  /// This session keeps its renderer across a resize, so renderer-held state
+  /// such as feature state carries over. A scale factor that differs from this
+  /// session's current one is the exception: a renderer compiles its shaders
+  /// for one pixel ratio, so that resize starts a new one with renderer-held
+  /// state empty. The same exception applies to every `setTarget` method, which
+  /// otherwise keeps the renderer.
   void resize(int width, int height, {double scaleFactor = 1}) {
     _checkNoActiveTextureFrame('resize render session');
     _check(
@@ -163,11 +170,11 @@ final class RenderSessionHandle {
   /// feature state.
   ///
   /// [descriptor] names the same graphics context this session attached with,
-  /// and its extent applies as [resize] applies one. A layer on a different
-  /// device throws an [InvalidArgumentException] and leaves this session
-  /// rendering into the surface it has, so [close] it and attach again to take
-  /// that one. The session sets the layer's pixel format itself, so there is
-  /// nothing else here for a replacement to mismatch.
+  /// and its extent applies as [resize] applies one. A descriptor whose
+  /// context device is neither null nor this session's device throws an
+  /// [InvalidArgumentException] and leaves this session rendering into the
+  /// surface it has. The session assigns the layer its own device and pixel
+  /// format, so the layer itself carries nothing that has to match.
   void setMetalSurfaceTarget(MetalSurfaceDescriptor descriptor) {
     _checkNoActiveTextureFrame('set Metal surface target');
     withNativeArena((arena) {

--- a/bindings/dotnet/src/Maplibre.Native/Generated/surface.g.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Generated/surface.g.cs
@@ -57,5 +57,14 @@ namespace Maplibre.Native.Internal.C
 
         [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern mln_status mln_opengl_surface_attach([NativeTypeName("mln_map")] MlnMap map, [NativeTypeName("const mln_opengl_surface_descriptor *")] mln_opengl_surface_descriptor* descriptor, [NativeTypeName("mln_render_session *")] MlnRenderSession* out_session);
+
+        [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern mln_status mln_metal_surface_set_target([NativeTypeName("mln_render_session")] MlnRenderSession session, [NativeTypeName("const mln_metal_surface_descriptor *")] mln_metal_surface_descriptor* descriptor);
+
+        [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern mln_status mln_vulkan_surface_set_target([NativeTypeName("mln_render_session")] MlnRenderSession session, [NativeTypeName("const mln_vulkan_surface_descriptor *")] mln_vulkan_surface_descriptor* descriptor);
+
+        [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern mln_status mln_opengl_surface_set_target([NativeTypeName("mln_render_session")] MlnRenderSession session, [NativeTypeName("const mln_opengl_surface_descriptor *")] mln_opengl_surface_descriptor* descriptor);
     }
 }

--- a/bindings/dotnet/src/Maplibre.Native/Generated/texture.g.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Generated/texture.g.cs
@@ -253,6 +253,15 @@ namespace Maplibre.Native.Internal.C
         public static extern mln_status mln_opengl_borrowed_texture_attach([NativeTypeName("mln_map")] MlnMap map, [NativeTypeName("const mln_opengl_borrowed_texture_descriptor *")] mln_opengl_borrowed_texture_descriptor* descriptor, [NativeTypeName("mln_render_session *")] MlnRenderSession* out_session);
 
         [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern mln_status mln_metal_borrowed_texture_set_target([NativeTypeName("mln_render_session")] MlnRenderSession session, [NativeTypeName("const mln_metal_borrowed_texture_descriptor *")] mln_metal_borrowed_texture_descriptor* descriptor);
+
+        [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern mln_status mln_vulkan_borrowed_texture_set_target([NativeTypeName("mln_render_session")] MlnRenderSession session, [NativeTypeName("const mln_vulkan_borrowed_texture_descriptor *")] mln_vulkan_borrowed_texture_descriptor* descriptor);
+
+        [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern mln_status mln_opengl_borrowed_texture_set_target([NativeTypeName("mln_render_session")] MlnRenderSession session, [NativeTypeName("const mln_opengl_borrowed_texture_descriptor *")] mln_opengl_borrowed_texture_descriptor* descriptor);
+
+        [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern mln_status mln_texture_read_premultiplied_rgba8([NativeTypeName("mln_render_session")] MlnRenderSession session, [NativeTypeName("uint8_t *")] byte* out_data, [NativeTypeName("size_t")] nuint out_data_capacity, mln_texture_image_info* out_info);
 
         [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
@@ -419,9 +419,10 @@ public sealed unsafe class RenderSessionHandle : IDisposable
     /// is sized by its owner, so a host that follows a resize reallocates rather than resizing and
     /// <see cref="Resize"/> throws an unsupported-feature error. Handing the replacement over here
     /// keeps this session's renderer instead, so the map does not go cold on every resize. The
-    /// replacement belongs to the device this session attached with and carries the pixel format it
-    /// attached with; one that does not throws an unsupported-feature error with this session still
-    /// rendering into the texture it has. The caller owns the replacement and keeps it valid until
+    /// replacement belongs to the device this session attached with, which throws an
+    /// invalid-argument error otherwise, and carries the pixel format it attached with, which throws
+    /// an unsupported-feature error otherwise. Both leave this session rendering into the texture it
+    /// has. The caller owns the replacement and keeps it valid until
     /// the next replacement, detach, or dispose. This session never retained the outgoing texture and
     /// never releases it, but reads from it during this call, so keep that texture valid until the
     /// call returns.

--- a/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
@@ -374,9 +374,10 @@ public sealed unsafe class RenderSessionHandle : IDisposable
     /// Replacing the surface in place keeps this session's renderer, and with it the tile pyramid,
     /// glyph and image atlases, symbol placement, and feature state. The descriptor names the same
     /// graphics context this session attached with, and its extent applies as <see cref="Resize"/>
-    /// applies one. A target on a different context throws an invalid-argument error, and one this
-    /// session's compiled state cannot serve throws an unsupported-feature error. Both leave this
-    /// session rendering into the surface it has; dispose it and attach again to take that target.
+    /// applies one. A layer on a different device throws an invalid-argument error and leaves this
+    /// session rendering into the surface it has, so disposing it and attaching again is what takes
+    /// that one. The session sets the layer's pixel format itself, so there is nothing else here for
+    /// a replacement to mismatch.
     /// </summary>
     public void SetMetalSurfaceTarget(MetalSurfaceDescriptor descriptor)
     {

--- a/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
@@ -374,10 +374,10 @@ public sealed unsafe class RenderSessionHandle : IDisposable
     /// Replacing the surface in place keeps this session's renderer, and with it the tile pyramid,
     /// glyph and image atlases, symbol placement, and feature state. The descriptor names the same
     /// graphics context this session attached with, and its extent applies as <see cref="Resize"/>
-    /// applies one. A layer on a different device throws an invalid-argument error and leaves this
-    /// session rendering into the surface it has, so disposing it and attaching again is what takes
-    /// that one. The session sets the layer's pixel format itself, so there is nothing else here for
-    /// a replacement to mismatch.
+    /// applies one. A descriptor whose context device is neither null nor this session's device
+    /// throws an invalid-argument error and leaves this session rendering into the surface it has.
+    /// The session assigns the layer its own device and pixel format, so the layer itself carries
+    /// nothing that has to match.
     /// </summary>
     public void SetMetalSurfaceTarget(MetalSurfaceDescriptor descriptor)
     {

--- a/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
@@ -419,7 +419,8 @@ public sealed unsafe class RenderSessionHandle : IDisposable
     /// Renders this attached texture session into a new caller-owned texture. A caller-owned texture
     /// is sized by its owner, so a host that follows a resize reallocates rather than resizing and
     /// <see cref="Resize"/> throws an unsupported-feature error. Handing the replacement over here
-    /// keeps this session's renderer instead, so the map does not go cold on every resize. The
+    /// keeps this session's renderer instead, so the map does not go cold on every resize, unless
+    /// the scale factor changes, which starts a new renderer for the new pixel ratio. The
     /// replacement belongs to the device this session attached with, which throws an
     /// invalid-argument error otherwise, and carries the pixel format it attached with, which throws
     /// an unsupported-feature error otherwise. Both leave this session rendering into the texture it

--- a/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
@@ -425,9 +425,9 @@ public sealed unsafe class RenderSessionHandle : IDisposable
     /// invalid-argument error otherwise, and carries the pixel format it attached with, which throws
     /// an unsupported-feature error otherwise. Both leave this session rendering into the texture it
     /// has. The caller owns the replacement and keeps it valid until
-    /// the next replacement, detach, or dispose. This session never retained the outgoing texture and
-    /// never releases it, but reads from it during this call, so keep that texture valid until the
-    /// call returns.
+    /// the next replacement, detach, or dispose. This session never retained the outgoing texture,
+    /// never releases it, and never reads it here, so a host that already released it hands over the
+    /// replacement all the same.
     /// </summary>
     public void SetMetalBorrowedTextureTarget(MetalBorrowedTextureDescriptor descriptor)
     {

--- a/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
@@ -355,16 +355,108 @@ public sealed unsafe class RenderSessionHandle : IDisposable
     /// <summary>
     /// Resizes this attached render session. Surface and owned-texture sessions resize in place.
     /// Borrowed texture targets are sized by their owner and throw an unsupported-feature error:
-    /// dispose this session, recreate the texture, and attach a new session. A map holds at most
-    /// one attached session, so dispose before attaching the replacement. The session keeps its
-    /// renderer across a resize, so renderer-held state such as feature state carries over; a scale
-    /// factor change is the exception, starting a new renderer with that state empty. Map state such
-    /// as camera, style, and sources survives either way.
+    /// allocate a texture at the new size and hand it over with the set-target method for the
+    /// backend, such as <see cref="SetOpenGLBorrowedTextureTarget"/>, which keeps this session. The
+    /// session keeps its renderer across a resize, so renderer-held state such as feature state
+    /// carries over; a scale factor change is the exception, starting a new renderer with that state
+    /// empty. Map state such as camera, style, and sources survives either way.
     /// </summary>
     public void Resize(uint width, uint height, double scaleFactor)
     {
         ThrowIfTextureFrameActive(nameof(Resize));
         NativeStatus.Check(ResizeNative(Handle, width, height, scaleFactor));
+    }
+
+    /// <summary>
+    /// Presents this attached surface session through a new surface. A host surface can be destroyed
+    /// and recreated while the map goes on living, which is what Android rotation, a Flutter surface
+    /// producer lifecycle change, and a window resize that reallocates all look like from here.
+    /// Replacing the surface in place keeps this session's renderer, and with it the tile pyramid,
+    /// glyph and image atlases, symbol placement, and feature state. The descriptor names the same
+    /// graphics context this session attached with, and its extent applies as <see cref="Resize"/>
+    /// applies one. A target on a different context throws an invalid-argument error, and one this
+    /// session's compiled state cannot serve throws an unsupported-feature error. Both leave this
+    /// session rendering into the surface it has; dispose it and attach again to take that target.
+    /// </summary>
+    public void SetMetalSurfaceTarget(MetalSurfaceDescriptor descriptor)
+    {
+        ThrowIfTextureFrameActive(nameof(SetMetalSurfaceTarget));
+        var native = RenderStructs.ToNative(descriptor);
+        NativeStatus.Check(NativeMethods.mln_metal_surface_set_target(Handle, &native));
+    }
+
+    /// <summary>
+    /// Presents this attached surface session through a new surface. See
+    /// <see cref="SetMetalSurfaceTarget"/> for what replacing a surface preserves. The outgoing
+    /// VkSurfaceKHR must still be valid: this session holds a swapchain built from it, and Vulkan
+    /// destroys every swapchain before its surface. The replacement reports the color format and
+    /// surface-transform support this session compiled a render pass and shaders for; one that does
+    /// not throws an unsupported-feature error.
+    /// </summary>
+    public void SetVulkanSurfaceTarget(VulkanSurfaceDescriptor descriptor)
+    {
+        ThrowIfTextureFrameActive(nameof(SetVulkanSurfaceTarget));
+        var native = RenderStructs.ToNative(descriptor);
+        NativeStatus.Check(NativeMethods.mln_vulkan_surface_set_target(Handle, &native));
+    }
+
+    /// <summary>
+    /// Presents this attached surface session through a new surface. See
+    /// <see cref="SetMetalSurfaceTarget"/> for what replacing a surface preserves. The new surface is
+    /// made current on the next render, so a host may hand over a replacement for one it has already
+    /// destroyed. A surface accepted here can still prove unusable, which the next
+    /// <see cref="RenderUpdate"/> reports rather than this call.
+    /// </summary>
+    public void SetOpenGLSurfaceTarget(OpenGLSurfaceDescriptor descriptor)
+    {
+        ThrowIfTextureFrameActive(nameof(SetOpenGLSurfaceTarget));
+        var native = RenderStructs.ToNative(descriptor);
+        NativeStatus.Check(NativeMethods.mln_opengl_surface_set_target(Handle, &native));
+    }
+
+    /// <summary>
+    /// Renders this attached texture session into a new caller-owned texture. A caller-owned texture
+    /// is sized by its owner, so a host that follows a resize reallocates rather than resizing and
+    /// <see cref="Resize"/> throws an unsupported-feature error. Handing the replacement over here
+    /// keeps this session's renderer instead, so the map does not go cold on every resize. The
+    /// replacement belongs to the device this session attached with and carries the pixel format it
+    /// attached with; one that does not throws an unsupported-feature error with this session still
+    /// rendering into the texture it has. The caller owns the replacement and keeps it valid until
+    /// the next replacement, detach, or dispose. This session never retained the outgoing texture and
+    /// never releases it, but reads from it during this call, so keep that texture valid until the
+    /// call returns.
+    /// </summary>
+    public void SetMetalBorrowedTextureTarget(MetalBorrowedTextureDescriptor descriptor)
+    {
+        ThrowIfTextureFrameActive(nameof(SetMetalBorrowedTextureTarget));
+        var native = RenderStructs.ToNative(descriptor);
+        NativeStatus.Check(NativeMethods.mln_metal_borrowed_texture_set_target(Handle, &native));
+    }
+
+    /// <summary>
+    /// Renders this attached texture session into a new caller-owned image. See
+    /// <see cref="SetMetalBorrowedTextureTarget"/> for what replacing a target preserves. The
+    /// replacement carries the format and both layouts this session attached with, since its render
+    /// pass was built around them.
+    /// </summary>
+    public void SetVulkanBorrowedTextureTarget(VulkanBorrowedTextureDescriptor descriptor)
+    {
+        ThrowIfTextureFrameActive(nameof(SetVulkanBorrowedTextureTarget));
+        var native = RenderStructs.ToNative(descriptor);
+        NativeStatus.Check(NativeMethods.mln_vulkan_borrowed_texture_set_target(Handle, &native));
+    }
+
+    /// <summary>
+    /// Renders this attached texture session into a new caller-owned texture. See
+    /// <see cref="SetMetalBorrowedTextureTarget"/> for what replacing a target preserves. The
+    /// replacement belongs to the context this session attached with, or one in its share group, and
+    /// the host context must be current on this thread.
+    /// </summary>
+    public void SetOpenGLBorrowedTextureTarget(OpenGLBorrowedTextureDescriptor descriptor)
+    {
+        ThrowIfTextureFrameActive(nameof(SetOpenGLBorrowedTextureTarget));
+        var native = RenderStructs.ToNative(descriptor);
+        NativeStatus.Check(NativeMethods.mln_opengl_borrowed_texture_set_target(Handle, &native));
     }
 
     /// <summary>

--- a/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
@@ -356,9 +356,10 @@ public sealed unsafe class RenderSessionHandle : IDisposable
     /// Resizes this attached render session. Surface and owned-texture sessions resize in place.
     /// Borrowed texture targets are sized by their owner and throw an unsupported-feature error:
     /// dispose this session, recreate the texture, and attach a new session. A map holds at most
-    /// one attached session, so dispose before attaching the replacement. Resizing discards the
-    /// session renderer, so renderer-held state such as feature state does not survive; map state
-    /// such as camera, style, and sources survives both resize and reattach.
+    /// one attached session, so dispose before attaching the replacement. The session keeps its
+    /// renderer across a resize, so renderer-held state such as feature state carries over; a scale
+    /// factor change is the exception, starting a new renderer with that state empty. Map state such
+    /// as camera, style, and sources survives either way.
     /// </summary>
     public void Resize(uint width, uint height, double scaleFactor)
     {

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/RenderSessionTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/RenderSessionTests.cs
@@ -447,6 +447,58 @@ public sealed unsafe class RenderSessionTests
         try
         {
             AssertActiveFrameError(() => session.Resize(64, 64, 1));
+            var extent = new RenderTargetExtent(64, 64, 1);
+            var handle = NativePointer.FromBorrowedAddress(1);
+            AssertActiveFrameError(() =>
+                session.SetMetalSurfaceTarget(
+                    new MetalSurfaceDescriptor { Extent = extent, Layer = handle }
+                )
+            );
+            AssertActiveFrameError(() =>
+                session.SetVulkanSurfaceTarget(
+                    new VulkanSurfaceDescriptor { Extent = extent, Surface = handle }
+                )
+            );
+            AssertActiveFrameError(() =>
+                session.SetOpenGLSurfaceTarget(
+                    new OpenGLSurfaceDescriptor { Extent = extent, Surface = handle }
+                )
+            );
+            AssertActiveFrameError(() =>
+                session.SetMetalBorrowedTextureTarget(
+                    new MetalBorrowedTextureDescriptor
+                    {
+                        Extent = extent,
+                        PhysicalWidth = 64,
+                        PhysicalHeight = 64,
+                        Texture = handle,
+                    }
+                )
+            );
+            AssertActiveFrameError(() =>
+                session.SetVulkanBorrowedTextureTarget(
+                    new VulkanBorrowedTextureDescriptor
+                    {
+                        Extent = extent,
+                        PhysicalWidth = 64,
+                        PhysicalHeight = 64,
+                        Image = handle,
+                        ImageView = handle,
+                    }
+                )
+            );
+            AssertActiveFrameError(() =>
+                session.SetOpenGLBorrowedTextureTarget(
+                    new OpenGLBorrowedTextureDescriptor
+                    {
+                        Extent = extent,
+                        PhysicalWidth = 64,
+                        PhysicalHeight = 64,
+                        Texture = 1,
+                        Target = 0x0de1,
+                    }
+                )
+            );
             AssertActiveFrameError(() => _ = session.RenderUpdate());
             AssertActiveFrameError(session.Detach);
             AssertActiveFrameError(() => _ = session.TextureImageInfo());

--- a/bindings/go/render.go
+++ b/bindings/go/render.go
@@ -814,7 +814,9 @@ func (session *RenderSessionHandle) SetOpenGLSurfaceTarget(descriptor OpenGLSurf
 // A caller-owned texture is sized by its owner, so a host that follows a resize
 // reallocates rather than resizing and Resize reports an unsupported-feature
 // error. Handing the replacement over here keeps this session's renderer
-// instead, so the map does not go cold on every resize.
+// instead, so the map does not go cold on every resize, unless the scale factor
+// changes, which starts a new renderer for the new pixel ratio just as Resize
+// does.
 //
 // The replacement belongs to the device this session attached with, which
 // reports an invalid-argument error otherwise, and carries the pixel format it

--- a/bindings/go/render.go
+++ b/bindings/go/render.go
@@ -815,10 +815,10 @@ func (session *RenderSessionHandle) SetOpenGLSurfaceTarget(descriptor OpenGLSurf
 // error. Handing the replacement over here keeps this session's renderer
 // instead, so the map does not go cold on every resize.
 //
-// The replacement belongs to the device this session attached with and carries
-// the pixel format it attached with; one that does not reports an
-// unsupported-feature error with this session still rendering into the texture
-// it has. The caller owns the replacement and keeps it valid until the next
+// The replacement belongs to the device this session attached with, which
+// reports an invalid-argument error otherwise, and carries the pixel format it
+// attached with, which reports an unsupported-feature error otherwise. Both
+// leave this session rendering into the texture it has. The caller owns the replacement and keeps it valid until the next
 // replacement, detach, or session close. This session never retained the
 // outgoing texture and never releases it, but reads from it during this call,
 // so keep that texture valid until the call returns.

--- a/bindings/go/render.go
+++ b/bindings/go/render.go
@@ -823,8 +823,8 @@ func (session *RenderSessionHandle) SetOpenGLSurfaceTarget(descriptor OpenGLSurf
 // attached with, which reports an unsupported-feature error otherwise. Both
 // leave this session rendering into the texture it has. The caller owns the replacement and keeps it valid until the next
 // replacement, detach, or session close. This session never retained the
-// outgoing texture and never releases it, but reads from it during this call,
-// so keep that texture valid until the call returns.
+// outgoing texture, never releases it, and never reads it here, so a host that
+// already released it hands over the replacement all the same.
 func (session *RenderSessionHandle) SetMetalBorrowedTextureTarget(descriptor MetalBorrowedTextureDescriptor) error {
 	if err := descriptor.Extent.validate(); err != nil {
 		return err

--- a/bindings/go/render.go
+++ b/bindings/go/render.go
@@ -749,10 +749,11 @@ func (session *RenderSessionHandle) Resize(extent RenderTargetExtent) error {
 //
 // The descriptor names the same graphics context this session attached with,
 // and its extent applies exactly as Resize applies one, scale factor change
-// included. A layer on a different device reports an invalid-argument error and
-// leaves this session rendering into the surface it has, so closing it and
-// attaching again is what takes that one. The session sets the layer's pixel
-// format itself, so there is nothing else here for a replacement to mismatch.
+// included. A descriptor whose Context.Device is neither zero nor this
+// session's device reports an invalid-argument error and leaves this session
+// rendering into the surface it has. The session assigns the layer its own
+// device and pixel format, so the layer itself carries nothing that has to
+// match.
 func (session *RenderSessionHandle) SetMetalSurfaceTarget(descriptor MetalSurfaceDescriptor) error {
 	if err := descriptor.Extent.validate(); err != nil {
 		return err

--- a/bindings/go/render.go
+++ b/bindings/go/render.go
@@ -710,9 +710,10 @@ func (session *RenderSessionHandle) markFrameReleased() {
 // Resize changes the render session target extent.
 //
 // Surface and owned-texture sessions resize in place. Borrowed texture targets
-// are sized by their owner and report an unsupported-feature error: close this
-// session, recreate the texture, and attach a new session. A map holds at most
-// one attached session, so close before attaching the replacement.
+// are sized by their owner and report an unsupported-feature error: allocate a
+// texture at the new size and hand it over with SetMetalBorrowedTextureTarget,
+// SetVulkanBorrowedTextureTarget, or SetOpenGLBorrowedTextureTarget, which keeps
+// this session.
 //
 // The session keeps its renderer across a resize, so renderer-held state such
 // as feature state carries over. A scale factor change is the exception: a
@@ -734,6 +735,151 @@ func (session *RenderSessionHandle) Resize(extent RenderTargetExtent) error {
 		return checkNative(func() int32 {
 			return int32(C.mln_render_session_resize(C.mln_render_session(ptr), C.uint32_t(extent.Width), C.uint32_t(extent.Height), C.double(extent.ScaleFactor)))
 		})
+	})
+}
+
+// SetMetalSurfaceTarget presents this attached surface session through a new
+// Metal surface.
+//
+// A host surface can be destroyed and recreated while the map goes on living,
+// which is what Android rotation, a Flutter SurfaceProducer lifecycle change,
+// and a window resize that reallocates all look like from here. Replacing the
+// surface in place keeps this session's renderer, and with it the tile pyramid,
+// glyph and image atlases, symbol placement, and feature state.
+//
+// The descriptor names the same graphics context this session attached with,
+// and its extent applies exactly as Resize applies one, scale factor change
+// included. A target on a different context reports an invalid-argument error,
+// and one this session's compiled state cannot serve reports an
+// unsupported-feature error. Both leave this session rendering into the surface
+// it has; close it and attach again to take that target.
+func (session *RenderSessionHandle) SetMetalSurfaceTarget(descriptor MetalSurfaceDescriptor) error {
+	if err := descriptor.Extent.validate(); err != nil {
+		return err
+	}
+	rawDescriptor := descriptor.toC()
+	return session.setTarget(func(ptr nativeRenderSession) int32 {
+		return int32(C.mln_metal_surface_set_target(C.mln_render_session(ptr), &rawDescriptor))
+	})
+}
+
+// SetVulkanSurfaceTarget presents this attached surface session through a new
+// Vulkan surface.
+//
+// See SetMetalSurfaceTarget for what replacing a surface preserves. The
+// outgoing VkSurfaceKHR must still be valid: this session holds a swapchain
+// built from it, and Vulkan destroys every swapchain before its surface. A host
+// that has to release its surface first closes this session and attaches again
+// afterward.
+//
+// The replacement reports the color format and surface-transform support this
+// session already compiled a render pass and shaders for; one that does not
+// reports an unsupported-feature error with this session still rendering into
+// the surface it has.
+func (session *RenderSessionHandle) SetVulkanSurfaceTarget(descriptor VulkanSurfaceDescriptor) error {
+	if err := descriptor.Extent.validate(); err != nil {
+		return err
+	}
+	rawDescriptor := descriptor.toC()
+	return session.setTarget(func(ptr nativeRenderSession) int32 {
+		return int32(C.mln_vulkan_surface_set_target(C.mln_render_session(ptr), &rawDescriptor))
+	})
+}
+
+// SetOpenGLSurfaceTarget presents this attached surface session through a new
+// OpenGL surface.
+//
+// See SetMetalSurfaceTarget for what replacing a surface preserves. The new
+// surface is made current on the next render, so a host may hand over a
+// replacement for one it has already destroyed. A surface accepted here can
+// still turn out to be unusable, which the next RenderUpdate reports as a
+// native error rather than this call.
+func (session *RenderSessionHandle) SetOpenGLSurfaceTarget(descriptor OpenGLSurfaceDescriptor) error {
+	if err := descriptor.Extent.validate(); err != nil {
+		return err
+	}
+	if err := descriptor.Context.validate(); err != nil {
+		return err
+	}
+	rawDescriptor := descriptor.toC()
+	return session.setTarget(func(ptr nativeRenderSession) int32 {
+		return int32(C.mln_opengl_surface_set_target(C.mln_render_session(ptr), &rawDescriptor))
+	})
+}
+
+// SetMetalBorrowedTextureTarget renders this attached texture session into a new
+// caller-owned Metal texture.
+//
+// A caller-owned texture is sized by its owner, so a host that follows a resize
+// reallocates rather than resizing and Resize reports an unsupported-feature
+// error. Handing the replacement over here keeps this session's renderer
+// instead, so the map does not go cold on every resize.
+//
+// The replacement belongs to the device this session attached with and carries
+// the pixel format it attached with; one that does not reports an
+// unsupported-feature error with this session still rendering into the texture
+// it has. The caller owns the replacement and keeps it valid until the next
+// replacement, detach, or session close. This session never retained the
+// outgoing texture and never releases it, but reads from it during this call,
+// so keep that texture valid until the call returns.
+func (session *RenderSessionHandle) SetMetalBorrowedTextureTarget(descriptor MetalBorrowedTextureDescriptor) error {
+	if err := descriptor.Extent.validate(); err != nil {
+		return err
+	}
+	rawDescriptor := descriptor.toC()
+	return session.setTarget(func(ptr nativeRenderSession) int32 {
+		return int32(C.mln_metal_borrowed_texture_set_target(C.mln_render_session(ptr), &rawDescriptor))
+	})
+}
+
+// SetVulkanBorrowedTextureTarget renders this attached texture session into a
+// new caller-owned Vulkan image.
+//
+// See SetMetalBorrowedTextureTarget for what replacing a target preserves. The
+// replacement carries the format and both layouts this session attached with,
+// since its render pass was built around them.
+func (session *RenderSessionHandle) SetVulkanBorrowedTextureTarget(descriptor VulkanBorrowedTextureDescriptor) error {
+	if err := descriptor.Extent.validate(); err != nil {
+		return err
+	}
+	rawDescriptor := descriptor.toC()
+	return session.setTarget(func(ptr nativeRenderSession) int32 {
+		return int32(C.mln_vulkan_borrowed_texture_set_target(C.mln_render_session(ptr), &rawDescriptor))
+	})
+}
+
+// SetOpenGLBorrowedTextureTarget renders this attached texture session into a
+// new caller-owned OpenGL texture.
+//
+// See SetMetalBorrowedTextureTarget for what replacing a target preserves. The
+// replacement belongs to the context this session attached with, or one in its
+// share group, and the host context must be current on the calling thread.
+func (session *RenderSessionHandle) SetOpenGLBorrowedTextureTarget(descriptor OpenGLBorrowedTextureDescriptor) error {
+	if err := descriptor.Extent.validate(); err != nil {
+		return err
+	}
+	if err := descriptor.Context.validate(); err != nil {
+		return err
+	}
+	rawDescriptor := descriptor.toC()
+	return session.setTarget(func(ptr nativeRenderSession) int32 {
+		return int32(C.mln_opengl_borrowed_texture_set_target(C.mln_render_session(ptr), &rawDescriptor))
+	})
+}
+
+// setTarget runs the shared body of the target replacement methods. The
+// materialized descriptor the caller closes over stays alive for the native
+// call, which is all the C API borrows it for.
+func (session *RenderSessionHandle) setTarget(call func(nativeRenderSession) int32) error {
+	ptr, release, err := session.ptr()
+	if err != nil {
+		return err
+	}
+	defer release()
+	defer session.state.KeepAlive()
+	defer session.parent.state.KeepAlive()
+	return session.withNoAcquiredFrame(func() error {
+		return checkNative(func() int32 { return call(ptr) })
 	})
 }
 

--- a/bindings/go/render.go
+++ b/bindings/go/render.go
@@ -749,10 +749,10 @@ func (session *RenderSessionHandle) Resize(extent RenderTargetExtent) error {
 //
 // The descriptor names the same graphics context this session attached with,
 // and its extent applies exactly as Resize applies one, scale factor change
-// included. A target on a different context reports an invalid-argument error,
-// and one this session's compiled state cannot serve reports an
-// unsupported-feature error. Both leave this session rendering into the surface
-// it has; close it and attach again to take that target.
+// included. A layer on a different device reports an invalid-argument error and
+// leaves this session rendering into the surface it has, so closing it and
+// attaching again is what takes that one. The session sets the layer's pixel
+// format itself, so there is nothing else here for a replacement to mismatch.
 func (session *RenderSessionHandle) SetMetalSurfaceTarget(descriptor MetalSurfaceDescriptor) error {
 	if err := descriptor.Extent.validate(); err != nil {
 		return err

--- a/bindings/go/render.go
+++ b/bindings/go/render.go
@@ -714,9 +714,11 @@ func (session *RenderSessionHandle) markFrameReleased() {
 // session, recreate the texture, and attach a new session. A map holds at most
 // one attached session, so close before attaching the replacement.
 //
-// Resizing discards the session renderer, so renderer-held state such as
-// feature state does not survive. Map state such as camera, style, and sources
-// lives on the map and survives both resize and reattach.
+// The session keeps its renderer across a resize, so renderer-held state such
+// as feature state carries over. A scale factor change is the exception: a
+// renderer compiles its shaders for one pixel ratio, so that resize starts a new
+// one with renderer-held state empty. Map state such as camera, style, and
+// sources lives on the map and survives either way.
 func (session *RenderSessionHandle) Resize(extent RenderTargetExtent) error {
 	if err := extent.validate(); err != nil {
 		return err

--- a/bindings/go/render_set_target_darwin_test.go
+++ b/bindings/go/render_set_target_darwin_test.go
@@ -1,0 +1,75 @@
+//go:build darwin && cgo
+
+package maplibre
+
+import (
+	"errors"
+	"testing"
+)
+
+// A session-owned texture session is the one live render session this suite can
+// attach, so it covers the target kinds SetTarget rejects. Replacing a target
+// the host owns needs a host-allocated surface or texture, which this suite has
+// no way to create.
+func TestSetTargetRejectsOtherTargetKindsDarwin(t *testing.T) {
+	if !SupportedRenderBackends().Has(RenderBackendMetal) {
+		t.Skip("Metal texture sessions are not supported by this build")
+	}
+
+	lockOSThreadForTest(t)
+
+	device := defaultMetalDeviceForTest()
+	if device == 0 {
+		t.Skip("Metal system default device is unavailable")
+	}
+
+	runtime, err := NewRuntime()
+	if err != nil {
+		t.Fatalf("NewRuntime(): %v", err)
+	}
+	m, err := runtime.NewMapWithOptions(NewMapOptions(64, 64, 1))
+	if err != nil {
+		_ = runtime.Close()
+		t.Fatalf("NewMapWithOptions(): %v", err)
+	}
+	extent := RenderTargetExtent{Width: 64, Height: 64, ScaleFactor: 1}
+	session, err := m.AttachMetalOwnedTexture(MetalOwnedTextureDescriptor{
+		Extent:  extent,
+		Context: MetalContextDescriptor{Device: NativePointer(device)},
+	})
+	if err != nil {
+		_ = m.Close()
+		_ = runtime.Close()
+		t.Fatalf("AttachMetalOwnedTexture(): %v", err)
+	}
+	defer func() {
+		if err := session.Close(); err != nil {
+			t.Errorf("RenderSession Close(): %v", err)
+		}
+		if err := m.Close(); err != nil {
+			t.Errorf("Map Close(): %v", err)
+		}
+		if err := runtime.Close(); err != nil {
+			t.Errorf("Runtime Close(): %v", err)
+		}
+	}()
+
+	if err := session.SetMetalSurfaceTarget(MetalSurfaceDescriptor{
+		Extent:  extent,
+		Context: MetalContextDescriptor{Device: NativePointer(device)},
+	}); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("SetMetalSurfaceTarget() on a texture session error = %v, want ErrUnsupported", err)
+	}
+	if err := session.SetMetalBorrowedTextureTarget(MetalBorrowedTextureDescriptor{
+		Extent:         extent,
+		PhysicalWidth:  64,
+		PhysicalHeight: 64,
+	}); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("SetMetalBorrowedTextureTarget() on a session-owned texture session error = %v, want ErrUnsupported", err)
+	}
+
+	// Both rejections leave the session rendering into the target it has.
+	if _, err := session.RenderUpdate(); err != nil {
+		t.Fatalf("RenderUpdate() after rejected target replacement: %v", err)
+	}
+}

--- a/bindings/go/render_test.go
+++ b/bindings/go/render_test.go
@@ -239,6 +239,10 @@ func newActiveFrameTestSession(t *testing.T) *RenderSessionHandle {
 	return session
 }
 
+// activeFrameTestExtent is a valid extent, so the active-frame guard is what
+// rejects each operation rather than descriptor validation ahead of it.
+var activeFrameTestExtent = RenderTargetExtent{Width: 1, Height: 1, ScaleFactor: 1}
+
 func TestRenderSessionOperationsRejectActiveFrame(t *testing.T) {
 	session := newActiveFrameTestSession(t)
 
@@ -247,6 +251,40 @@ func TestRenderSessionOperationsRejectActiveFrame(t *testing.T) {
 		call func() error
 	}{
 		{name: "Resize", call: func() error { return session.Resize(RenderTargetExtent{Width: 1, Height: 1, ScaleFactor: 1}) }},
+		{name: "SetMetalSurfaceTarget", call: func() error {
+			return session.SetMetalSurfaceTarget(MetalSurfaceDescriptor{Extent: activeFrameTestExtent})
+		}},
+		{name: "SetVulkanSurfaceTarget", call: func() error {
+			return session.SetVulkanSurfaceTarget(VulkanSurfaceDescriptor{Extent: activeFrameTestExtent})
+		}},
+		{name: "SetOpenGLSurfaceTarget", call: func() error {
+			return session.SetOpenGLSurfaceTarget(OpenGLSurfaceDescriptor{
+				Extent:  activeFrameTestExtent,
+				Context: OpenGLContextDescriptor{EGL: &EGLContextDescriptor{}},
+			})
+		}},
+		{name: "SetMetalBorrowedTextureTarget", call: func() error {
+			return session.SetMetalBorrowedTextureTarget(MetalBorrowedTextureDescriptor{
+				Extent:         activeFrameTestExtent,
+				PhysicalWidth:  1,
+				PhysicalHeight: 1,
+			})
+		}},
+		{name: "SetVulkanBorrowedTextureTarget", call: func() error {
+			return session.SetVulkanBorrowedTextureTarget(VulkanBorrowedTextureDescriptor{
+				Extent:         activeFrameTestExtent,
+				PhysicalWidth:  1,
+				PhysicalHeight: 1,
+			})
+		}},
+		{name: "SetOpenGLBorrowedTextureTarget", call: func() error {
+			return session.SetOpenGLBorrowedTextureTarget(OpenGLBorrowedTextureDescriptor{
+				Extent:         activeFrameTestExtent,
+				PhysicalWidth:  1,
+				PhysicalHeight: 1,
+				Context:        OpenGLContextDescriptor{EGL: &EGLContextDescriptor{}},
+			})
+		}},
 		{name: "RenderUpdate", call: func() error {
 			_, err := session.RenderUpdate()
 			return err

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -55,6 +55,72 @@ private constructor(private val map: MapHandle, private val handleId: Long) : Au
     )
   }
 
+  public actual fun setMetalSurfaceTarget(descriptor: MetalSurfaceDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    Status.check(
+      MaplibreNativeC.mln_metal_surface_set_target(
+        requireLiveHandle(),
+        metalSurfaceDescriptor(descriptor),
+      )
+    )
+  }
+
+  public actual fun setVulkanSurfaceTarget(descriptor: VulkanSurfaceDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    Status.check(
+      MaplibreNativeC.mln_vulkan_surface_set_target(
+        requireLiveHandle(),
+        vulkanSurfaceDescriptor(descriptor),
+      )
+    )
+  }
+
+  public actual fun setOpenGLSurfaceTarget(descriptor: OpenGLSurfaceDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    Status.check(
+      MaplibreNativeC.mln_opengl_surface_set_target(
+        requireLiveHandle(),
+        openglSurfaceDescriptor(descriptor),
+      )
+    )
+  }
+
+  public actual fun setMetalBorrowedTextureTarget(descriptor: MetalBorrowedTextureDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    Status.check(
+      MaplibreNativeC.mln_metal_borrowed_texture_set_target(
+        requireLiveHandle(),
+        metalBorrowedTextureDescriptor(descriptor),
+      )
+    )
+  }
+
+  public actual fun setVulkanBorrowedTextureTarget(descriptor: VulkanBorrowedTextureDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    Status.check(
+      MaplibreNativeC.mln_vulkan_borrowed_texture_set_target(
+        requireLiveHandle(),
+        vulkanBorrowedTextureDescriptor(descriptor),
+      )
+    )
+  }
+
+  public actual fun setOpenGLBorrowedTextureTarget(descriptor: OpenGLBorrowedTextureDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    Status.check(
+      MaplibreNativeC.mln_opengl_borrowed_texture_set_target(
+        requireLiveHandle(),
+        openglBorrowedTextureDescriptor(descriptor),
+      )
+    )
+  }
+
   public actual fun renderUpdate(): Boolean {
     NativeAccess.ensureLoaded()
     activeFrame.ensureInactive("render")

--- a/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
+++ b/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
@@ -803,7 +803,20 @@ class RenderSessionHandleTest {
         false,
       )
     descriptor.usage = MTLTextureUsageRenderTarget or MTLTextureUsageShaderRead
-    return device.newTextureWithDescriptor(descriptor) ?: error("Metal texture creation failed")
+    val texture =
+      device.newTextureWithDescriptor(descriptor) ?: error("Metal texture creation failed")
+    // A new MTLTexture's contents are undefined, so clear it: a test that reads
+    // this back to prove a session rendered into it needs a known start value.
+    val blank = ByteArray(width * height * 4)
+    blank.usePinned { pinned ->
+      texture.replaceRegion(
+        MTLRegionMake2D(0u, 0u, width.toULong(), height.toULong()),
+        0u,
+        pinned.addressOf(0),
+        (width * 4).toULong(),
+      )
+    }
+    return texture
   }
 
   // Reads a borrowed texture back to the CPU. A texture created without an

--- a/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
+++ b/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
@@ -14,6 +14,7 @@ import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ObjCObject
 import kotlinx.cinterop.StableRef
+import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.asStableRef
 import kotlinx.cinterop.get
@@ -23,6 +24,7 @@ import kotlinx.cinterop.ptr
 import kotlinx.cinterop.rawValue
 import kotlinx.cinterop.staticCFunction
 import kotlinx.cinterop.toLong
+import kotlinx.cinterop.usePinned
 import org.maplibre.nativeffi.Maplibre
 import org.maplibre.nativeffi.camera.CameraOptions
 import org.maplibre.nativeffi.error.InvalidArgumentException
@@ -56,7 +58,9 @@ import platform.Metal.MTLCreateSystemDefaultDevice
 import platform.Metal.MTLDeviceProtocol
 import platform.Metal.MTLPixelFormatBGRA8Unorm
 import platform.Metal.MTLPixelFormatRGBA8Unorm
+import platform.Metal.MTLRegionMake2D
 import platform.Metal.MTLTextureDescriptor
+import platform.Metal.MTLTextureProtocol
 import platform.Metal.MTLTextureUsageRenderTarget
 import platform.Metal.MTLTextureUsageShaderRead
 import platform.QuartzCore.CAMetalLayer
@@ -499,11 +503,22 @@ class RenderSessionHandleTest {
                 physicalHeight = 8,
                 texture = NativePointer.ofAddress(replacementTexture.address()),
               )
+            // Freshly allocated, so anything non-zero later came from this
+            // session rendering into it after the handoff.
+            assertTrue(
+              readMetalTextureRgba(device, replacementTexture, 16, 8).all { it == 0.toByte() },
+              "a freshly allocated replacement should start blank",
+            )
             session.setMetalBorrowedTextureTarget(replacement)
             assertSame(borrowedMap, session.map())
             assertFalse(session.renderUpdate())
             runtime.pump(0)
             assertTrue(session.renderUpdate())
+            // The session paints the texture it was handed, not the one it had.
+            assertTrue(
+              readMetalTextureRgba(device, replacementTexture, 16, 8).any { it != 0.toByte() },
+              "the replacement texture should have been rendered into",
+            )
             assertEquals(replacementTexture.address(), replacement.texture.address)
             // The session never retained the outgoing texture, so the host
             // still owns the one it attached with.
@@ -789,6 +804,38 @@ class RenderSessionHandleTest {
       )
     descriptor.usage = MTLTextureUsageRenderTarget or MTLTextureUsageShaderRead
     return device.newTextureWithDescriptor(descriptor) ?: error("Metal texture creation failed")
+  }
+
+  // Reads a borrowed texture back to the CPU. A texture created without an
+  // explicit storage mode is managed on macOS, so its CPU copy stays stale
+  // until a blit synchronizes it.
+  private fun readMetalTextureRgba(
+    device: MTLDeviceProtocol,
+    texture: ObjCObject,
+    width: Int,
+    height: Int,
+  ): ByteArray {
+    val metalTexture = texture as MTLTextureProtocol
+    val queue = device.newCommandQueue() ?: error("MTLDevice.newCommandQueue returned nil")
+    val commandBuffer = queue.commandBuffer() ?: error("MTLCommandQueue.commandBuffer returned nil")
+    val encoder =
+      commandBuffer.blitCommandEncoder()
+        ?: error("MTLCommandBuffer.blitCommandEncoder returned nil")
+    encoder.synchronizeResource(metalTexture)
+    encoder.endEncoding()
+    commandBuffer.commit()
+    commandBuffer.waitUntilCompleted()
+
+    val pixels = ByteArray(width * height * 4)
+    pixels.usePinned { pinned ->
+      metalTexture.getBytes(
+        pinned.addressOf(0),
+        (width * 4).toULong(),
+        MTLRegionMake2D(0u, 0u, width.toULong(), height.toULong()),
+        0u,
+      )
+    }
+    return pixels
   }
 
   private fun createMetalLayer(device: MTLDeviceProtocol, width: Int, height: Int): CAMetalLayer {

--- a/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
+++ b/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
@@ -279,6 +279,16 @@ class RenderSessionHandleTest {
             assertFalse(frameHandle.isClosed)
             assertFailsWith<InvalidStateException> { session.renderUpdate() }
             assertFailsWith<InvalidStateException> { session.resize(16, 8, 2.0) }
+            assertFailsWith<InvalidStateException> {
+              session.setMetalBorrowedTextureTarget(
+                MetalBorrowedTextureDescriptor(
+                  extent = RenderTargetExtent(16, 8, 1.0),
+                  physicalWidth = 16,
+                  physicalHeight = 8,
+                  texture = NativePointer.ofAddress(frame.texture().address),
+                )
+              )
+            }
             assertFailsWith<InvalidStateException> { session.detach() }
             assertFailsWith<InvalidStateException> { session.reduceMemoryUse() }
             assertFailsWith<InvalidStateException> { session.clearData() }
@@ -438,6 +448,212 @@ class RenderSessionHandleTest {
     }
   }
 
+  // BND-175: replacing a host-owned target keeps the session and hands it the
+  // replacement's extent, which the map catches up to on its next pump.
+
+  @Test
+  fun metalSetTargetReplacesBorrowedTextureAndSurfaceTargets() {
+    if (!metalSupportedOrInapplicable()) return
+    val device =
+      MTLCreateSystemDefaultDevice() ?: error("MTLCreateSystemDefaultDevice returned nil")
+    Maplibre.setLogCallback(LogCallback { true })
+    Maplibre.setAsyncLogSeverities(emptySet())
+    try {
+      val runtime = RuntimeHandle.create(org.maplibre.nativeffi.runtime.RuntimeOptions())
+      try {
+        val borrowedTexture = createMetalTexture(device, 32, 16)
+        val borrowedMap =
+          MapHandle.create(
+            runtime,
+            MapOptions().apply {
+              width = 64
+              height = 64
+            },
+          )
+        try {
+          val borrowedTextureAddress = borrowedTexture.address()
+          val session =
+            borrowedMap.attachMetalBorrowedTexture(
+              MetalBorrowedTextureDescriptor(
+                extent = RenderTargetExtent(32, 16, 1.0),
+                physicalWidth = 32,
+                physicalHeight = 16,
+                texture = NativePointer.ofAddress(borrowedTextureAddress),
+              )
+            )
+          try {
+            borrowedMap.setStyleJson(QUERY_STYLE_JSON)
+            assertTrue(
+              waitForMapEvent(runtime, borrowedMap, RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE)
+            )
+            assertTrue(session.renderUpdate())
+
+            // A caller-owned texture is sized by its owner, so the host
+            // reallocates and hands the replacement over instead of resizing.
+            assertFailsWith<UnsupportedFeatureException> { session.resize(16, 8, 1.0) }
+            val replacementTexture = createMetalTexture(device, 16, 8)
+            val replacement =
+              MetalBorrowedTextureDescriptor(
+                extent = RenderTargetExtent(16, 8, 1.0),
+                physicalWidth = 16,
+                physicalHeight = 8,
+                texture = NativePointer.ofAddress(replacementTexture.address()),
+              )
+            session.setMetalBorrowedTextureTarget(replacement)
+            assertSame(borrowedMap, session.map())
+            assertFalse(session.renderUpdate())
+            runtime.pump(0)
+            assertTrue(session.renderUpdate())
+            assertEquals(replacementTexture.address(), replacement.texture.address)
+            // The session never retained the outgoing texture, so the host
+            // still owns the one it attached with.
+            assertEquals(borrowedTextureAddress, borrowedTexture.address())
+          } finally {
+            session.close()
+          }
+        } finally {
+          borrowedMap.close()
+        }
+
+        val layer = createMetalLayer(device, 32, 16)
+        val replacementLayer = createMetalLayer(device, 16, 8)
+        val surfaceMap =
+          MapHandle.create(
+            runtime,
+            MapOptions().apply {
+              width = 64
+              height = 64
+            },
+          )
+        try {
+          val session =
+            surfaceMap.attachMetalSurface(
+              MetalSurfaceDescriptor(
+                extent = RenderTargetExtent(32, 16, 1.0),
+                context = MetalContextDescriptor(NativePointer.ofAddress(device.address())),
+                layer = NativePointer.ofAddress(layer.address()),
+              )
+            )
+          try {
+            surfaceMap.setStyleJson(QUERY_STYLE_JSON)
+            assertTrue(
+              waitForMapEvent(runtime, surfaceMap, RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE)
+            )
+            assertTrue(session.renderUpdate())
+
+            // A recreated host surface replaces the presentation target while
+            // the session and its renderer go on living.
+            session.setMetalSurfaceTarget(
+              MetalSurfaceDescriptor(
+                extent = RenderTargetExtent(16, 8, 1.0),
+                context = MetalContextDescriptor(NativePointer.ofAddress(device.address())),
+                layer = NativePointer.ofAddress(replacementLayer.address()),
+              )
+            )
+            assertSame(surfaceMap, session.map())
+            assertFalse(session.renderUpdate())
+            runtime.pump(0)
+            assertTrue(session.renderUpdate())
+          } finally {
+            session.close()
+          }
+        } finally {
+          surfaceMap.close()
+        }
+      } finally {
+        runtime.close()
+      }
+    } finally {
+      Maplibre.clearLogCallback()
+      Maplibre.restoreDefaultAsyncLogSeverities()
+    }
+  }
+
+  // BND-176: set_target reports unsupported for a target kind the session does
+  // not have, covering a session-owned texture and a swapped surface/texture
+  // pairing.
+
+  @Test
+  fun metalSetTargetReportsUnsupportedForOtherTargetKinds() {
+    if (!metalSupportedOrInapplicable()) return
+    val device =
+      MTLCreateSystemDefaultDevice() ?: error("MTLCreateSystemDefaultDevice returned nil")
+    val metalContext = MetalContextDescriptor(NativePointer.ofAddress(device.address()))
+    val runtime = RuntimeHandle.create(org.maplibre.nativeffi.runtime.RuntimeOptions())
+    try {
+      val texture = createMetalTexture(device, 32, 16)
+      val textureTarget =
+        MetalBorrowedTextureDescriptor(
+          extent = RenderTargetExtent(32, 16, 1.0),
+          physicalWidth = 32,
+          physicalHeight = 16,
+          texture = NativePointer.ofAddress(texture.address()),
+        )
+      val layer = createMetalLayer(device, 32, 16)
+      val surfaceTarget =
+        MetalSurfaceDescriptor(
+          extent = RenderTargetExtent(32, 16, 1.0),
+          context = metalContext,
+          layer = NativePointer.ofAddress(layer.address()),
+        )
+
+      val ownedMap = createStaticMap(runtime)
+      try {
+        val session =
+          ownedMap.attachMetalOwnedTexture(
+            MetalOwnedTextureDescriptor(
+              extent = RenderTargetExtent(32, 16, 1.0),
+              context = metalContext,
+            )
+          )
+        try {
+          val error =
+            assertFailsWith<UnsupportedFeatureException> {
+              session.setMetalBorrowedTextureTarget(textureTarget)
+            }
+          assertEquals(MaplibreStatus.UNSUPPORTED, error.status)
+          assertFailsWith<UnsupportedFeatureException> {
+            session.setMetalSurfaceTarget(surfaceTarget)
+          }
+        } finally {
+          session.close()
+        }
+      } finally {
+        ownedMap.close()
+      }
+
+      val borrowedMap = createStaticMap(runtime)
+      try {
+        val session = borrowedMap.attachMetalBorrowedTexture(textureTarget)
+        try {
+          assertFailsWith<UnsupportedFeatureException> {
+            session.setMetalSurfaceTarget(surfaceTarget)
+          }
+        } finally {
+          session.close()
+        }
+      } finally {
+        borrowedMap.close()
+      }
+
+      val surfaceMap = createStaticMap(runtime)
+      try {
+        val session = surfaceMap.attachMetalSurface(surfaceTarget)
+        try {
+          assertFailsWith<UnsupportedFeatureException> {
+            session.setMetalBorrowedTextureTarget(textureTarget)
+          }
+        } finally {
+          session.close()
+        }
+      } finally {
+        surfaceMap.close()
+      }
+    } finally {
+      runtime.close()
+    }
+  }
+
   // BND-107: an unsigned cluster_id survives the query round trip, and an
   // unsigned leaves limit bounds the returned features.
   @Test
@@ -552,6 +768,16 @@ class RenderSessionHandleTest {
   private fun metalSupportedOrInapplicable(): Boolean {
     return RenderBackend.METAL in Maplibre.supportedRenderBackends()
   }
+
+  private fun createStaticMap(runtime: RuntimeHandle): MapHandle =
+    MapHandle.create(
+      runtime,
+      MapOptions().apply {
+        width = 64
+        height = 64
+        mapMode = MapMode.STATIC
+      },
+    )
 
   private fun createMetalTexture(device: MTLDeviceProtocol, width: Int, height: Int): ObjCObject {
     val descriptor =

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -41,8 +41,8 @@ public expect class RenderSessionHandle : AutoCloseable {
    * state.
    *
    * [descriptor] names the graphics context this session attached with, and its extent applies as
-   * [resize] applies one, including a scale factor change starting a new renderer. A layer on a
-   * `context.device` that is neither null nor this session's device throws
+   * [resize] applies one, including a scale factor change starting a new renderer. A descriptor
+   * whose `context.device` is neither null nor this session's device throws
    * `InvalidArgumentException` and leaves this session rendering into the surface it has. The
    * session assigns the layer its own device and pixel format, so the layer itself carries nothing
    * that has to match.
@@ -78,7 +78,8 @@ public expect class RenderSessionHandle : AutoCloseable {
    * A caller-owned texture is sized by its owner, so a host that follows a resize reallocates
    * rather than resizing and [resize] throws `UnsupportedFeatureException`. Handing the replacement
    * over here keeps this session's renderer instead, and with it the tile pyramid, glyph and image
-   * atlases, symbol placement, and feature state.
+   * atlases, symbol placement, and feature state. A scale factor change is the exception, starting
+   * a new renderer for the new pixel ratio just as [resize] does.
    *
    * The replacement belongs to the device this session attached with and carries the pixel format
    * it attached with; another device throws `InvalidArgumentException` and another pixel format

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -24,9 +24,10 @@ public expect class RenderSessionHandle : AutoCloseable {
    * attach a new session. A map holds at most one attached session, so close before attaching the
    * replacement.
    *
-   * Resizing discards the session renderer, so renderer-held state such as feature state does not
-   * survive. Map state such as camera, style, and sources lives on the map and survives both resize
-   * and reattach.
+   * The session keeps its renderer across a resize, so renderer-held state such as feature state
+   * carries over. A scale factor change is the exception: a renderer compiles its shaders for one
+   * pixel ratio, so that resize starts a new one with renderer-held state empty. Map state such as
+   * camera, style, and sources lives on the map and survives either way.
    */
   public fun resize(width: Int, height: Int, scaleFactor: Double)
 

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -20,9 +20,9 @@ public expect class RenderSessionHandle : AutoCloseable {
    * Resizes this attached render session.
    *
    * Surface and owned-texture sessions resize in place. Borrowed texture targets are sized by their
-   * owner and throw `UnsupportedFeatureException`: [close] this session, recreate the texture, and
-   * attach a new session. A map holds at most one attached session, so close before attaching the
-   * replacement.
+   * owner and throw `UnsupportedFeatureException`: allocate a texture at the new size and hand it
+   * over with the backend's set-target method, such as [setMetalBorrowedTextureTarget], which keeps
+   * this session.
    *
    * The session keeps its renderer across a resize, so renderer-held state such as feature state
    * carries over. A scale factor change is the exception: a renderer compiles its shaders for one
@@ -30,6 +30,81 @@ public expect class RenderSessionHandle : AutoCloseable {
    * camera, style, and sources lives on the map and survives either way.
    */
   public fun resize(width: Int, height: Int, scaleFactor: Double)
+
+  /**
+   * Presents this attached surface session through a new surface.
+   *
+   * A host surface can be destroyed and recreated while the map goes on living, which is what
+   * Android rotation, a Flutter `SurfaceProducer` lifecycle change, and a window resize that
+   * reallocates all look like from here. Replacing the surface in place keeps this session's
+   * renderer, and with it the tile pyramid, glyph and image atlases, symbol placement, and feature
+   * state.
+   *
+   * [descriptor] names the graphics context this session attached with, and its extent applies as
+   * [resize] applies one, including a scale factor change starting a new renderer. One naming
+   * another context throws `InvalidArgumentException`, and one this session's compiled state cannot
+   * serve throws `UnsupportedFeatureException`; both leave this session rendering into the surface
+   * it has, so [close] it and attach again to take that target.
+   */
+  public fun setMetalSurfaceTarget(descriptor: MetalSurfaceDescriptor)
+
+  /**
+   * Presents this attached surface session through a new surface.
+   *
+   * See [setMetalSurfaceTarget] for what replacing a surface preserves. The outgoing `VkSurfaceKHR`
+   * must still be valid: this session holds a swapchain built from it, and Vulkan destroys every
+   * swapchain before its surface. A host that has to release its surface first closes this session
+   * and attaches again instead.
+   *
+   * The replacement reports the color format and surface-transform support this session compiled a
+   * render pass and shaders for; one that does not throws `UnsupportedFeatureException`.
+   */
+  public fun setVulkanSurfaceTarget(descriptor: VulkanSurfaceDescriptor)
+
+  /**
+   * Presents this attached surface session through a new surface.
+   *
+   * See [setMetalSurfaceTarget] for what replacing a surface preserves. The new surface is made
+   * current on the next render, so a host may hand over a replacement for one it has already
+   * destroyed. Nothing is made current here, so a surface this call accepts can still prove
+   * unusable; the next [renderUpdate] reports that rather than this call.
+   */
+  public fun setOpenGLSurfaceTarget(descriptor: OpenGLSurfaceDescriptor)
+
+  /**
+   * Renders this attached texture session into a new caller-owned texture.
+   *
+   * A caller-owned texture is sized by its owner, so a host that follows a resize reallocates
+   * rather than resizing and [resize] throws `UnsupportedFeatureException`. Handing the replacement
+   * over here keeps this session's renderer instead, and with it the tile pyramid, glyph and image
+   * atlases, symbol placement, and feature state.
+   *
+   * The replacement belongs to the device this session attached with and carries the pixel format
+   * it attached with; another device throws `InvalidArgumentException` and another pixel format
+   * throws `UnsupportedFeatureException`, both leaving this session rendering into the texture it
+   * has. The caller owns the replacement and keeps it valid until the next replacement, [detach],
+   * or [close]. This session never retained the outgoing texture and never releases it, so the
+   * caller is free to release that one once this call returns.
+   */
+  public fun setMetalBorrowedTextureTarget(descriptor: MetalBorrowedTextureDescriptor)
+
+  /**
+   * Renders this attached texture session into a new caller-owned image.
+   *
+   * See [setMetalBorrowedTextureTarget] for what replacing a target preserves. The replacement
+   * carries the format and both layouts this session attached with, since its render pass was built
+   * around them.
+   */
+  public fun setVulkanBorrowedTextureTarget(descriptor: VulkanBorrowedTextureDescriptor)
+
+  /**
+   * Renders this attached texture session into a new caller-owned texture.
+   *
+   * See [setMetalBorrowedTextureTarget] for what replacing a target preserves. The replacement
+   * belongs to the context this session attached with, or one in its share group, and that context
+   * must be current on this thread.
+   */
+  public fun setOpenGLBorrowedTextureTarget(descriptor: OpenGLBorrowedTextureDescriptor)
 
   /**
    * Renders the latest available map render update.

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -41,10 +41,10 @@ public expect class RenderSessionHandle : AutoCloseable {
    * state.
    *
    * [descriptor] names the graphics context this session attached with, and its extent applies as
-   * [resize] applies one, including a scale factor change starting a new renderer. One naming
-   * another context throws `InvalidArgumentException`, and one this session's compiled state cannot
-   * serve throws `UnsupportedFeatureException`; both leave this session rendering into the surface
-   * it has, so [close] it and attach again to take that target.
+   * [resize] applies one, including a scale factor change starting a new renderer. A layer on
+   * another device throws `InvalidArgumentException` and leaves this session rendering into the
+   * surface it has, so [close] it and attach again to take that one. The session sets the layer's
+   * pixel format itself, so there is nothing else here for a replacement to mismatch.
    */
   public fun setMetalSurfaceTarget(descriptor: MetalSurfaceDescriptor)
 

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -41,10 +41,11 @@ public expect class RenderSessionHandle : AutoCloseable {
    * state.
    *
    * [descriptor] names the graphics context this session attached with, and its extent applies as
-   * [resize] applies one, including a scale factor change starting a new renderer. A layer on
-   * another device throws `InvalidArgumentException` and leaves this session rendering into the
-   * surface it has, so [close] it and attach again to take that one. The session sets the layer's
-   * pixel format itself, so there is nothing else here for a replacement to mismatch.
+   * [resize] applies one, including a scale factor change starting a new renderer. A layer on a
+   * `context.device` that is neither null nor this session's device throws
+   * `InvalidArgumentException` and leaves this session rendering into the surface it has. The
+   * session assigns the layer its own device and pixel format, so the layer itself carries nothing
+   * that has to match.
    */
   public fun setMetalSurfaceTarget(descriptor: MetalSurfaceDescriptor)
 

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -85,8 +85,8 @@ public expect class RenderSessionHandle : AutoCloseable {
    * it attached with; another device throws `InvalidArgumentException` and another pixel format
    * throws `UnsupportedFeatureException`, both leaving this session rendering into the texture it
    * has. The caller owns the replacement and keeps it valid until the next replacement, [detach],
-   * or [close]. This session never retained the outgoing texture and never releases it, so the
-   * caller is free to release that one once this call returns.
+   * or [close]. This session never retained the outgoing texture, never releases it, and never
+   * reads it here, so a caller that already released it hands over the replacement all the same.
    */
   public fun setMetalBorrowedTextureTarget(descriptor: MetalBorrowedTextureDescriptor)
 

--- a/bindings/kotlin/src/jextract/maplibre-native-c.includes
+++ b/bindings/kotlin/src/jextract/maplibre-native-c.includes
@@ -628,10 +628,13 @@
 # include/maplibre_native_c/surface.h
 --include-function mln_metal_surface_attach
 --include-function mln_metal_surface_descriptor_default
+--include-function mln_metal_surface_set_target
 --include-function mln_opengl_surface_attach
 --include-function mln_opengl_surface_descriptor_default
+--include-function mln_opengl_surface_set_target
 --include-function mln_vulkan_surface_attach
 --include-function mln_vulkan_surface_descriptor_default
+--include-function mln_vulkan_surface_set_target
 --include-struct mln_metal_surface_descriptor
 --include-struct mln_opengl_surface_descriptor
 --include-struct mln_vulkan_surface_descriptor
@@ -639,12 +642,14 @@
 # include/maplibre_native_c/texture.h
 --include-function mln_metal_borrowed_texture_attach
 --include-function mln_metal_borrowed_texture_descriptor_default
+--include-function mln_metal_borrowed_texture_set_target
 --include-function mln_metal_owned_texture_acquire_frame
 --include-function mln_metal_owned_texture_attach
 --include-function mln_metal_owned_texture_descriptor_default
 --include-function mln_metal_owned_texture_release_frame
 --include-function mln_opengl_borrowed_texture_attach
 --include-function mln_opengl_borrowed_texture_descriptor_default
+--include-function mln_opengl_borrowed_texture_set_target
 --include-function mln_opengl_owned_texture_acquire_frame
 --include-function mln_opengl_owned_texture_attach
 --include-function mln_opengl_owned_texture_descriptor_default
@@ -653,6 +658,7 @@
 --include-function mln_texture_read_premultiplied_rgba8
 --include-function mln_vulkan_borrowed_texture_attach
 --include-function mln_vulkan_borrowed_texture_descriptor_default
+--include-function mln_vulkan_borrowed_texture_set_target
 --include-function mln_vulkan_owned_texture_acquire_frame
 --include-function mln_vulkan_owned_texture_attach
 --include-function mln_vulkan_owned_texture_descriptor_default

--- a/bindings/kotlin/src/jvmMain/generated/org/maplibre/nativeffi/internal/c/MapLibreNativeC.java
+++ b/bindings/kotlin/src/jvmMain/generated/org/maplibre/nativeffi/internal/c/MapLibreNativeC.java
@@ -16555,6 +16555,189 @@ public class MapLibreNativeC extends MapLibreNativeC$shared {
         }
     }
 
+    private static class mln_metal_surface_set_target {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            MapLibreNativeC.C_INT,
+            MapLibreNativeC.C_LONG,
+            MapLibreNativeC.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("mln_metal_surface_set_target");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * mln_status mln_metal_surface_set_target(mln_render_session session, const mln_metal_surface_descriptor *descriptor)
+     * }
+     */
+    public static FunctionDescriptor mln_metal_surface_set_target$descriptor() {
+        return mln_metal_surface_set_target.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * mln_status mln_metal_surface_set_target(mln_render_session session, const mln_metal_surface_descriptor *descriptor)
+     * }
+     */
+    public static MethodHandle mln_metal_surface_set_target$handle() {
+        return mln_metal_surface_set_target.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * mln_status mln_metal_surface_set_target(mln_render_session session, const mln_metal_surface_descriptor *descriptor)
+     * }
+     */
+    public static MemorySegment mln_metal_surface_set_target$address() {
+        return mln_metal_surface_set_target.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * mln_status mln_metal_surface_set_target(mln_render_session session, const mln_metal_surface_descriptor *descriptor)
+     * }
+     */
+    public static int mln_metal_surface_set_target(long session, MemorySegment descriptor) {
+        var mh$ = mln_metal_surface_set_target.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("mln_metal_surface_set_target", session, descriptor);
+            }
+            return (int)mh$.invokeExact(session, descriptor);
+        } catch (Error | RuntimeException ex) {
+           throw ex;
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class mln_vulkan_surface_set_target {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            MapLibreNativeC.C_INT,
+            MapLibreNativeC.C_LONG,
+            MapLibreNativeC.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("mln_vulkan_surface_set_target");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * mln_status mln_vulkan_surface_set_target(mln_render_session session, const mln_vulkan_surface_descriptor *descriptor)
+     * }
+     */
+    public static FunctionDescriptor mln_vulkan_surface_set_target$descriptor() {
+        return mln_vulkan_surface_set_target.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * mln_status mln_vulkan_surface_set_target(mln_render_session session, const mln_vulkan_surface_descriptor *descriptor)
+     * }
+     */
+    public static MethodHandle mln_vulkan_surface_set_target$handle() {
+        return mln_vulkan_surface_set_target.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * mln_status mln_vulkan_surface_set_target(mln_render_session session, const mln_vulkan_surface_descriptor *descriptor)
+     * }
+     */
+    public static MemorySegment mln_vulkan_surface_set_target$address() {
+        return mln_vulkan_surface_set_target.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * mln_status mln_vulkan_surface_set_target(mln_render_session session, const mln_vulkan_surface_descriptor *descriptor)
+     * }
+     */
+    public static int mln_vulkan_surface_set_target(long session, MemorySegment descriptor) {
+        var mh$ = mln_vulkan_surface_set_target.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("mln_vulkan_surface_set_target", session, descriptor);
+            }
+            return (int)mh$.invokeExact(session, descriptor);
+        } catch (Error | RuntimeException ex) {
+           throw ex;
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class mln_opengl_surface_set_target {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            MapLibreNativeC.C_INT,
+            MapLibreNativeC.C_LONG,
+            MapLibreNativeC.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("mln_opengl_surface_set_target");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * mln_status mln_opengl_surface_set_target(mln_render_session session, const mln_opengl_surface_descriptor *descriptor)
+     * }
+     */
+    public static FunctionDescriptor mln_opengl_surface_set_target$descriptor() {
+        return mln_opengl_surface_set_target.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * mln_status mln_opengl_surface_set_target(mln_render_session session, const mln_opengl_surface_descriptor *descriptor)
+     * }
+     */
+    public static MethodHandle mln_opengl_surface_set_target$handle() {
+        return mln_opengl_surface_set_target.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * mln_status mln_opengl_surface_set_target(mln_render_session session, const mln_opengl_surface_descriptor *descriptor)
+     * }
+     */
+    public static MemorySegment mln_opengl_surface_set_target$address() {
+        return mln_opengl_surface_set_target.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * mln_status mln_opengl_surface_set_target(mln_render_session session, const mln_opengl_surface_descriptor *descriptor)
+     * }
+     */
+    public static int mln_opengl_surface_set_target(long session, MemorySegment descriptor) {
+        var mh$ = mln_opengl_surface_set_target.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("mln_opengl_surface_set_target", session, descriptor);
+            }
+            return (int)mh$.invokeExact(session, descriptor);
+        } catch (Error | RuntimeException ex) {
+           throw ex;
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
     private static class mln_metal_owned_texture_descriptor_default {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             mln_metal_owned_texture_descriptor.layout()    );
@@ -17326,6 +17509,189 @@ public class MapLibreNativeC extends MapLibreNativeC$shared {
                 traceDowncall("mln_opengl_borrowed_texture_attach", map, descriptor, out_session);
             }
             return (int)mh$.invokeExact(map, descriptor, out_session);
+        } catch (Error | RuntimeException ex) {
+           throw ex;
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class mln_metal_borrowed_texture_set_target {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            MapLibreNativeC.C_INT,
+            MapLibreNativeC.C_LONG,
+            MapLibreNativeC.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("mln_metal_borrowed_texture_set_target");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * mln_status mln_metal_borrowed_texture_set_target(mln_render_session session, const mln_metal_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static FunctionDescriptor mln_metal_borrowed_texture_set_target$descriptor() {
+        return mln_metal_borrowed_texture_set_target.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * mln_status mln_metal_borrowed_texture_set_target(mln_render_session session, const mln_metal_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static MethodHandle mln_metal_borrowed_texture_set_target$handle() {
+        return mln_metal_borrowed_texture_set_target.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * mln_status mln_metal_borrowed_texture_set_target(mln_render_session session, const mln_metal_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static MemorySegment mln_metal_borrowed_texture_set_target$address() {
+        return mln_metal_borrowed_texture_set_target.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * mln_status mln_metal_borrowed_texture_set_target(mln_render_session session, const mln_metal_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static int mln_metal_borrowed_texture_set_target(long session, MemorySegment descriptor) {
+        var mh$ = mln_metal_borrowed_texture_set_target.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("mln_metal_borrowed_texture_set_target", session, descriptor);
+            }
+            return (int)mh$.invokeExact(session, descriptor);
+        } catch (Error | RuntimeException ex) {
+           throw ex;
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class mln_vulkan_borrowed_texture_set_target {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            MapLibreNativeC.C_INT,
+            MapLibreNativeC.C_LONG,
+            MapLibreNativeC.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("mln_vulkan_borrowed_texture_set_target");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * mln_status mln_vulkan_borrowed_texture_set_target(mln_render_session session, const mln_vulkan_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static FunctionDescriptor mln_vulkan_borrowed_texture_set_target$descriptor() {
+        return mln_vulkan_borrowed_texture_set_target.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * mln_status mln_vulkan_borrowed_texture_set_target(mln_render_session session, const mln_vulkan_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static MethodHandle mln_vulkan_borrowed_texture_set_target$handle() {
+        return mln_vulkan_borrowed_texture_set_target.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * mln_status mln_vulkan_borrowed_texture_set_target(mln_render_session session, const mln_vulkan_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static MemorySegment mln_vulkan_borrowed_texture_set_target$address() {
+        return mln_vulkan_borrowed_texture_set_target.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * mln_status mln_vulkan_borrowed_texture_set_target(mln_render_session session, const mln_vulkan_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static int mln_vulkan_borrowed_texture_set_target(long session, MemorySegment descriptor) {
+        var mh$ = mln_vulkan_borrowed_texture_set_target.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("mln_vulkan_borrowed_texture_set_target", session, descriptor);
+            }
+            return (int)mh$.invokeExact(session, descriptor);
+        } catch (Error | RuntimeException ex) {
+           throw ex;
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class mln_opengl_borrowed_texture_set_target {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            MapLibreNativeC.C_INT,
+            MapLibreNativeC.C_LONG,
+            MapLibreNativeC.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("mln_opengl_borrowed_texture_set_target");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * mln_status mln_opengl_borrowed_texture_set_target(mln_render_session session, const mln_opengl_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static FunctionDescriptor mln_opengl_borrowed_texture_set_target$descriptor() {
+        return mln_opengl_borrowed_texture_set_target.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * mln_status mln_opengl_borrowed_texture_set_target(mln_render_session session, const mln_opengl_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static MethodHandle mln_opengl_borrowed_texture_set_target$handle() {
+        return mln_opengl_borrowed_texture_set_target.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * mln_status mln_opengl_borrowed_texture_set_target(mln_render_session session, const mln_opengl_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static MemorySegment mln_opengl_borrowed_texture_set_target$address() {
+        return mln_opengl_borrowed_texture_set_target.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * mln_status mln_opengl_borrowed_texture_set_target(mln_render_session session, const mln_opengl_borrowed_texture_descriptor *descriptor)
+     * }
+     */
+    public static int mln_opengl_borrowed_texture_set_target(long session, MemorySegment descriptor) {
+        var mh$ = mln_opengl_borrowed_texture_set_target.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("mln_opengl_borrowed_texture_set_target", session, descriptor);
+            }
+            return (int)mh$.invokeExact(session, descriptor);
         } catch (Error | RuntimeException ex) {
            throw ex;
         } catch (Throwable ex$) {

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/loader/NativeAccess.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/loader/NativeAccess.kt
@@ -2014,6 +2014,72 @@ internal object NativeAccess {
     )
   }
 
+  internal fun setMetalSurfaceTarget(
+    session: NativeRenderSession,
+    descriptor: MetalSurfaceDescriptor,
+  ) {
+    setRenderSessionTarget(
+      session,
+      "mln_metal_surface_set_target",
+      metalSurfaceDescriptor(descriptor),
+    )
+  }
+
+  internal fun setVulkanSurfaceTarget(
+    session: NativeRenderSession,
+    descriptor: VulkanSurfaceDescriptor,
+  ) {
+    setRenderSessionTarget(
+      session,
+      "mln_vulkan_surface_set_target",
+      vulkanSurfaceDescriptor(descriptor),
+    )
+  }
+
+  internal fun setOpenGLSurfaceTarget(
+    session: NativeRenderSession,
+    descriptor: OpenGLSurfaceDescriptor,
+  ) {
+    setRenderSessionTarget(
+      session,
+      "mln_opengl_surface_set_target",
+      openglSurfaceDescriptor(descriptor),
+    )
+  }
+
+  internal fun setMetalBorrowedTextureTarget(
+    session: NativeRenderSession,
+    descriptor: MetalBorrowedTextureDescriptor,
+  ) {
+    setRenderSessionTarget(
+      session,
+      "mln_metal_borrowed_texture_set_target",
+      metalBorrowedTextureDescriptor(descriptor),
+    )
+  }
+
+  internal fun setVulkanBorrowedTextureTarget(
+    session: NativeRenderSession,
+    descriptor: VulkanBorrowedTextureDescriptor,
+  ) {
+    setRenderSessionTarget(
+      session,
+      "mln_vulkan_borrowed_texture_set_target",
+      vulkanBorrowedTextureDescriptor(descriptor),
+    )
+  }
+
+  internal fun setOpenGLBorrowedTextureTarget(
+    session: NativeRenderSession,
+    descriptor: OpenGLBorrowedTextureDescriptor,
+  ) {
+    setRenderSessionTarget(
+      session,
+      "mln_opengl_borrowed_texture_set_target",
+      openglBorrowedTextureDescriptor(descriptor),
+    )
+  }
+
   internal fun renderUpdate(session: NativeRenderSession): Boolean =
     Arena.ofConfined().use { arena ->
       val outRendered = arena.allocate(ValueLayout.JAVA_BOOLEAN)
@@ -2472,6 +2538,21 @@ internal object NativeAccess {
         require(!session.isNull) { "render session attach returned the null handle" }
       }
     }
+
+  // The C API borrows the replacement descriptor for the call alone, so the
+  // confined arena that materialized it closes once the call returns.
+  private fun setRenderSessionTarget(
+    session: NativeRenderSession,
+    functionName: String,
+    descriptor: (Arena) -> MemorySegment,
+  ) {
+    Arena.ofConfined().use { arena ->
+      Status.check(
+        renderSessionAddressStatusFunction(functionName).invokeNative(session, descriptor(arena))
+          as Int
+      )
+    }
+  }
 
   private fun metalOwnedTextureDescriptor(
     descriptor: MetalOwnedTextureDescriptor

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -42,6 +42,42 @@ internal constructor(private val map: MapHandle, private val handle: NativeRende
     NativeAccess.resizeRenderSession(requireLiveHandle(), width, height, scaleFactor)
   }
 
+  public actual fun setMetalSurfaceTarget(descriptor: MetalSurfaceDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    NativeAccess.setMetalSurfaceTarget(requireLiveHandle(), descriptor)
+  }
+
+  public actual fun setVulkanSurfaceTarget(descriptor: VulkanSurfaceDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    NativeAccess.setVulkanSurfaceTarget(requireLiveHandle(), descriptor)
+  }
+
+  public actual fun setOpenGLSurfaceTarget(descriptor: OpenGLSurfaceDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    NativeAccess.setOpenGLSurfaceTarget(requireLiveHandle(), descriptor)
+  }
+
+  public actual fun setMetalBorrowedTextureTarget(descriptor: MetalBorrowedTextureDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    NativeAccess.setMetalBorrowedTextureTarget(requireLiveHandle(), descriptor)
+  }
+
+  public actual fun setVulkanBorrowedTextureTarget(descriptor: VulkanBorrowedTextureDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    NativeAccess.setVulkanBorrowedTextureTarget(requireLiveHandle(), descriptor)
+  }
+
+  public actual fun setOpenGLBorrowedTextureTarget(descriptor: OpenGLBorrowedTextureDescriptor) {
+    NativeAccess.ensureLoaded()
+    activeFrame.ensureInactive("set target")
+    NativeAccess.setOpenGLBorrowedTextureTarget(requireLiveHandle(), descriptor)
+  }
+
   public actual fun renderUpdate(): Boolean {
     NativeAccess.ensureLoaded()
     activeFrame.ensureInactive("render")

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -17,17 +17,21 @@ import kotlinx.cinterop.toLong
 import kotlinx.cinterop.value
 import org.maplibre.nativeffi.geo.Feature
 import org.maplibre.nativeffi.internal.c.mln_metal_borrowed_texture_attach
+import org.maplibre.nativeffi.internal.c.mln_metal_borrowed_texture_set_target
 import org.maplibre.nativeffi.internal.c.mln_metal_owned_texture_acquire_frame
 import org.maplibre.nativeffi.internal.c.mln_metal_owned_texture_attach
 import org.maplibre.nativeffi.internal.c.mln_metal_owned_texture_frame
 import org.maplibre.nativeffi.internal.c.mln_metal_owned_texture_release_frame
 import org.maplibre.nativeffi.internal.c.mln_metal_surface_attach
+import org.maplibre.nativeffi.internal.c.mln_metal_surface_set_target
 import org.maplibre.nativeffi.internal.c.mln_opengl_borrowed_texture_attach
+import org.maplibre.nativeffi.internal.c.mln_opengl_borrowed_texture_set_target
 import org.maplibre.nativeffi.internal.c.mln_opengl_owned_texture_acquire_frame
 import org.maplibre.nativeffi.internal.c.mln_opengl_owned_texture_attach
 import org.maplibre.nativeffi.internal.c.mln_opengl_owned_texture_frame
 import org.maplibre.nativeffi.internal.c.mln_opengl_owned_texture_release_frame
 import org.maplibre.nativeffi.internal.c.mln_opengl_surface_attach
+import org.maplibre.nativeffi.internal.c.mln_opengl_surface_set_target
 import org.maplibre.nativeffi.internal.c.mln_render_session_clear_data
 import org.maplibre.nativeffi.internal.c.mln_render_session_destroy
 import org.maplibre.nativeffi.internal.c.mln_render_session_detach
@@ -44,11 +48,13 @@ import org.maplibre.nativeffi.internal.c.mln_render_session_set_feature_state
 import org.maplibre.nativeffi.internal.c.mln_texture_image_info_default
 import org.maplibre.nativeffi.internal.c.mln_texture_read_premultiplied_rgba8
 import org.maplibre.nativeffi.internal.c.mln_vulkan_borrowed_texture_attach
+import org.maplibre.nativeffi.internal.c.mln_vulkan_borrowed_texture_set_target
 import org.maplibre.nativeffi.internal.c.mln_vulkan_owned_texture_acquire_frame
 import org.maplibre.nativeffi.internal.c.mln_vulkan_owned_texture_attach
 import org.maplibre.nativeffi.internal.c.mln_vulkan_owned_texture_frame
 import org.maplibre.nativeffi.internal.c.mln_vulkan_owned_texture_release_frame
 import org.maplibre.nativeffi.internal.c.mln_vulkan_surface_attach
+import org.maplibre.nativeffi.internal.c.mln_vulkan_surface_set_target
 import org.maplibre.nativeffi.internal.lifecycle.HandleState
 import org.maplibre.nativeffi.internal.lifecycle.NativeRenderSession
 import org.maplibre.nativeffi.internal.lifecycle.asHandle
@@ -91,6 +97,78 @@ private constructor(private val map: MapHandle, handle: NativeRenderSession) : A
         scaleFactor,
       )
     )
+  }
+
+  public actual fun setMetalSurfaceTarget(descriptor: MetalSurfaceDescriptor) {
+    activeFrame.ensureInactive("set target")
+    memScoped {
+      Status.check(
+        mln_metal_surface_set_target(
+          state.requireLive().rawHandleValue,
+          RenderStructs.metalSurfaceDescriptor(descriptor, this),
+        )
+      )
+    }
+  }
+
+  public actual fun setVulkanSurfaceTarget(descriptor: VulkanSurfaceDescriptor) {
+    activeFrame.ensureInactive("set target")
+    memScoped {
+      Status.check(
+        mln_vulkan_surface_set_target(
+          state.requireLive().rawHandleValue,
+          RenderStructs.vulkanSurfaceDescriptor(descriptor, this),
+        )
+      )
+    }
+  }
+
+  public actual fun setOpenGLSurfaceTarget(descriptor: OpenGLSurfaceDescriptor) {
+    activeFrame.ensureInactive("set target")
+    memScoped {
+      Status.check(
+        mln_opengl_surface_set_target(
+          state.requireLive().rawHandleValue,
+          RenderStructs.openglSurfaceDescriptor(descriptor, this),
+        )
+      )
+    }
+  }
+
+  public actual fun setMetalBorrowedTextureTarget(descriptor: MetalBorrowedTextureDescriptor) {
+    activeFrame.ensureInactive("set target")
+    memScoped {
+      Status.check(
+        mln_metal_borrowed_texture_set_target(
+          state.requireLive().rawHandleValue,
+          RenderStructs.metalBorrowedTextureDescriptor(descriptor, this),
+        )
+      )
+    }
+  }
+
+  public actual fun setVulkanBorrowedTextureTarget(descriptor: VulkanBorrowedTextureDescriptor) {
+    activeFrame.ensureInactive("set target")
+    memScoped {
+      Status.check(
+        mln_vulkan_borrowed_texture_set_target(
+          state.requireLive().rawHandleValue,
+          RenderStructs.vulkanBorrowedTextureDescriptor(descriptor, this),
+        )
+      )
+    }
+  }
+
+  public actual fun setOpenGLBorrowedTextureTarget(descriptor: OpenGLBorrowedTextureDescriptor) {
+    activeFrame.ensureInactive("set target")
+    memScoped {
+      Status.check(
+        mln_opengl_borrowed_texture_set_target(
+          state.requireLive().rawHandleValue,
+          RenderStructs.openglBorrowedTextureDescriptor(descriptor, this),
+        )
+      )
+    }
   }
 
   public actual fun renderUpdate(): Boolean = memScoped {

--- a/bindings/python/python/maplibre_native/_native.pyi
+++ b/bindings/python/python/maplibre_native/_native.pyi
@@ -496,6 +496,84 @@ class _RenderSessionHandle:
     def detached(self) -> bool: ...
     def close(self) -> None: ...
     def resize(self, width: int, height: int, scale_factor: float) -> None: ...
+    def set_metal_surface_target(
+        self,
+        width: int,
+        height: int,
+        scale_factor: float,
+        device_address: int,
+        layer_address: int,
+    ) -> None: ...
+    def set_vulkan_surface_target(
+        self,
+        width: int,
+        height: int,
+        scale_factor: float,
+        instance_address: int,
+        physical_device_address: int,
+        device_address: int,
+        graphics_queue_address: int,
+        graphics_queue_family_index: int,
+        get_instance_proc_addr: int,
+        get_device_proc_addr: int,
+        surface_address: int,
+    ) -> None: ...
+    def set_opengl_surface_target(
+        self,
+        width: int,
+        height: int,
+        scale_factor: float,
+        context_platform: int,
+        context_address_1: int,
+        context_address_2: int,
+        share_context_address: int,
+        get_proc_address: int,
+        surface_address: int,
+    ) -> None: ...
+    def set_metal_borrowed_texture_target(
+        self,
+        width: int,
+        height: int,
+        scale_factor: float,
+        physical_width: int,
+        physical_height: int,
+        texture_address: int,
+    ) -> None: ...
+    def set_vulkan_borrowed_texture_target(
+        self,
+        width: int,
+        height: int,
+        scale_factor: float,
+        physical_width: int,
+        physical_height: int,
+        instance_address: int,
+        physical_device_address: int,
+        device_address: int,
+        graphics_queue_address: int,
+        graphics_queue_family_index: int,
+        get_instance_proc_addr: int,
+        get_device_proc_addr: int,
+        image_address: int,
+        image_view_address: int,
+        format: int,
+        initial_layout: int,
+        final_layout: int,
+    ) -> None: ...
+    def set_opengl_borrowed_texture_target(
+        self,
+        width: int,
+        height: int,
+        scale_factor: float,
+        physical_width: int,
+        physical_height: int,
+        context_platform: int,
+        context_address_1: int,
+        context_address_2: int,
+        share_context_address: int,
+        get_proc_address: int,
+        texture: int,
+        target: int,
+    ) -> None: ...
     def render_update(self) -> bool: ...
     def detach(self) -> "_DetachedRenderSessionHandle": ...
     def reduce_memory_use(self) -> None: ...

--- a/bindings/python/python/maplibre_native/map.py
+++ b/bindings/python/python/maplibre_native/map.py
@@ -26,7 +26,6 @@ from .errors import InvalidArgumentError
 from .geo import GeoJson, Geometry, LatLng, LatLngBounds
 from .json import JsonObject, JsonValue
 from .render import (
-    EglContextDescriptor,
     MetalBorrowedTextureDescriptor,
     MetalOwnedTextureDescriptor,
     MetalSurfaceDescriptor,
@@ -38,7 +37,7 @@ from .render import (
     VulkanBorrowedTextureDescriptor,
     VulkanOwnedTextureDescriptor,
     VulkanSurfaceDescriptor,
-    WglContextDescriptor,
+    _opengl_context_parts,
 )
 from .style import (
     CanonicalTileId,
@@ -1693,29 +1692,6 @@ class MapHandle(NativeHandleMixin):
             descriptor.texture,
             descriptor.target,
         )
-
-
-def _opengl_context_parts(
-    context: EglContextDescriptor | WglContextDescriptor,
-) -> tuple[int, int, int, int, int]:
-    if isinstance(context, WglContextDescriptor):
-        return (
-            1,
-            context.device_context.address,
-            0,
-            context.share_context.address,
-            context.get_proc_address.address,
-        )
-    if isinstance(context, EglContextDescriptor):
-        return (
-            2,
-            context.display.address,
-            context.config.address,
-            context.share_context.address,
-            context.get_proc_address.address,
-        )
-    msg = f"unsupported OpenGL context descriptor: {type(context)!r}"
-    raise TypeError(msg)
 
 
 __all__ = [

--- a/bindings/python/python/maplibre_native/render.py
+++ b/bindings/python/python/maplibre_native/render.py
@@ -564,8 +564,8 @@ class RenderSessionHandle(NativeHandleMixin):
         otherwise. Both leave this session rendering into the texture it has. The
         caller owns the replacement and keeps it valid until the next
         replacement, detach, or close. This session never retained the outgoing
-        texture and never releases it, but reads from it during this call, so
-        keep it valid until the call returns.
+        texture, never releases it, and never reads it here, so a host that
+        already released it hands over the replacement all the same.
         """
         self._set_target(
             self._native.set_metal_borrowed_texture_target,

--- a/bindings/python/python/maplibre_native/render.py
+++ b/bindings/python/python/maplibre_native/render.py
@@ -460,6 +460,13 @@ class RenderSessionHandle(NativeHandleMixin):
         :class:`UnsupportedFeatureError`: allocate a texture at the new size and
         hand it over with the ``set_*_borrowed_texture_target`` method for the
         backend, which keeps this session.
+
+        This session keeps its renderer across a resize, so renderer-held state
+        such as feature state carries over. A scale factor that differs from
+        this session's current one is the exception: a renderer compiles its
+        shaders for one pixel ratio, so that resize starts a new one with
+        renderer-held state empty. The same exception applies to every
+        ``set_*_target`` method, which otherwise keeps the renderer.
         """
         self._native.resize(width, height, scale_factor)
 
@@ -483,11 +490,11 @@ class RenderSessionHandle(NativeHandleMixin):
         placement, and feature state.
 
         The descriptor names the same graphics context this session attached
-        with, and its extent applies as a resize does. A layer on a different
-        device raises :class:`InvalidArgumentError` and leaves this session
-        rendering into the surface it has, so close it and attach again to take
-        that one. The session sets the layer's pixel format itself, so there is
-        nothing else here for a replacement to mismatch.
+        with, and its extent applies as a resize does. A descriptor whose
+        ``context.device`` is neither null nor this session's device raises
+        :class:`InvalidArgumentError` and leaves this session rendering into the
+        surface it has. The session assigns the layer its own device and pixel
+        format, so the layer itself carries nothing that has to match.
         """
         self._set_target(
             self._native.set_metal_surface_target,

--- a/bindings/python/python/maplibre_native/render.py
+++ b/bindings/python/python/maplibre_native/render.py
@@ -483,11 +483,11 @@ class RenderSessionHandle(NativeHandleMixin):
         placement, and feature state.
 
         The descriptor names the same graphics context this session attached
-        with, and its extent applies as a resize does. A target on a different
-        context raises :class:`InvalidArgumentError`, and one this session's
-        compiled state cannot serve raises :class:`UnsupportedFeatureError`.
-        Both leave this session rendering into the surface it has; close it and
-        attach again to take that target.
+        with, and its extent applies as a resize does. A layer on a different
+        device raises :class:`InvalidArgumentError` and leaves this session
+        rendering into the surface it has, so close it and attach again to take
+        that one. The session sets the layer's pixel format itself, so there is
+        nothing else here for a replacement to mismatch.
         """
         self._set_target(
             self._native.set_metal_surface_target,

--- a/bindings/python/python/maplibre_native/render.py
+++ b/bindings/python/python/maplibre_native/render.py
@@ -453,8 +453,176 @@ class RenderSessionHandle(NativeHandleMixin):
         return bool(self._native.detached)
 
     def resize(self, width: int, height: int, scale_factor: float) -> None:
-        """Resize this attached render session."""
+        """Resize this attached render session.
+
+        Surface and session-owned texture targets resize in place. A
+        caller-owned texture target is sized by its owner and reports
+        :class:`UnsupportedFeatureError`: allocate a texture at the new size and
+        hand it over with the ``set_*_borrowed_texture_target`` method for the
+        backend, which keeps this session.
+        """
         self._native.resize(width, height, scale_factor)
+
+    def _set_target(
+        self,
+        set_target: Callable[..., None],
+        descriptor: Any,
+        *args: object,
+    ) -> None:
+        extent = descriptor.extent
+        set_target(extent.width, extent.height, extent.scale_factor, *args)
+
+    def set_metal_surface_target(self, descriptor: MetalSurfaceDescriptor) -> None:
+        """Present this attached surface session through a new surface.
+
+        A host surface can be destroyed and recreated while the map goes on
+        living, which is what Android rotation, a Flutter ``SurfaceProducer``
+        lifecycle change, and a window resize that reallocates all look like
+        from here. Replacing the surface in place keeps this session's
+        renderer, and with it the tile pyramid, glyph and image atlases, symbol
+        placement, and feature state.
+
+        The descriptor names the same graphics context this session attached
+        with, and its extent applies as a resize does. A target on a different
+        context raises :class:`InvalidArgumentError`, and one this session's
+        compiled state cannot serve raises :class:`UnsupportedFeatureError`.
+        Both leave this session rendering into the surface it has; close it and
+        attach again to take that target.
+        """
+        self._set_target(
+            self._native.set_metal_surface_target,
+            descriptor,
+            descriptor.context.device.address,
+            descriptor.layer.address,
+        )
+
+    def set_vulkan_surface_target(self, descriptor: VulkanSurfaceDescriptor) -> None:
+        """Present this attached surface session through a new surface.
+
+        See :meth:`set_metal_surface_target` for what replacing a surface
+        preserves. The outgoing ``VkSurfaceKHR`` must still be valid: this
+        session holds a swapchain built from it, and Vulkan destroys every
+        swapchain before its surface.
+        """
+        self._set_target(
+            self._native.set_vulkan_surface_target,
+            descriptor,
+            descriptor.context.instance.address,
+            descriptor.context.physical_device.address,
+            descriptor.context.device.address,
+            descriptor.context.graphics_queue.address,
+            descriptor.context.graphics_queue_family_index,
+            descriptor.context.get_instance_proc_addr.address,
+            descriptor.context.get_device_proc_addr.address,
+            descriptor.surface.address,
+        )
+
+    def set_opengl_surface_target(self, descriptor: OpenGLSurfaceDescriptor) -> None:
+        """Present this attached surface session through a new surface.
+
+        See :meth:`set_metal_surface_target` for what replacing a surface
+        preserves. The new surface is made current on the next render, so a
+        host may hand over a replacement for one it has already destroyed. A
+        surface accepted here can still prove unusable, which the next
+        :meth:`render_update` reports rather than this call.
+        """
+        platform, first, second, share, get_proc = _opengl_context_parts(
+            descriptor.context
+        )
+        self._set_target(
+            self._native.set_opengl_surface_target,
+            descriptor,
+            platform,
+            first,
+            second,
+            share,
+            get_proc,
+            descriptor.surface.address,
+        )
+
+    def set_metal_borrowed_texture_target(
+        self, descriptor: MetalBorrowedTextureDescriptor
+    ) -> None:
+        """Render this attached texture session into a new caller-owned texture.
+
+        A caller-owned texture is sized by its owner, so a host that follows a
+        resize reallocates rather than resizing and :meth:`resize` reports
+        :class:`UnsupportedFeatureError`. Handing the replacement over here
+        keeps this session's renderer instead, so the map does not go cold on
+        every resize.
+
+        The replacement belongs to the device this session attached with, which
+        raises :class:`InvalidArgumentError` otherwise, and carries the pixel
+        format it attached with, which raises :class:`UnsupportedFeatureError`
+        otherwise. Both leave this session rendering into the texture it has. The
+        caller owns the replacement and keeps it valid until the next
+        replacement, detach, or close. This session never retained the outgoing
+        texture and never releases it, but reads from it during this call, so
+        keep it valid until the call returns.
+        """
+        self._set_target(
+            self._native.set_metal_borrowed_texture_target,
+            descriptor,
+            descriptor.physical_width,
+            descriptor.physical_height,
+            descriptor.texture.address,
+        )
+
+    def set_vulkan_borrowed_texture_target(
+        self, descriptor: VulkanBorrowedTextureDescriptor
+    ) -> None:
+        """Render this attached texture session into a new caller-owned image.
+
+        See :meth:`set_metal_borrowed_texture_target` for what replacing a
+        target preserves. The replacement carries the format and both layouts
+        this session attached with, since its render pass was built around
+        them.
+        """
+        self._set_target(
+            self._native.set_vulkan_borrowed_texture_target,
+            descriptor,
+            descriptor.physical_width,
+            descriptor.physical_height,
+            descriptor.context.instance.address,
+            descriptor.context.physical_device.address,
+            descriptor.context.device.address,
+            descriptor.context.graphics_queue.address,
+            descriptor.context.graphics_queue_family_index,
+            descriptor.context.get_instance_proc_addr.address,
+            descriptor.context.get_device_proc_addr.address,
+            descriptor.image.address,
+            descriptor.image_view.address,
+            descriptor.format,
+            descriptor.initial_layout,
+            descriptor.final_layout,
+        )
+
+    def set_opengl_borrowed_texture_target(
+        self, descriptor: OpenGLBorrowedTextureDescriptor
+    ) -> None:
+        """Render this attached texture session into a new caller-owned texture.
+
+        See :meth:`set_metal_borrowed_texture_target` for what replacing a
+        target preserves. The replacement belongs to the context this session
+        attached with, or one in its share group, and the host context must be
+        current on this thread.
+        """
+        platform, first, second, share, get_proc = _opengl_context_parts(
+            descriptor.context
+        )
+        self._set_target(
+            self._native.set_opengl_borrowed_texture_target,
+            descriptor,
+            descriptor.physical_width,
+            descriptor.physical_height,
+            platform,
+            first,
+            second,
+            share,
+            get_proc,
+            descriptor.texture,
+            descriptor.target,
+        )
 
     def render_update(self) -> bool:
         """Process the latest map render update for this target.
@@ -737,6 +905,29 @@ class OpenGLOwnedTextureFrameHandle(NativeHandleMixin):
             int(self._native.texture()),
             _is_live=lambda: not self.closed,
         )
+
+
+def _opengl_context_parts(
+    context: EglContextDescriptor | WglContextDescriptor,
+) -> tuple[int, int, int, int, int]:
+    if isinstance(context, WglContextDescriptor):
+        return (
+            1,
+            context.device_context.address,
+            0,
+            context.share_context.address,
+            context.get_proc_address.address,
+        )
+    if isinstance(context, EglContextDescriptor):
+        return (
+            2,
+            context.display.address,
+            context.config.address,
+            context.share_context.address,
+            context.get_proc_address.address,
+        )
+    msg = f"unsupported OpenGL context descriptor: {type(context)!r}"
+    raise TypeError(msg)
 
 
 __all__ = [

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3673,6 +3673,25 @@ impl MapProjectionHandle {
     }
 }
 
+impl RenderSessionHandle {
+    /// Shared body for the `set_*_target` methods.
+    ///
+    /// The native descriptor is materialized by the caller and lives for the
+    /// duration of this call, which is all the C API borrows it for.
+    fn set_target<D>(
+        &self,
+        raw: D,
+        set_target: impl FnOnce(sys::mln_render_session, &D) -> sys::mln_status,
+    ) -> PyResult<()> {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.ensure_no_frame_acquired()?;
+        maplibre_core::check(set_target(state.native(), &raw)).map_err(map_error)
+    }
+}
+
 #[pymethods]
 impl RenderSessionHandle {
     fn close(&self) -> PyResult<()> {
@@ -3701,6 +3720,236 @@ impl RenderSessionHandle {
             sys::mln_render_session_resize(state.native(), width, height, scale_factor)
         })
         .map_err(map_error)
+    }
+
+    fn set_metal_surface_target(
+        &self,
+        width: u32,
+        height: u32,
+        scale_factor: f64,
+        device_address: usize,
+        layer_address: usize,
+    ) -> PyResult<()> {
+        let descriptor = maplibre_core::render::metal_surface_descriptor_to_native(
+            maplibre_core::render::MetalSurfaceDescriptorFields {
+                extent: maplibre_core::render::RenderTargetExtentFields {
+                    width,
+                    height,
+                    scale_factor,
+                },
+                context: maplibre_core::render::MetalContextDescriptorFields {
+                    device: device_address as *mut c_void,
+                },
+                layer: layer_address as *mut c_void,
+            },
+        );
+        self.set_target(descriptor, |session, raw| {
+            // SAFETY: raw is fully initialized and lives for this call. The C
+            // API validates the session pointer, state, and descriptor fields.
+            unsafe { sys::mln_metal_surface_set_target(session, raw) }
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn set_vulkan_surface_target(
+        &self,
+        width: u32,
+        height: u32,
+        scale_factor: f64,
+        instance_address: usize,
+        physical_device_address: usize,
+        device_address: usize,
+        graphics_queue_address: usize,
+        graphics_queue_family_index: u32,
+        get_instance_proc_addr: usize,
+        get_device_proc_addr: usize,
+        surface_address: usize,
+    ) -> PyResult<()> {
+        let descriptor = maplibre_core::render::vulkan_surface_descriptor_to_native(
+            maplibre_core::render::VulkanSurfaceDescriptorFields {
+                extent: maplibre_core::render::RenderTargetExtentFields {
+                    width,
+                    height,
+                    scale_factor,
+                },
+                context: vulkan_context_fields(
+                    instance_address,
+                    physical_device_address,
+                    device_address,
+                    graphics_queue_address,
+                    graphics_queue_family_index,
+                    get_instance_proc_addr,
+                    get_device_proc_addr,
+                ),
+                surface: surface_address as *mut c_void,
+            },
+        );
+        self.set_target(descriptor, |session, raw| {
+            // SAFETY: raw is fully initialized and lives for this call. The C
+            // API validates the session pointer, state, and descriptor fields.
+            unsafe { sys::mln_vulkan_surface_set_target(session, raw) }
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn set_opengl_surface_target(
+        &self,
+        width: u32,
+        height: u32,
+        scale_factor: f64,
+        context_platform: u32,
+        context_address_1: usize,
+        context_address_2: usize,
+        share_context_address: usize,
+        get_proc_address: usize,
+        surface_address: usize,
+    ) -> PyResult<()> {
+        let descriptor = maplibre_core::render::opengl_surface_descriptor_to_native(
+            maplibre_core::render::OpenGLSurfaceDescriptorFields {
+                extent: maplibre_core::render::RenderTargetExtentFields {
+                    width,
+                    height,
+                    scale_factor,
+                },
+                context: opengl_context_fields(
+                    context_platform,
+                    context_address_1,
+                    context_address_2,
+                    share_context_address,
+                    get_proc_address,
+                )?,
+                surface: surface_address as *mut c_void,
+            },
+        );
+        self.set_target(descriptor, |session, raw| {
+            // SAFETY: raw is fully initialized and lives for this call. The C
+            // API validates the session pointer, state, and descriptor fields.
+            unsafe { sys::mln_opengl_surface_set_target(session, raw) }
+        })
+    }
+
+    fn set_metal_borrowed_texture_target(
+        &self,
+        width: u32,
+        height: u32,
+        scale_factor: f64,
+        physical_width: u32,
+        physical_height: u32,
+        texture_address: usize,
+    ) -> PyResult<()> {
+        let descriptor = maplibre_core::render::metal_borrowed_texture_descriptor_to_native(
+            maplibre_core::render::MetalBorrowedTextureDescriptorFields {
+                extent: maplibre_core::render::RenderTargetExtentFields {
+                    width,
+                    height,
+                    scale_factor,
+                },
+                physical_width,
+                physical_height,
+                texture: texture_address as *mut c_void,
+            },
+        );
+        self.set_target(descriptor, |session, raw| {
+            // SAFETY: raw is fully initialized and lives for this call. The C
+            // API validates the session pointer, state, and descriptor fields.
+            unsafe { sys::mln_metal_borrowed_texture_set_target(session, raw) }
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn set_vulkan_borrowed_texture_target(
+        &self,
+        width: u32,
+        height: u32,
+        scale_factor: f64,
+        physical_width: u32,
+        physical_height: u32,
+        instance_address: usize,
+        physical_device_address: usize,
+        device_address: usize,
+        graphics_queue_address: usize,
+        graphics_queue_family_index: u32,
+        get_instance_proc_addr: usize,
+        get_device_proc_addr: usize,
+        image_address: usize,
+        image_view_address: usize,
+        format: u32,
+        initial_layout: u32,
+        final_layout: u32,
+    ) -> PyResult<()> {
+        let descriptor = maplibre_core::render::vulkan_borrowed_texture_descriptor_to_native(
+            maplibre_core::render::VulkanBorrowedTextureDescriptorFields {
+                extent: maplibre_core::render::RenderTargetExtentFields {
+                    width,
+                    height,
+                    scale_factor,
+                },
+                physical_width,
+                physical_height,
+                context: vulkan_context_fields(
+                    instance_address,
+                    physical_device_address,
+                    device_address,
+                    graphics_queue_address,
+                    graphics_queue_family_index,
+                    get_instance_proc_addr,
+                    get_device_proc_addr,
+                ),
+                image: image_address as *mut c_void,
+                image_view: image_view_address as *mut c_void,
+                format,
+                initial_layout,
+                final_layout,
+            },
+        );
+        self.set_target(descriptor, |session, raw| {
+            // SAFETY: raw is fully initialized and lives for this call. The C
+            // API validates the session pointer, state, and descriptor fields.
+            unsafe { sys::mln_vulkan_borrowed_texture_set_target(session, raw) }
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn set_opengl_borrowed_texture_target(
+        &self,
+        width: u32,
+        height: u32,
+        scale_factor: f64,
+        physical_width: u32,
+        physical_height: u32,
+        context_platform: u32,
+        context_address_1: usize,
+        context_address_2: usize,
+        share_context_address: usize,
+        get_proc_address: usize,
+        texture: u32,
+        target: u32,
+    ) -> PyResult<()> {
+        let descriptor = maplibre_core::render::opengl_borrowed_texture_descriptor_to_native(
+            maplibre_core::render::OpenGLBorrowedTextureDescriptorFields {
+                extent: maplibre_core::render::RenderTargetExtentFields {
+                    width,
+                    height,
+                    scale_factor,
+                },
+                physical_width,
+                physical_height,
+                context: opengl_context_fields(
+                    context_platform,
+                    context_address_1,
+                    context_address_2,
+                    share_context_address,
+                    get_proc_address,
+                )?,
+                texture,
+                target,
+            },
+        );
+        self.set_target(descriptor, |session, raw| {
+            // SAFETY: raw is fully initialized and lives for this call. The C
+            // API validates the session pointer, state, and descriptor fields.
+            unsafe { sys::mln_opengl_borrowed_texture_set_target(session, raw) }
+        })
     }
 
     fn render_update(&self) -> PyResult<bool> {

--- a/bindings/python/tests/render_backend_helpers/egl.py
+++ b/bindings/python/tests/render_backend_helpers/egl.py
@@ -266,6 +266,9 @@ class EglBorrowedTexture:
                 GL.GL_TEXTURE_WRAP_T,
                 GL.GL_CLAMP_TO_EDGE,
             )
+            # Zeroed rather than left undefined: a test that reads this back
+            # to prove a session rendered into it needs a known starting value.
+            blank = (ctypes.c_ubyte * (width * height * 4))()
             GL.glTexImage2D(
                 GL.GL_TEXTURE_2D,
                 0,
@@ -275,7 +278,7 @@ class EglBorrowedTexture:
                 0,
                 GL.GL_RGBA,
                 GL.GL_UNSIGNED_BYTE,
-                None,
+                blank,
             )
             GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
         except BaseException:

--- a/bindings/python/tests/render_backend_helpers/egl.py
+++ b/bindings/python/tests/render_backend_helpers/egl.py
@@ -285,6 +285,39 @@ class EglBorrowedTexture:
         context.clear_current()
         return cls(context, surface, texture, width, height, scale_factor)
 
+    def read_rgba(self) -> bytes:
+        """Read this texture back through a scratch framebuffer."""
+        self.context.make_current(self.surface)
+        try:
+            framebuffer = GL.glGenFramebuffers(1)
+            GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, framebuffer)
+            GL.glFramebufferTexture2D(
+                GL.GL_FRAMEBUFFER,
+                GL.GL_COLOR_ATTACHMENT0,
+                GL.GL_TEXTURE_2D,
+                self.texture,
+                0,
+            )
+            status = GL.glCheckFramebufferStatus(GL.GL_FRAMEBUFFER)
+            if status != GL.GL_FRAMEBUFFER_COMPLETE:
+                msg = f"borrowed texture framebuffer is incomplete: 0x{status:x}"
+                raise EglUnavailableError(msg)
+            pixels = (ctypes.c_ubyte * (self.width * self.height * 4))()
+            GL.glReadPixels(
+                0,
+                0,
+                self.width,
+                self.height,
+                GL.GL_RGBA,
+                GL.GL_UNSIGNED_BYTE,
+                pixels,
+            )
+            GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, 0)
+            GL.glDeleteFramebuffers(1, [framebuffer])
+            return bytes(pixels)
+        finally:
+            self.context.clear_current()
+
     def descriptor(self) -> render.OpenGLBorrowedTextureDescriptor:
         return render.OpenGLBorrowedTextureDescriptor(
             extent=render.RenderTargetExtent(

--- a/bindings/python/tests/render_backend_helpers/metal.py
+++ b/bindings/python/tests/render_backend_helpers/metal.py
@@ -170,6 +170,28 @@ class MetalBorrowedTexture:
             texture=_pointer(self.texture, "MTLTexture"),
         )
 
+    def read_rgba(self) -> bytes:
+        queue = self.context.device.newCommandQueue()
+        if queue is None:
+            msg = "MTLDevice.newCommandQueue returned nil"
+            raise MetalUnavailableError(msg)
+        command_buffer = queue.commandBuffer()
+        encoder = command_buffer.blitCommandEncoder()
+        # A texture created without an explicit storage mode is managed on
+        # macOS, so its CPU copy stays stale until a blit synchronizes it.
+        encoder.synchronizeResource_(self.texture)
+        encoder.endEncoding()
+        command_buffer.commit()
+        command_buffer.waitUntilCompleted()
+        pixels = bytearray(self.width * self.height * 4)
+        self.texture.getBytes_bytesPerRow_fromRegion_mipmapLevel_(
+            pixels,
+            self.width * 4,
+            Metal.MTLRegionMake2D(0, 0, self.width, self.height),
+            0,
+        )
+        return bytes(pixels)
+
     def exists(self) -> bool:
         return not self._closed and self.texture is not None
 

--- a/bindings/python/tests/render_backend_helpers/metal.py
+++ b/bindings/python/tests/render_backend_helpers/metal.py
@@ -156,6 +156,16 @@ class MetalBorrowedTexture:
         if texture is None:
             msg = "MTLDevice.newTextureWithDescriptor returned nil"
             raise MetalUnavailableError(msg)
+        # A new MTLTexture's contents are undefined, so clear it: a test that
+        # reads this back to prove a session rendered into it needs a known
+        # starting value.
+        blank = bytes(width * height * 4)
+        texture.replaceRegion_mipmapLevel_withBytes_bytesPerRow_(
+            Metal.MTLRegionMake2D(0, 0, width, height),
+            0,
+            blank,
+            width * 4,
+        )
         return cls(context, texture, width, height, scale_factor)
 
     def descriptor(self) -> render.MetalBorrowedTextureDescriptor:

--- a/bindings/python/tests/render_backend_helpers/runtime.py
+++ b/bindings/python/tests/render_backend_helpers/runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 import time
 
 import pytest
@@ -105,6 +106,26 @@ def render_until_update(
     )
     assert event.event_type == mln.RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE
     assert session.render_update()
+
+
+def render_until(
+    runtime: mln.RuntimeHandle,
+    session: render.RenderSessionHandle,
+    condition: Callable[[], bool],
+    description: str,
+    *,
+    iterations: int = 5000,
+) -> None:
+    """Pump and render until `condition` holds, failing with `description`."""
+    for _ in range(iterations):
+        runtime.pump()
+        while event := runtime.poll_event():
+            if event.event_type == mln.RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE:
+                session.render_update()
+        if condition():
+            return
+        time.sleep(0.001)
+    raise AssertionError(description)
 
 
 def request_still_image_if_needed(map_handle: mln.MapHandle) -> None:

--- a/bindings/python/tests/render_backend_helpers/runtime.py
+++ b/bindings/python/tests/render_backend_helpers/runtime.py
@@ -10,6 +10,15 @@ from maplibre_native import camera, geo, json, query, render, style
 
 EMPTY_STYLE_JSON = '{"version":8,"sources":{},"layers":[]}'
 
+RED_BACKGROUND_STYLE_JSON = (
+    '{"version":8,"sources":{},"layers":['
+    '{"id":"background","type":"background",'
+    '"paint":{"background-color":"#ff0000"}}]}'
+)
+"""A style that paints every pixel, for tests that read a target back."""
+
+RED_PIXEL = b"\xff\x00\x00\xff"
+
 CLUSTER_POINTS = geo.FeatureCollection(
     tuple(
         geo.Feature(

--- a/bindings/python/tests/test_render_metal_attach.py
+++ b/bindings/python/tests/test_render_metal_attach.py
@@ -10,6 +10,8 @@ from maplibre_native import render
 
 from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
+    RED_BACKGROUND_STYLE_JSON,
+    RED_PIXEL,
     render_until,
     render_until_update,
     skip_or_fail_fixture_setup,
@@ -110,15 +112,6 @@ def _metal_borrowed_texture(
         yield texture
     finally:
         texture.close()
-
-
-RED_BACKGROUND_STYLE_JSON = (
-    '{"version":8,"sources":{},"layers":['
-    '{"id":"background","type":"background",'
-    '"paint":{"background-color":"#ff0000"}}]}'
-)
-
-RED_PIXEL = b"\xff\x00\x00\xff"
 
 
 def _is_painted_red(texture: MetalBorrowedTexture) -> bool:
@@ -290,8 +283,13 @@ def test_metal_borrowed_texture_set_target_renders_into_the_replacement() -> Non
 def test_metal_surface_set_target_presents_through_a_new_surface() -> None:
     """Spec coverage: BND-175.
 
-    A host surface can be destroyed and recreated while the map goes on
-    living, and this session presents through the replacement afterward.
+    A host surface can be destroyed and recreated while the map goes on living,
+    and this session keeps rendering afterward.
+
+    This verifies that the handoff is accepted, that the map takes the extent
+    handed with it, and that the session stays usable. Observing presentation
+    through the replacement layer needs a drawable-counting layer, which the
+    Zig binding's equivalent test has and this one does not.
     """
     with _metal_context() as context:
         with _metal_surface(context) as surface:

--- a/bindings/python/tests/test_render_metal_attach.py
+++ b/bindings/python/tests/test_render_metal_attach.py
@@ -10,6 +10,7 @@ from maplibre_native import render
 
 from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
+    render_until,
     render_until_update,
     skip_or_fail_fixture_setup,
 )
@@ -70,9 +71,14 @@ def _metal_context() -> Iterator[MetalContext]:
 
 
 @contextmanager
-def _metal_surface(context: MetalContext) -> Iterator[MetalSurface]:
+def _metal_surface(
+    context: MetalContext,
+    *,
+    width: int = 32,
+    height: int = 16,
+) -> Iterator[MetalSurface]:
     try:
-        surface = context.surface(width=32, height=16)
+        surface = context.surface(width=width, height=height)
     except MetalUnavailableError as error:
         skip_or_fail_fixture_setup(
             f"Metal surface fixture creation is unavailable: {error}",
@@ -88,9 +94,12 @@ def _metal_surface(context: MetalContext) -> Iterator[MetalSurface]:
 @contextmanager
 def _metal_borrowed_texture(
     context: MetalContext,
+    *,
+    width: int = 64,
+    height: int = 64,
 ) -> Iterator[MetalBorrowedTexture]:
     try:
-        texture = context.borrowed_texture(width=64, height=64)
+        texture = context.borrowed_texture(width=width, height=height)
     except MetalUnavailableError as error:
         skip_or_fail_fixture_setup(
             f"Metal borrowed-texture fixture creation is unavailable: {error}",
@@ -101,6 +110,20 @@ def _metal_borrowed_texture(
         yield texture
     finally:
         texture.close()
+
+
+RED_BACKGROUND_STYLE_JSON = (
+    '{"version":8,"sources":{},"layers":['
+    '{"id":"background","type":"background",'
+    '"paint":{"background-color":"#ff0000"}}]}'
+)
+
+RED_PIXEL = b"\xff\x00\x00\xff"
+
+
+def _is_painted_red(texture: MetalBorrowedTexture) -> bool:
+    """Return whether the whole texture carries the style's background color."""
+    return texture.read_rgba() == RED_PIXEL * (texture.width * texture.height)
 
 
 def _assert_public_session_shape(session: render.RenderSessionHandle) -> None:
@@ -203,3 +226,137 @@ def test_metal_borrowed_texture_session_close_preserves_caller_resources() -> No
 
             replacement_descriptor = texture.descriptor()
             assert _descriptor_snapshot(replacement_descriptor) == before_descriptor
+
+
+def test_metal_borrowed_texture_set_target_renders_into_the_replacement() -> None:
+    """Spec coverage: BND-175.
+
+    A caller-owned texture is sized by its owner, so a host that follows a
+    resize allocates a texture at the new size and hands it over instead of
+    resizing this session.
+    """
+    with _metal_context() as context:
+        with _metal_borrowed_texture(context) as texture:
+            descriptor = texture.descriptor()
+
+            with mln.RuntimeHandle() as runtime:
+                with runtime.create_map(
+                    mln.MapOptions(
+                        width=descriptor.extent.width,
+                        height=descriptor.extent.height,
+                    )
+                ) as map_handle:
+                    session = map_handle.attach_metal_borrowed_texture(descriptor)
+                    try:
+                        map_handle.set_style_json(RED_BACKGROUND_STYLE_JSON)
+                        render_until(
+                            runtime,
+                            session,
+                            lambda: _is_painted_red(texture),
+                            "the attached texture was never rendered into",
+                        )
+
+                        with pytest.raises(mln.UnsupportedFeatureError) as raised:
+                            session.resize(96, 48, 1.0)
+                        assert raised.value.status == mln.MaplibreStatus.UNSUPPORTED
+
+                        with _metal_borrowed_texture(
+                            context, width=96, height=48
+                        ) as replacement:
+                            assert not any(replacement.read_rgba())
+
+                            session.set_metal_borrowed_texture_target(
+                                replacement.descriptor()
+                            )
+
+                            # The session kept its renderer and paints the
+                            # texture it was handed, at the extent handed with
+                            # it, once the map has caught up to that extent.
+                            render_until(
+                                runtime,
+                                session,
+                                lambda: _is_painted_red(replacement),
+                                "the replacement texture was never rendered into",
+                            )
+                            assert map_handle.get_size() == (
+                                96,
+                                48,
+                                pytest.approx(1.0),
+                            )
+                    finally:
+                        session.close()
+
+
+def test_metal_surface_set_target_presents_through_a_new_surface() -> None:
+    """Spec coverage: BND-175.
+
+    A host surface can be destroyed and recreated while the map goes on
+    living, and this session presents through the replacement afterward.
+    """
+    with _metal_context() as context:
+        with _metal_surface(context) as surface:
+            with mln.RuntimeHandle() as runtime:
+                with runtime.create_map(
+                    mln.MapOptions(width=surface.width, height=surface.height)
+                ) as map_handle:
+                    session = map_handle.attach_metal_surface(surface.descriptor())
+                    try:
+                        map_handle.set_style_json(EMPTY_STYLE_JSON)
+                        render_until_update(runtime, session)
+
+                        with _metal_surface(
+                            context, width=48, height=24
+                        ) as replacement:
+                            session.set_metal_surface_target(replacement.descriptor())
+
+                            render_until(
+                                runtime,
+                                session,
+                                lambda: (
+                                    map_handle.get_size()
+                                    == (48, 24, pytest.approx(1.0))
+                                ),
+                                "the map never took the replacement surface extent",
+                            )
+                            assert session.detached is False
+                            assert session.render_update()
+                    finally:
+                        session.close()
+
+
+def test_metal_set_target_reports_unsupported_for_another_target_kind() -> None:
+    """Spec coverage: BND-176.
+
+    A session renders through the target kind it attached with, so a
+    descriptor for the other kind is rejected and leaves the session usable.
+    """
+    with _metal_context() as context:
+        with _metal_borrowed_texture(context) as texture:
+            with _metal_surface(context) as surface:
+                with mln.RuntimeHandle() as runtime:
+                    with runtime.create_map(
+                        mln.MapOptions(width=surface.width, height=surface.height)
+                    ) as map_handle:
+                        session = map_handle.attach_metal_borrowed_texture(
+                            texture.descriptor()
+                        )
+                        try:
+                            with pytest.raises(mln.UnsupportedFeatureError) as raised:
+                                session.set_metal_surface_target(surface.descriptor())
+                            assert raised.value.status == mln.MaplibreStatus.UNSUPPORTED
+                            # The rejection left the session usable.
+                            session.render_update()
+                        finally:
+                            session.close()
+
+                        session = map_handle.attach_metal_surface(surface.descriptor())
+                        try:
+                            with pytest.raises(mln.UnsupportedFeatureError) as raised:
+                                session.set_metal_borrowed_texture_target(
+                                    texture.descriptor()
+                                )
+                            assert raised.value.status == mln.MaplibreStatus.UNSUPPORTED
+                            # The rejection left the session usable.
+                            session.render_update()
+                        finally:
+                            session.close()

--- a/bindings/python/tests/test_render_metal_owned.py
+++ b/bindings/python/tests/test_render_metal_owned.py
@@ -157,6 +157,44 @@ def wait_for_metal_frame(
     raise AssertionError(f"matching Metal frame was not observed; last={last_frame!r}")
 
 
+def set_target_calls(
+    session: render.RenderSessionHandle,
+) -> tuple[Callable[[], object], ...]:
+    """Return one `set_*_target` call per backend and target kind.
+
+    Every descriptor here names null backend handles, which is all these tests
+    need: the acquired-frame guard and the session's owner thread are both
+    checked before any handle is read.
+    """
+    extent = render.RenderTargetExtent(16, 16, 1.0)
+    return (
+        lambda: session.set_metal_surface_target(
+            render.MetalSurfaceDescriptor(extent=extent)
+        ),
+        lambda: session.set_vulkan_surface_target(
+            render.VulkanSurfaceDescriptor(extent=extent)
+        ),
+        lambda: session.set_opengl_surface_target(
+            render.OpenGLSurfaceDescriptor(extent=extent)
+        ),
+        lambda: session.set_metal_borrowed_texture_target(
+            render.MetalBorrowedTextureDescriptor(
+                extent=extent, physical_width=16, physical_height=16
+            )
+        ),
+        lambda: session.set_vulkan_borrowed_texture_target(
+            render.VulkanBorrowedTextureDescriptor(
+                extent=extent, physical_width=16, physical_height=16
+            )
+        ),
+        lambda: session.set_opengl_borrowed_texture_target(
+            render.OpenGLBorrowedTextureDescriptor(
+                extent=extent, physical_width=16, physical_height=16
+            )
+        ),
+    )
+
+
 def assert_invalid_state(call: Callable[[], object]) -> None:
     with pytest.raises(mln.InvalidStateError) as raised:
         call()
@@ -360,6 +398,7 @@ def test_active_metal_frame_rejects_nested_acquire_and_session_operations(
         lambda: metal_owned_session.session.get_feature_state(selector),
         lambda: metal_owned_session.session.remove_feature_state(selector),
         metal_owned_session.session.close,
+        *set_target_calls(metal_owned_session.session),
     )
     try:
         for call in calls:
@@ -401,6 +440,7 @@ def test_real_metal_render_session_reports_wrong_thread_errors(
         metal_owned_session.session.render_update,
         metal_owned_session.session.acquire_metal_owned_texture_frame,
         metal_owned_session.session.close,
+        *set_target_calls(metal_owned_session.session),
     )
 
     for call in calls:
@@ -420,6 +460,30 @@ def test_real_metal_render_session_reports_wrong_thread_errors(
         assert isinstance(observed[0], mln.WrongThreadError)
         assert observed[0].status == mln.MaplibreStatus.WRONG_THREAD
         assert not metal_owned_session.session.closed
+
+
+def test_set_target_reports_unsupported_for_a_session_owned_texture(
+    metal_owned_session: MetalOwnedSession,
+) -> None:
+    """Spec coverage: BND-176.
+
+    A session-owned texture is sized and replaced by its session, so it takes a
+    resize rather than a replacement. The session's target kind is checked
+    before the descriptor, so the null texture below is never read.
+    """
+    with pytest.raises(mln.UnsupportedFeatureError) as raised:
+        metal_owned_session.session.set_metal_borrowed_texture_target(
+            render.MetalBorrowedTextureDescriptor(
+                extent=render.RenderTargetExtent(32, 16, 1.0),
+                physical_width=32,
+                physical_height=16,
+            )
+        )
+    assert raised.value.status == mln.MaplibreStatus.UNSUPPORTED
+
+    # The rejection left the session rendering into the texture it owns.
+    metal_owned_session.session.resize(32, 16, 1.0)
+    metal_owned_session.render_once()
 
 
 def test_cluster_feature_extension_queries_resolve_unsigned_cluster_id_and_limit(

--- a/bindings/python/tests/test_render_opengl_egl.py
+++ b/bindings/python/tests/test_render_opengl_egl.py
@@ -13,6 +13,7 @@ from maplibre_native import camera, geo, json, query, render
 
 from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
+    RED_BACKGROUND_STYLE_JSON,
     assert_cluster_feature_extensions,
     assert_typed_geojson_cluster_source,
     render_until,
@@ -611,7 +612,7 @@ def test_egl_borrowed_texture_set_target_hands_over_a_replacement() -> None:
                 ) as map_handle:
                     session = map_handle.attach_opengl_borrowed_texture(descriptor)
                     try:
-                        map_handle.set_style_json(EMPTY_STYLE_JSON)
+                        map_handle.set_style_json(RED_BACKGROUND_STYLE_JSON)
                         render_until_update(runtime, session)
 
                         with pytest.raises(mln.UnsupportedFeatureError) as raised:
@@ -621,6 +622,10 @@ def test_egl_borrowed_texture_set_target_hands_over_a_replacement() -> None:
                         with _egl_borrowed_texture(
                             context, width=48, height=24
                         ) as replacement:
+                            # Freshly allocated, so anything drawn into it
+                            # later came from this session after the handoff.
+                            assert not any(replacement.read_rgba())
+
                             # The C API replaces the target on the calling
                             # thread, so the host context is current for it.
                             context.make_current(replacement.surface)
@@ -631,16 +636,18 @@ def test_egl_borrowed_texture_set_target_hands_over_a_replacement() -> None:
                             finally:
                                 context.clear_current()
 
-                            # The session kept its renderer and renders at the
-                            # extent it was handed, once the map catches up.
+                            # The session kept its renderer and paints the
+                            # texture it was handed, at the extent handed with
+                            # it, once the map catches up.
                             render_until(
                                 runtime,
                                 session,
                                 lambda: (
                                     map_handle.get_size()
                                     == (48, 24, pytest.approx(1.0))
+                                    and any(replacement.read_rgba())
                                 ),
-                                "the map never took the replacement texture extent",
+                                "the replacement texture was never rendered into",
                             )
                             assert session.render_update()
 

--- a/bindings/python/tests/test_render_opengl_egl.py
+++ b/bindings/python/tests/test_render_opengl_egl.py
@@ -15,6 +15,7 @@ from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
     assert_cluster_feature_extensions,
     assert_typed_geojson_cluster_source,
+    render_until,
     render_until_update,
     skip_or_fail_fixture_setup,
 )
@@ -154,9 +155,14 @@ def _egl_pbuffer_surface(context: EglContext) -> Iterator[EglPbufferSurface]:
 
 
 @contextmanager
-def _egl_borrowed_texture(context: EglContext) -> Iterator[EglBorrowedTexture]:
+def _egl_borrowed_texture(
+    context: EglContext,
+    *,
+    width: int = 32,
+    height: int = 16,
+) -> Iterator[EglBorrowedTexture]:
     try:
-        texture = context.borrowed_texture(width=32, height=16)
+        texture = context.borrowed_texture(width=width, height=height)
     except EglUnavailableError as error:
         skip_or_fail_fixture_setup(
             f"EGL texture fixture creation is unavailable: {error}",
@@ -583,6 +589,82 @@ def test_egl_borrowed_texture_session_close_preserves_caller_resources() -> None
             assert _borrowed_descriptor_snapshot(replacement_descriptor) == (
                 before_descriptor
             )
+
+
+def test_egl_borrowed_texture_set_target_hands_over_a_replacement() -> None:
+    """Spec coverage: BND-175, BND-176.
+
+    A caller-owned texture is sized by its owner, so a host that follows a
+    resize allocates a texture at the new size and hands it over instead of
+    resizing this session.
+    """
+    with _egl_context() as context:
+        with _egl_borrowed_texture(context) as texture:
+            descriptor = texture.descriptor()
+
+            with mln.RuntimeHandle() as runtime:
+                with runtime.create_map(
+                    mln.MapOptions(
+                        width=descriptor.extent.width,
+                        height=descriptor.extent.height,
+                    )
+                ) as map_handle:
+                    session = map_handle.attach_opengl_borrowed_texture(descriptor)
+                    try:
+                        map_handle.set_style_json(EMPTY_STYLE_JSON)
+                        render_until_update(runtime, session)
+
+                        with pytest.raises(mln.UnsupportedFeatureError) as raised:
+                            session.resize(48, 24, 1.0)
+                        assert raised.value.status == mln.MaplibreStatus.UNSUPPORTED
+
+                        with _egl_borrowed_texture(
+                            context, width=48, height=24
+                        ) as replacement:
+                            # The C API replaces the target on the calling
+                            # thread, so the host context is current for it.
+                            context.make_current(replacement.surface)
+                            try:
+                                session.set_opengl_borrowed_texture_target(
+                                    replacement.descriptor()
+                                )
+                            finally:
+                                context.clear_current()
+
+                            # The session kept its renderer and renders at the
+                            # extent it was handed, once the map catches up.
+                            render_until(
+                                runtime,
+                                session,
+                                lambda: (
+                                    map_handle.get_size()
+                                    == (48, 24, pytest.approx(1.0))
+                                ),
+                                "the map never took the replacement texture extent",
+                            )
+                            assert session.render_update()
+
+                            # Both textures belong to their owner: the session
+                            # neither released the outgoing one nor took over
+                            # the replacement's lifetime.
+                            assert texture.exists()
+                            assert replacement.exists()
+
+                            # A surface descriptor names a target this session
+                            # does not have.
+                            with pytest.raises(mln.UnsupportedFeatureError) as raised:
+                                session.set_opengl_surface_target(
+                                    render.OpenGLSurfaceDescriptor(
+                                        extent=replacement.descriptor().extent,
+                                        context=context.descriptor(),
+                                        surface=render.NativePointer(0x1),
+                                    )
+                                )
+                            assert raised.value.status == mln.MaplibreStatus.UNSUPPORTED
+                            # The rejection left the session usable.
+                            session.render_update()
+                    finally:
+                        session.close()
 
 
 def test_cluster_feature_extension_queries_resolve_unsigned_cluster_id_and_limit(

--- a/bindings/python/tests/test_render_vulkan_attach.py
+++ b/bindings/python/tests/test_render_vulkan_attach.py
@@ -186,8 +186,9 @@ def test_vulkan_borrowed_texture_set_target_hands_over_a_replacement() -> None:
     This verifies that the handoff is accepted, that the map takes the extent
     handed with it, and that the session stays usable. It does not read the
     replacement back — the Vulkan helper has no staging-buffer readback — so
-    the proof that pixels land in the replacement image is the Zig binding's
-    equivalent test, which does.
+    nothing here proves pixels land in the replacement image. No binding covers
+    that for Vulkan yet; the Metal and OpenGL replacement tests do cover it for
+    their backends.
     """
     _require_native_vulkan_support()
 

--- a/bindings/python/tests/test_render_vulkan_attach.py
+++ b/bindings/python/tests/test_render_vulkan_attach.py
@@ -10,6 +10,7 @@ from maplibre_native import render
 
 from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
+    render_until,
     render_until_update,
     skip_or_fail_fixture_setup,
 )
@@ -55,9 +56,14 @@ def _vulkan_context() -> Iterator[VulkanContext]:
 
 
 @contextmanager
-def _vulkan_borrowed_image(context: VulkanContext) -> Iterator[VulkanBorrowedImage]:
+def _vulkan_borrowed_image(
+    context: VulkanContext,
+    *,
+    width: int = 64,
+    height: int = 64,
+) -> Iterator[VulkanBorrowedImage]:
     try:
-        image = context.borrowed_image(width=64, height=64)
+        image = context.borrowed_image(width=width, height=height)
     except VulkanUnavailableError as error:
         skip_or_fail_fixture_setup(
             f"Vulkan borrowed-image fixture creation is unavailable: {error}",
@@ -168,3 +174,70 @@ def test_vulkan_borrowed_texture_session_close_preserves_caller_resources() -> N
 
             replacement_descriptor = image.descriptor()
             assert _descriptor_snapshot(replacement_descriptor) == before_descriptor
+
+
+def test_vulkan_borrowed_texture_set_target_hands_over_a_replacement() -> None:
+    """Spec coverage: BND-175, BND-176.
+
+    A caller-owned image is sized by its owner, so a host that follows a resize
+    allocates an image at the new size and hands it over instead of resizing
+    this session.
+    """
+    _require_native_vulkan_support()
+
+    with _vulkan_context() as context:
+        with _vulkan_borrowed_image(context) as image:
+            descriptor = image.descriptor()
+
+            with mln.RuntimeHandle() as runtime:
+                with runtime.create_map(
+                    mln.MapOptions(
+                        width=descriptor.extent.width,
+                        height=descriptor.extent.height,
+                    )
+                ) as map_handle:
+                    session = map_handle.attach_vulkan_borrowed_texture(descriptor)
+                    try:
+                        map_handle.set_style_json(EMPTY_STYLE_JSON)
+                        render_until_update(runtime, session)
+
+                        with pytest.raises(mln.UnsupportedFeatureError) as raised:
+                            session.resize(48, 24, 1.0)
+                        assert raised.value.status == mln.MaplibreStatus.UNSUPPORTED
+
+                        with _vulkan_borrowed_image(
+                            context, width=48, height=24
+                        ) as replacement:
+                            replacement_descriptor = replacement.descriptor()
+                            session.set_vulkan_borrowed_texture_target(
+                                replacement_descriptor
+                            )
+
+                            # The session kept its renderer and renders at the
+                            # extent it was handed, once the map catches up.
+                            render_until(
+                                runtime,
+                                session,
+                                lambda: (
+                                    map_handle.get_size()
+                                    == (48, 24, pytest.approx(1.0))
+                                ),
+                                "the map never took the replacement image extent",
+                            )
+                            assert session.render_update()
+
+                            # A surface descriptor names a target this session
+                            # does not have.
+                            with pytest.raises(mln.UnsupportedFeatureError) as raised:
+                                session.set_vulkan_surface_target(
+                                    render.VulkanSurfaceDescriptor(
+                                        extent=replacement_descriptor.extent,
+                                        context=context.descriptor(),
+                                        surface=render.NativePointer(0x1),
+                                    )
+                                )
+                            assert raised.value.status == mln.MaplibreStatus.UNSUPPORTED
+                            # The rejection left the session usable.
+                            session.render_update()
+                    finally:
+                        session.close()

--- a/bindings/python/tests/test_render_vulkan_attach.py
+++ b/bindings/python/tests/test_render_vulkan_attach.py
@@ -182,6 +182,12 @@ def test_vulkan_borrowed_texture_set_target_hands_over_a_replacement() -> None:
     A caller-owned image is sized by its owner, so a host that follows a resize
     allocates an image at the new size and hands it over instead of resizing
     this session.
+
+    This verifies that the handoff is accepted, that the map takes the extent
+    handed with it, and that the session stays usable. It does not read the
+    replacement back — the Vulkan helper has no staging-buffer readback — so
+    the proof that pixels land in the replacement image is the Zig binding's
+    equivalent test, which does.
     """
     _require_native_vulkan_support()
 

--- a/bindings/rust/crates/maplibre-native/src/render.rs
+++ b/bindings/rust/crates/maplibre-native/src/render.rs
@@ -1329,7 +1329,9 @@ impl RenderSessionHandle {
     /// resize reallocates rather than resizing and [`RenderSessionHandle::resize`]
     /// reports an unsupported-feature error. Handing the replacement over here
     /// keeps this session's renderer instead, so the map does not go cold on
-    /// every resize.
+    /// every resize — unless the scale factor changes, which starts a new
+    /// renderer for the new pixel ratio, as [`RenderSessionHandle::resize`]
+    /// does.
     ///
     /// The replacement belongs to the device this session attached with, which
     /// reports an invalid-argument error otherwise, and carries the pixel

--- a/bindings/rust/crates/maplibre-native/src/render.rs
+++ b/bindings/rust/crates/maplibre-native/src/render.rs
@@ -1338,8 +1338,8 @@ impl RenderSessionHandle {
     /// format it attached with, which reports an unsupported-feature error
     /// otherwise. Both leave this session rendering into the texture it has. The caller owns the replacement and keeps it valid until
     /// the next replacement, detach, or close. This session never retained the
-    /// outgoing texture and never releases it, but reads from it during this
-    /// call, so keep it valid until the call returns.
+    /// outgoing texture, never releases it, and never reads it here, so a host
+    /// that already released it hands over the replacement all the same.
     pub fn set_metal_borrowed_texture_target(
         &self,
         descriptor: &MetalBorrowedTextureDescriptor,

--- a/bindings/rust/crates/maplibre-native/src/render.rs
+++ b/bindings/rust/crates/maplibre-native/src/render.rs
@@ -1257,9 +1257,11 @@ impl RenderSessionHandle {
     /// session. A map holds at most one attached session, so close before
     /// attaching the replacement.
     ///
-    /// Resizing discards the session renderer, so renderer-held state such as
-    /// feature state does not survive. Map state such as camera, style, and
-    /// sources lives on the map and survives both resize and reattach.
+    /// The session keeps its renderer across a resize, so renderer-held state
+    /// such as feature state carries over. A scale factor change is the
+    /// exception: a renderer compiles its shaders for one pixel ratio, so that
+    /// resize starts a new one with renderer-held state empty. Map state such as
+    /// camera, style, and sources lives on the map and survives either way.
     pub fn resize(&self, width: u32, height: u32, scale_factor: f64) -> Result<()> {
         self.inner.ensure_no_frame_acquired()?;
         let session = self.inner.native()?;

--- a/bindings/rust/crates/maplibre-native/src/render.rs
+++ b/bindings/rust/crates/maplibre-native/src/render.rs
@@ -1281,11 +1281,11 @@ impl RenderSessionHandle {
     /// and feature state.
     ///
     /// The descriptor names the same graphics context this session attached
-    /// with, and its extent applies as a resize does. A target on a different
-    /// context reports an invalid-argument error, and one this session's
-    /// compiled state cannot serve reports an unsupported-feature error. Both
-    /// leave this session rendering into the surface it has; close it and
-    /// attach again to take that target.
+    /// with, and its extent applies as a resize does. A layer on a different
+    /// device reports an invalid-argument error and leaves this session
+    /// rendering into the surface it has; close it and attach again to take
+    /// that one. The session sets the layer's pixel format itself, so there is
+    /// nothing else here for a replacement to mismatch.
     pub fn set_metal_surface_target(&self, descriptor: &MetalSurfaceDescriptor) -> Result<()> {
         self.set_target(descriptor.to_native(), |session, raw| {
             // SAFETY: session is a live render session handle owned by this

--- a/bindings/rust/crates/maplibre-native/src/render.rs
+++ b/bindings/rust/crates/maplibre-native/src/render.rs
@@ -1253,9 +1253,9 @@ impl RenderSessionHandle {
     ///
     /// Surface and owned-texture sessions resize in place. Borrowed texture
     /// targets are sized by their owner and report an unsupported-feature
-    /// error: close this session, recreate the texture, and attach a new
-    /// session. A map holds at most one attached session, so close before
-    /// attaching the replacement.
+    /// error: allocate a texture at the new size and hand it over with the
+    /// `set_*_borrowed_texture_target` method for the backend, which keeps this
+    /// session.
     ///
     /// The session keeps its renderer across a resize, so renderer-held state
     /// such as feature state carries over. A scale factor change is the
@@ -1269,6 +1269,131 @@ impl RenderSessionHandle {
         maplibre_core::check(unsafe {
             sys::mln_render_session_resize(session, width, height, scale_factor)
         })
+    }
+
+    /// Presents this attached surface session through a new surface.
+    ///
+    /// A host surface can be destroyed and recreated while the map goes on
+    /// living, which is what Android rotation, a Flutter `SurfaceProducer`
+    /// lifecycle change, and a window resize that reallocates all look like
+    /// from here. Replacing the surface in place keeps this session's renderer,
+    /// and with it the tile pyramid, glyph and image atlases, symbol placement,
+    /// and feature state.
+    ///
+    /// The descriptor names the same graphics context this session attached
+    /// with, and its extent applies as a resize does. A target on a different
+    /// context, or one this session's compiled state cannot serve, reports an
+    /// unsupported-feature error with this session still rendering into the
+    /// surface it has; close it and attach again to take that one.
+    pub fn set_metal_surface_target(&self, descriptor: &MetalSurfaceDescriptor) -> Result<()> {
+        self.set_target(descriptor.to_native(), |session, raw| {
+            // SAFETY: session is a live render session handle owned by this
+            // wrapper, and raw is a materialized descriptor valid for this call.
+            unsafe { sys::mln_metal_surface_set_target(session, raw) }
+        })
+    }
+
+    /// Presents this attached surface session through a new surface.
+    ///
+    /// See [`RenderSessionHandle::set_metal_surface_target`] for what replacing
+    /// a surface preserves. The outgoing `VkSurfaceKHR` must still be valid:
+    /// this session holds a swapchain built from it, and Vulkan destroys every
+    /// swapchain before its surface.
+    pub fn set_vulkan_surface_target(&self, descriptor: &VulkanSurfaceDescriptor) -> Result<()> {
+        self.set_target(descriptor.to_native(), |session, raw| {
+            // SAFETY: session is a live render session handle owned by this
+            // wrapper, and raw is a materialized descriptor valid for this call.
+            unsafe { sys::mln_vulkan_surface_set_target(session, raw) }
+        })
+    }
+
+    /// Presents this attached surface session through a new surface.
+    ///
+    /// See [`RenderSessionHandle::set_metal_surface_target`] for what replacing
+    /// a surface preserves. The new surface is made current on the next render,
+    /// so a host may hand over a replacement for one it has already destroyed.
+    /// A surface accepted here can still prove unusable, which the next
+    /// `render_update` reports rather than this call.
+    pub fn set_opengl_surface_target(&self, descriptor: &OpenGLSurfaceDescriptor) -> Result<()> {
+        self.set_target(descriptor.to_native(), |session, raw| {
+            // SAFETY: session is a live render session handle owned by this
+            // wrapper, and raw is a materialized descriptor valid for this call.
+            unsafe { sys::mln_opengl_surface_set_target(session, raw) }
+        })
+    }
+
+    /// Renders this attached texture session into a new caller-owned texture.
+    ///
+    /// A caller-owned texture is sized by its owner, so a host that follows a
+    /// resize reallocates rather than resizing and [`RenderSessionHandle::resize`]
+    /// reports an unsupported-feature error. Handing the replacement over here
+    /// keeps this session's renderer instead, so the map does not go cold on
+    /// every resize.
+    ///
+    /// The replacement belongs to the device this session attached with and
+    /// carries the pixel format it attached with; one that does not reports an
+    /// unsupported-feature error with this session still rendering into the
+    /// texture it has. The caller owns the replacement and keeps it valid until
+    /// the next replacement, detach, or close. This session never retained the
+    /// outgoing texture and never releases it, but reads from it during this
+    /// call, so keep it valid until the call returns.
+    pub fn set_metal_borrowed_texture_target(
+        &self,
+        descriptor: &MetalBorrowedTextureDescriptor,
+    ) -> Result<()> {
+        self.set_target(descriptor.to_native(), |session, raw| {
+            // SAFETY: session is a live render session handle owned by this
+            // wrapper, and raw is a materialized descriptor valid for this call.
+            unsafe { sys::mln_metal_borrowed_texture_set_target(session, raw) }
+        })
+    }
+
+    /// Renders this attached texture session into a new caller-owned image.
+    ///
+    /// See [`RenderSessionHandle::set_metal_borrowed_texture_target`] for what
+    /// replacing a target preserves. The replacement carries the format and
+    /// both layouts this session attached with, since its render pass was built
+    /// around them.
+    pub fn set_vulkan_borrowed_texture_target(
+        &self,
+        descriptor: &VulkanBorrowedTextureDescriptor,
+    ) -> Result<()> {
+        self.set_target(descriptor.to_native(), |session, raw| {
+            // SAFETY: session is a live render session handle owned by this
+            // wrapper, and raw is a materialized descriptor valid for this call.
+            unsafe { sys::mln_vulkan_borrowed_texture_set_target(session, raw) }
+        })
+    }
+
+    /// Renders this attached texture session into a new caller-owned texture.
+    ///
+    /// See [`RenderSessionHandle::set_metal_borrowed_texture_target`] for what
+    /// replacing a target preserves. The replacement belongs to the context
+    /// this session attached with, or one in its share group, and the host
+    /// context must be current on this thread.
+    pub fn set_opengl_borrowed_texture_target(
+        &self,
+        descriptor: &OpenGLBorrowedTextureDescriptor,
+    ) -> Result<()> {
+        self.set_target(descriptor.to_native(), |session, raw| {
+            // SAFETY: session is a live render session handle owned by this
+            // wrapper, and raw is a materialized descriptor valid for this call.
+            unsafe { sys::mln_opengl_borrowed_texture_set_target(session, raw) }
+        })
+    }
+
+    /// Shared body for the `set_*_target` methods.
+    ///
+    /// The native descriptor is materialized by the caller and lives for the
+    /// duration of `set_target`, which is all the C API borrows it for.
+    fn set_target<D>(
+        &self,
+        raw: D,
+        set_target: impl FnOnce(sys::mln_render_session, &D) -> sys::mln_status,
+    ) -> Result<()> {
+        self.inner.ensure_no_frame_acquired()?;
+        let session = self.inner.native()?;
+        maplibre_core::check(set_target(session, &raw))
     }
 
     /// Processes the latest map render update for this render target.

--- a/bindings/rust/crates/maplibre-native/src/render.rs
+++ b/bindings/rust/crates/maplibre-native/src/render.rs
@@ -1281,11 +1281,11 @@ impl RenderSessionHandle {
     /// and feature state.
     ///
     /// The descriptor names the same graphics context this session attached
-    /// with, and its extent applies as a resize does. A layer on a different
-    /// device reports an invalid-argument error and leaves this session
-    /// rendering into the surface it has; close it and attach again to take
-    /// that one. The session sets the layer's pixel format itself, so there is
-    /// nothing else here for a replacement to mismatch.
+    /// with, and its extent applies as a resize does. A descriptor whose
+    /// `context.device` is neither null nor this session's device reports an
+    /// invalid-argument error and leaves this session rendering into the
+    /// surface it has. The session assigns the layer its own device and pixel
+    /// format, so the layer itself carries nothing that has to match.
     pub fn set_metal_surface_target(&self, descriptor: &MetalSurfaceDescriptor) -> Result<()> {
         self.set_target(descriptor.to_native(), |session, raw| {
             // SAFETY: session is a live render session handle owned by this

--- a/bindings/rust/crates/maplibre-native/src/render.rs
+++ b/bindings/rust/crates/maplibre-native/src/render.rs
@@ -1282,9 +1282,10 @@ impl RenderSessionHandle {
     ///
     /// The descriptor names the same graphics context this session attached
     /// with, and its extent applies as a resize does. A target on a different
-    /// context, or one this session's compiled state cannot serve, reports an
-    /// unsupported-feature error with this session still rendering into the
-    /// surface it has; close it and attach again to take that one.
+    /// context reports an invalid-argument error, and one this session's
+    /// compiled state cannot serve reports an unsupported-feature error. Both
+    /// leave this session rendering into the surface it has; close it and
+    /// attach again to take that target.
     pub fn set_metal_surface_target(&self, descriptor: &MetalSurfaceDescriptor) -> Result<()> {
         self.set_target(descriptor.to_native(), |session, raw| {
             // SAFETY: session is a live render session handle owned by this
@@ -1330,10 +1331,10 @@ impl RenderSessionHandle {
     /// keeps this session's renderer instead, so the map does not go cold on
     /// every resize.
     ///
-    /// The replacement belongs to the device this session attached with and
-    /// carries the pixel format it attached with; one that does not reports an
-    /// unsupported-feature error with this session still rendering into the
-    /// texture it has. The caller owns the replacement and keeps it valid until
+    /// The replacement belongs to the device this session attached with, which
+    /// reports an invalid-argument error otherwise, and carries the pixel
+    /// format it attached with, which reports an unsupported-feature error
+    /// otherwise. Both leave this session rendering into the texture it has. The caller owns the replacement and keeps it valid until
     /// the next replacement, detach, or close. This session never retained the
     /// outgoing texture and never releases it, but reads from it during this
     /// call, so keep it valid until the call returns.

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -961,6 +961,10 @@ impl OpenGLBorrowedTexture {
                 glow::TEXTURE_MAG_FILTER,
                 glow::NEAREST as i32,
             );
+            // Zeroed rather than left undefined: a test that reads this back
+            // to prove the session rendered into it needs a known starting
+            // value, or undefined contents could pass for a rendered frame.
+            let blank = vec![0_u8; (width as usize) * (height as usize) * 4];
             context.gl.tex_image_2d(
                 glow::TEXTURE_2D,
                 0,
@@ -970,7 +974,7 @@ impl OpenGLBorrowedTexture {
                 0,
                 glow::RGBA,
                 glow::UNSIGNED_BYTE,
-                glow::PixelUnpackData::Slice(None),
+                glow::PixelUnpackData::Slice(Some(&blank)),
             );
             context.gl.bind_texture(glow::TEXTURE_2D, None);
             texture
@@ -1705,13 +1709,25 @@ fn set_target_hands_a_live_session_a_new_borrowed_texture() {
 
     // The session stayed live across the replacement and renders into the
     // texture it was just given, once the map has caught up to the new size.
+    // QUERY_STYLE_JSON paints this background over every pixel it covers, so
+    // finding it in a texture that started zeroed means this session rendered
+    // into the one it was handed.
+    const QUERY_STYLE_BACKGROUND_RGBA: [u8; 4] = [0xd8, 0xf1, 0xff, 0xff];
+    assert!(
+        texture.read_rgba().unwrap().iter().all(|byte| *byte == 0),
+        "a freshly allocated replacement should start blank"
+    );
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut rendered_into_replacement = false;
     while Instant::now() < deadline && !rendered_into_replacement {
         let _ = runtime.pump(Some(Duration::ZERO));
         while let Ok(Some(_)) = runtime.poll_event() {}
         if session.render_update().unwrap() {
-            rendered_into_replacement = texture.read_rgba().unwrap().iter().any(|byte| *byte != 0);
+            rendered_into_replacement = texture
+                .read_rgba()
+                .unwrap()
+                .chunks_exact(4)
+                .any(|pixel| pixel == QUERY_STYLE_BACKGROUND_RGBA);
         }
         std::thread::sleep(Duration::from_millis(1));
     }
@@ -1743,6 +1759,43 @@ fn set_target_reports_unsupported_for_a_session_owned_texture() {
     // would answer in place of the target-kind rejection under test.
     let error = context
         .set_placeholder_borrowed_target(&session, &extent)
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+
+    // The rejection left the session usable.
+    assert!(session.render_update().is_ok());
+
+    session.close().unwrap();
+    map.close().unwrap();
+    runtime.close().unwrap();
+}
+
+#[test]
+// Spec coverage: BND-176.
+fn set_target_reports_unsupported_for_a_session_owned_opengl_texture() {
+    // The Metal and Vulkan case is covered by the test above, whose owned
+    // texture fixture supports only those two backends. OpenGL has its own
+    // owned texture fixture, so an OpenGL-only build covers the same rejection
+    // here rather than skipping it.
+    if !has_opengl_test_context_backend() {
+        return;
+    }
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::new(64, 64, 1.0)).unwrap();
+    let extent = RenderTargetExtent::new(64, 64, 1.0);
+    let (context, session) =
+        create_opengl_owned_texture_session(&map.attach_ref().unwrap(), extent.clone())
+            .expect("OpenGL owned texture test session should attach when OpenGL is supported");
+
+    let error = session
+        .set_opengl_borrowed_texture_target(&OpenGLBorrowedTextureDescriptor::new(
+            extent,
+            64,
+            64,
+            context.descriptor(),
+            1,
+            glow::TEXTURE_2D,
+        ))
         .unwrap_err();
     assert_eq!(error.kind(), ErrorKind::Unsupported);
 

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -901,6 +901,20 @@ struct OpenGLBorrowedTexture {
 impl OpenGLBorrowedTexture {
     fn new(width: u32, height: u32) -> std::result::Result<Self, Box<dyn StdError>> {
         let context = OpenGLTestContext::new(width, height)?;
+        let texture = Self::create_texture(&context, width, height)?;
+        Ok(Self {
+            context,
+            texture: Some(texture),
+            width,
+            height,
+        })
+    }
+
+    fn create_texture(
+        context: &OpenGLTestContext,
+        width: u32,
+        height: u32,
+    ) -> std::result::Result<glow::NativeTexture, Box<dyn StdError>> {
         context.make_current()?;
         let texture = unsafe {
             let texture = context.gl.create_texture()?;
@@ -930,12 +944,39 @@ impl OpenGLBorrowedTexture {
             texture
         };
         context.check_gl_error("create borrowed texture")?;
-        Ok(Self {
-            context,
-            texture: Some(texture),
-            width,
-            height,
-        })
+        Ok(texture)
+    }
+
+    /// Allocates a replacement in this helper's own context, the way a host that
+    /// reallocates on resize does. The outgoing texture stays live so the caller
+    /// can hand the replacement over before releasing it.
+    fn allocate_replacement(
+        &self,
+        width: u32,
+        height: u32,
+    ) -> std::result::Result<glow::NativeTexture, Box<dyn StdError>> {
+        Self::create_texture(&self.context, width, height)
+    }
+
+    /// Tracks a replacement the session has taken and releases the outgoing one.
+    fn adopt(
+        &mut self,
+        texture: glow::NativeTexture,
+        width: u32,
+        height: u32,
+    ) -> std::result::Result<(), Box<dyn StdError>> {
+        let previous = self.texture.replace(texture);
+        self.width = width;
+        self.height = height;
+        if let Some(previous) = previous {
+            self.context.make_current()?;
+            unsafe {
+                self.context.gl.delete_texture(previous);
+            }
+            self.context
+                .check_gl_error("delete replaced borrowed texture")?;
+        }
+        Ok(())
     }
 
     fn descriptor(&self) -> OpenGLContextDescriptor {
@@ -1575,6 +1616,149 @@ fn opengl_borrowed_texture_session_renders_with_platform_context() {
     session.close().unwrap();
     let pixels_after_close = texture.read_rgba().unwrap();
     assert!(pixels_after_close.iter().any(|byte| *byte != 0));
+    map.close().unwrap();
+    runtime.close().unwrap();
+}
+
+#[test]
+// Spec coverage: BND-175.
+fn set_target_hands_a_live_session_a_new_borrowed_texture() {
+    if !has_opengl_test_context_backend() {
+        return;
+    }
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::new(128, 128, 1.0)).unwrap();
+
+    let initial_extent = RenderTargetExtent::new(128, 128, 1.0);
+    let (mut texture, session) =
+        create_opengl_borrowed_texture_session(&map.attach_ref().unwrap(), initial_extent)
+            .expect("OpenGL borrowed texture test session should attach when OpenGL is supported");
+
+    map.set_style_json(QUERY_STYLE_JSON).unwrap();
+    assert!(wait_for_runtime_event(
+        &runtime,
+        RuntimeEventType::MapRenderUpdateAvailable
+    ));
+    assert!(session.render_update().unwrap());
+
+    // A caller-owned texture is sized by its owner, so resizing is not the way
+    // to follow a host that changed size.
+    let resized_extent = RenderTargetExtent::new(96, 64, 1.0);
+    let resize_error = session
+        .resize(
+            resized_extent.width,
+            resized_extent.height,
+            resized_extent.scale_factor,
+        )
+        .unwrap_err();
+    assert_eq!(resize_error.kind(), ErrorKind::Unsupported);
+
+    let (physical_width, physical_height) = resized_extent.physical_size().unwrap();
+    let replacement = texture
+        .allocate_replacement(physical_width, physical_height)
+        .unwrap();
+    session
+        .set_opengl_borrowed_texture_target(&OpenGLBorrowedTextureDescriptor::new(
+            resized_extent.clone(),
+            physical_width,
+            physical_height,
+            texture.descriptor(),
+            replacement.0.get(),
+            glow::TEXTURE_2D,
+        ))
+        .unwrap();
+    texture
+        .adopt(replacement, physical_width, physical_height)
+        .unwrap();
+
+    // The session stayed live across the replacement and renders into the
+    // texture it was just given, once the map has caught up to the new size.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut rendered_into_replacement = false;
+    while Instant::now() < deadline && !rendered_into_replacement {
+        let _ = runtime.pump(Some(Duration::ZERO));
+        while let Ok(Some(_)) = runtime.poll_event() {}
+        if session.render_update().unwrap() {
+            rendered_into_replacement = texture.read_rgba().unwrap().iter().any(|byte| *byte != 0);
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    assert!(
+        rendered_into_replacement,
+        "the session should render into the texture it was handed"
+    );
+
+    session.close().unwrap();
+    map.close().unwrap();
+    runtime.close().unwrap();
+}
+
+#[test]
+// Spec coverage: BND-176.
+fn set_target_reports_unsupported_for_a_session_owned_texture() {
+    if !has_test_owned_texture_session_backend() {
+        return;
+    }
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::new(64, 64, 1.0)).unwrap();
+    let extent = RenderTargetExtent::new(64, 64, 1.0);
+    let (_context, session) =
+        create_owned_texture_session(&map.attach_ref().unwrap(), extent.clone())
+            .expect("Metal or Vulkan owned texture test session should attach when supported");
+
+    // A session-owned texture is sized and replaced by its session. The session
+    // is checked before the descriptor, so this reports the target kind rather
+    // than the placeholder handle below, which is never dereferenced.
+    let error = session
+        .set_metal_borrowed_texture_target(&MetalBorrowedTextureDescriptor::new(
+            extent,
+            64,
+            64,
+            // SAFETY: Test passes an opaque non-null address that the rejected
+            // call never dereferences.
+            unsafe { NativePointer::from_address(0x1) },
+        ))
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+
+    // The rejection left the session usable.
+    assert!(session.render_update().is_ok());
+
+    session.close().unwrap();
+    map.close().unwrap();
+    runtime.close().unwrap();
+}
+
+#[test]
+// Spec coverage: BND-176.
+fn set_target_reports_unsupported_for_a_target_kind_the_session_does_not_have() {
+    if !has_opengl_test_context_backend() {
+        return;
+    }
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::new(64, 64, 1.0)).unwrap();
+
+    let extent = RenderTargetExtent::new(64, 64, 1.0);
+    let (texture, session) =
+        create_opengl_borrowed_texture_session(&map.attach_ref().unwrap(), extent.clone())
+            .expect("OpenGL borrowed texture test session should attach when OpenGL is supported");
+
+    // A surface descriptor names a target this session does not have.
+    let error = session
+        .set_opengl_surface_target(&OpenGLSurfaceDescriptor::new(
+            extent.clone(),
+            texture.descriptor(),
+            // SAFETY: Test passes an opaque non-null address that the rejected
+            // call never dereferences.
+            unsafe { NativePointer::from_address(0x1) },
+        ))
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+
+    // The rejected call left the session usable.
+    assert!(session.render_update().is_ok());
+
+    session.close().unwrap();
     map.close().unwrap();
     runtime.close().unwrap();
 }

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -173,6 +173,38 @@ impl OwnedTextureTestContext {
         }
     }
 
+    /// Hands the session a placeholder replacement of this context's own
+    /// backend. The session's kind is checked before the descriptor, so the
+    /// placeholder handle is never dereferenced — but the setter has to match
+    /// the backend, or an unsupported build would answer instead of the kind.
+    fn set_placeholder_borrowed_target(
+        &self,
+        session: &RenderSessionHandle,
+        extent: &RenderTargetExtent,
+    ) -> Result<()> {
+        // SAFETY: Test passes an opaque non-null address that the rejected call
+        // never dereferences.
+        let placeholder = unsafe { NativePointer::from_address(0x1) };
+        match self {
+            Self::Metal(_) => session.set_metal_borrowed_texture_target(
+                &MetalBorrowedTextureDescriptor::new(extent.clone(), 64, 64, placeholder),
+            ),
+            Self::Vulkan(context) => {
+                session.set_vulkan_borrowed_texture_target(&VulkanBorrowedTextureDescriptor::new(
+                    extent.clone(),
+                    64,
+                    64,
+                    context.descriptor(),
+                    placeholder,
+                    placeholder,
+                    1,
+                    0,
+                    1,
+                ))
+            }
+        }
+    }
+
     fn try_acquire_frame_extent(
         &self,
         session: &RenderSessionHandle,
@@ -1702,22 +1734,15 @@ fn set_target_reports_unsupported_for_a_session_owned_texture() {
     let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
     let map = MapHandle::with_options(&runtime, &MapOptions::new(64, 64, 1.0)).unwrap();
     let extent = RenderTargetExtent::new(64, 64, 1.0);
-    let (_context, session) =
+    let (context, session) =
         create_owned_texture_session(&map.attach_ref().unwrap(), extent.clone())
             .expect("Metal or Vulkan owned texture test session should attach when supported");
 
-    // A session-owned texture is sized and replaced by its session. The session
-    // is checked before the descriptor, so this reports the target kind rather
-    // than the placeholder handle below, which is never dereferenced.
-    let error = session
-        .set_metal_borrowed_texture_target(&MetalBorrowedTextureDescriptor::new(
-            extent,
-            64,
-            64,
-            // SAFETY: Test passes an opaque non-null address that the rejected
-            // call never dereferences.
-            unsafe { NativePointer::from_address(0x1) },
-        ))
+    // A session-owned texture is sized and replaced by its session. The setter
+    // has to be this build's own backend, or "not supported by this build"
+    // would answer in place of the target-kind rejection under test.
+    let error = context
+        .set_placeholder_borrowed_target(&session, &extent)
         .unwrap_err();
     assert_eq!(error.kind(), ErrorKind::Unsupported);
 

--- a/bindings/swift/Sources/MaplibreNative/Render.swift
+++ b/bindings/swift/Sources/MaplibreNative/Render.swift
@@ -460,9 +460,11 @@ public final class RenderSessionHandle {
   /// holds at most one attached session, so close before attaching the
   /// replacement.
   ///
-  /// Resizing discards the session renderer, so renderer-held state such as
-  /// feature state does not survive. Map state such as camera, style, and
-  /// sources lives on the map and survives both resize and reattach.
+  /// The session keeps its renderer across a resize, so renderer-held state
+  /// such as feature state carries over. A scale factor change is the
+  /// exception: a renderer compiles its shaders for one pixel ratio, so that
+  /// resize starts a new one with renderer-held state empty. Map state such as
+  /// camera, style, and sources lives on the map and survives either way.
   public func resize(width: UInt32, height: UInt32,
                      scaleFactor: Double) throws
   {

--- a/bindings/swift/Sources/MaplibreNative/Render.swift
+++ b/bindings/swift/Sources/MaplibreNative/Render.swift
@@ -488,11 +488,11 @@ public final class RenderSessionHandle {
   /// feature state.
   ///
   /// The descriptor names the same graphics context this session attached
-  /// with, and its extent applies as a resize does. A layer on a different
-  /// device throws an invalid-argument error and leaves this session rendering
-  /// into the surface it has, so close it and attach again to take that one.
-  /// The session sets the layer's pixel format itself, so there is nothing else
-  /// here for a replacement to mismatch.
+  /// with, and its extent applies as a resize does. A descriptor whose
+  /// `context.device` is neither nil nor this session's device throws an
+  /// invalid-argument error and leaves this session rendering into the surface
+  /// it has. The session assigns the layer its own device and pixel format, so
+  /// the layer itself carries nothing that has to match.
   public func setMetalSurfaceTarget(
     _ descriptor: MetalSurfaceDescriptor
   ) throws {

--- a/bindings/swift/Sources/MaplibreNative/Render.swift
+++ b/bindings/swift/Sources/MaplibreNative/Render.swift
@@ -551,7 +551,9 @@ public final class RenderSessionHandle {
   /// resize reallocates rather than resizing and
   /// ``resize(width:height:scaleFactor:)`` throws an unsupported-feature error.
   /// Handing the replacement over here keeps this session's renderer instead,
-  /// so the map does not go cold on every resize.
+  /// so the map does not go cold on every resize, unless the scale factor
+  /// changes, which starts a new renderer for the new pixel ratio just as
+  /// ``resize(width:height:scaleFactor:)`` does.
   ///
   /// The replacement belongs to the device this session attached with, which
   /// throws an invalid-argument error otherwise, and carries the pixel format

--- a/bindings/swift/Sources/MaplibreNative/Render.swift
+++ b/bindings/swift/Sources/MaplibreNative/Render.swift
@@ -560,9 +560,9 @@ public final class RenderSessionHandle {
   /// it attached with, which throws an unsupported-feature error otherwise.
   /// Both leave this session rendering into the texture it has. The caller owns
   /// the replacement and keeps it valid until the next replacement, detach, or
-  /// close. This session never retained the outgoing texture and never releases
-  /// it, but reads from it during this call, so keep that texture valid until
-  /// the call returns.
+  /// close. This session never retained the outgoing texture, never releases
+  /// it, and never reads it here, so a host that already released it hands over
+  /// the replacement all the same.
   public func setMetalBorrowedTextureTarget(
     _ descriptor: MetalBorrowedTextureDescriptor
   ) throws {

--- a/bindings/swift/Sources/MaplibreNative/Render.swift
+++ b/bindings/swift/Sources/MaplibreNative/Render.swift
@@ -488,11 +488,11 @@ public final class RenderSessionHandle {
   /// feature state.
   ///
   /// The descriptor names the same graphics context this session attached
-  /// with, and its extent applies as a resize does. A target on a different
-  /// context throws an invalid-argument error, and one this session's compiled
-  /// state cannot serve throws an unsupported-feature error. Both leave this
-  /// session rendering into the surface it has; close it and attach again to
-  /// take that target.
+  /// with, and its extent applies as a resize does. A layer on a different
+  /// device throws an invalid-argument error and leaves this session rendering
+  /// into the surface it has, so close it and attach again to take that one.
+  /// The session sets the layer's pixel format itself, so there is nothing else
+  /// here for a replacement to mismatch.
   public func setMetalSurfaceTarget(
     _ descriptor: MetalSurfaceDescriptor
   ) throws {

--- a/bindings/swift/Sources/MaplibreNative/Render.swift
+++ b/bindings/swift/Sources/MaplibreNative/Render.swift
@@ -456,9 +456,9 @@ public final class RenderSessionHandle {
   ///
   /// Surface and owned-texture sessions resize in place. Borrowed texture
   /// targets are sized by their owner and throw an unsupported-feature error:
-  /// close this session, recreate the texture, and attach a new session. A map
-  /// holds at most one attached session, so close before attaching the
-  /// replacement.
+  /// allocate a texture at the new size and hand it over with the backend's
+  /// borrowed-texture target setter, such as
+  /// ``setMetalBorrowedTextureTarget(_:)``, which keeps this session.
   ///
   /// The session keeps its renderer across a resize, so renderer-held state
   /// such as feature state carries over. A scale factor change is the
@@ -475,6 +475,139 @@ public final class RenderSessionHandle {
         height,
         scaleFactor
       ))
+    }
+  }
+
+  /// Presents this attached surface session through a new surface.
+  ///
+  /// A host surface can be destroyed and recreated while the map goes on
+  /// living, which is what Android rotation, a Flutter `SurfaceProducer`
+  /// lifecycle change, and a window resize that reallocates all look like from
+  /// here. Replacing the surface in place keeps this session's renderer, and
+  /// with it the tile pyramid, glyph and image atlases, symbol placement, and
+  /// feature state.
+  ///
+  /// The descriptor names the same graphics context this session attached
+  /// with, and its extent applies as a resize does. A target on a different
+  /// context throws an invalid-argument error, and one this session's compiled
+  /// state cannot serve throws an unsupported-feature error. Both leave this
+  /// session rendering into the surface it has; close it and attach again to
+  /// take that target.
+  public func setMetalSurfaceTarget(
+    _ descriptor: MetalSurfaceDescriptor
+  ) throws {
+    try mapNativeFailure {
+      try descriptor.nativeInput.withNativeDescriptor { nativeDescriptor in
+        try checkStatus(mln_metal_surface_set_target(
+          handle.requireLive().raw,
+          nativeDescriptor
+        ))
+      }
+    }
+  }
+
+  /// Presents this attached surface session through a new surface.
+  ///
+  /// See ``setMetalSurfaceTarget(_:)`` for what replacing a surface preserves.
+  /// The outgoing `VkSurfaceKHR` must still be valid: this session holds a
+  /// swapchain built from it, and Vulkan destroys every swapchain before its
+  /// surface.
+  public func setVulkanSurfaceTarget(
+    _ descriptor: VulkanSurfaceDescriptor
+  ) throws {
+    try mapNativeFailure {
+      try descriptor.nativeInput.withNativeDescriptor { nativeDescriptor in
+        try checkStatus(mln_vulkan_surface_set_target(
+          handle.requireLive().raw,
+          nativeDescriptor
+        ))
+      }
+    }
+  }
+
+  /// Presents this attached surface session through a new surface.
+  ///
+  /// See ``setMetalSurfaceTarget(_:)`` for what replacing a surface preserves.
+  /// The new surface is made current on the next render, so a host may hand
+  /// over a replacement for one it has already destroyed. A surface accepted
+  /// here can still prove unusable, which the next ``renderUpdate()`` reports
+  /// rather than this call.
+  public func setOpenGLSurfaceTarget(
+    _ descriptor: OpenGLSurfaceDescriptor
+  ) throws {
+    try mapNativeFailure {
+      try descriptor.nativeInput.withNativeDescriptor { nativeDescriptor in
+        try checkStatus(mln_opengl_surface_set_target(
+          handle.requireLive().raw,
+          nativeDescriptor
+        ))
+      }
+    }
+  }
+
+  /// Renders this attached texture session into a new caller-owned texture.
+  ///
+  /// A caller-owned texture is sized by its owner, so a host that follows a
+  /// resize reallocates rather than resizing and
+  /// ``resize(width:height:scaleFactor:)`` throws an unsupported-feature error.
+  /// Handing the replacement over here keeps this session's renderer instead,
+  /// so the map does not go cold on every resize.
+  ///
+  /// The replacement belongs to the device this session attached with, which
+  /// throws an invalid-argument error otherwise, and carries the pixel format
+  /// it attached with, which throws an unsupported-feature error otherwise.
+  /// Both leave this session rendering into the texture it has. The caller owns
+  /// the replacement and keeps it valid until the next replacement, detach, or
+  /// close. This session never retained the outgoing texture and never releases
+  /// it, but reads from it during this call, so keep that texture valid until
+  /// the call returns.
+  public func setMetalBorrowedTextureTarget(
+    _ descriptor: MetalBorrowedTextureDescriptor
+  ) throws {
+    try mapNativeFailure {
+      try descriptor.nativeInput.withNativeDescriptor { nativeDescriptor in
+        try checkStatus(mln_metal_borrowed_texture_set_target(
+          handle.requireLive().raw,
+          nativeDescriptor
+        ))
+      }
+    }
+  }
+
+  /// Renders this attached texture session into a new caller-owned image.
+  ///
+  /// See ``setMetalBorrowedTextureTarget(_:)`` for what replacing a target
+  /// preserves. The replacement carries the format and both layouts this
+  /// session attached with, since its render pass was built around them.
+  public func setVulkanBorrowedTextureTarget(
+    _ descriptor: VulkanBorrowedTextureDescriptor
+  ) throws {
+    try mapNativeFailure {
+      try descriptor.nativeInput.withNativeDescriptor { nativeDescriptor in
+        try checkStatus(mln_vulkan_borrowed_texture_set_target(
+          handle.requireLive().raw,
+          nativeDescriptor
+        ))
+      }
+    }
+  }
+
+  /// Renders this attached texture session into a new caller-owned texture.
+  ///
+  /// See ``setMetalBorrowedTextureTarget(_:)`` for what replacing a target
+  /// preserves. The replacement belongs to the context this session attached
+  /// with, or one in its share group, and the host context must be current on
+  /// this thread.
+  public func setOpenGLBorrowedTextureTarget(
+    _ descriptor: OpenGLBorrowedTextureDescriptor
+  ) throws {
+    try mapNativeFailure {
+      try descriptor.nativeInput.withNativeDescriptor { nativeDescriptor in
+        try checkStatus(mln_opengl_borrowed_texture_set_target(
+          handle.requireLive().raw,
+          nativeDescriptor
+        ))
+      }
     }
   }
 

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -465,10 +465,10 @@ pub const RenderSessionHandle = enum(c.mln_render_session) {
     /// The descriptor names the graphics context this session attached with,
     /// and its extent applies exactly as `resize` applies one, so the map
     /// publishes an update matching the new size only once pumped. A descriptor
-    /// naming another device returns `error.InvalidArgument` and leaves the
-    /// session rendering into the surface it has, so closing it and attaching
-    /// again is what takes that one. The session sets the layer's pixel format
-    /// itself, so there is nothing else here for a replacement to mismatch.
+    /// whose `context.device` is neither null nor this session's device returns
+    /// `error.InvalidArgument` and leaves the session rendering into the surface
+    /// it has. The session assigns the layer its own device and pixel format, so
+    /// the layer itself carries nothing that has to match.
     pub fn setMetalSurfaceTarget(self: *RenderSessionHandle, descriptor: MetalSurfaceDescriptor) status.Error!void {
         var raw = metalSurfaceDescriptorToNative(descriptor);
         return try setTarget(self.*, c.mln_metal_surface_set_target, &raw);

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -465,10 +465,10 @@ pub const RenderSessionHandle = enum(c.mln_render_session) {
     /// The descriptor names the graphics context this session attached with,
     /// and its extent applies exactly as `resize` applies one, so the map
     /// publishes an update matching the new size only once pumped. A descriptor
-    /// naming another device returns `error.InvalidArgument`, and a replacement
-    /// this session's compiled state cannot serve returns `error.Unsupported`;
-    /// both leave the session rendering into the surface it has, and closing it
-    /// and attaching again is what takes the new target.
+    /// naming another device returns `error.InvalidArgument` and leaves the
+    /// session rendering into the surface it has, so closing it and attaching
+    /// again is what takes that one. The session sets the layer's pixel format
+    /// itself, so there is nothing else here for a replacement to mismatch.
     pub fn setMetalSurfaceTarget(self: *RenderSessionHandle, descriptor: MetalSurfaceDescriptor) status.Error!void {
         var raw = metalSurfaceDescriptorToNative(descriptor);
         return try setTarget(self.*, c.mln_metal_surface_set_target, &raw);

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -505,7 +505,8 @@ pub const RenderSessionHandle = enum(c.mln_render_session) {
     /// resize reallocates rather than resizing and `resize` returns
     /// `error.Unsupported`. Handing the replacement over here keeps this
     /// session's renderer instead, so the map does not go cold on every resize,
-    /// and the new extent applies exactly as `resize` applies one.
+    /// and the new extent applies exactly as `resize` applies one — including a
+    /// scale factor change starting a new renderer for the new pixel ratio.
     ///
     /// The replacement belongs to the device this session attached with, which
     /// returns `error.InvalidArgument` otherwise, and carries the pixel format

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -433,10 +433,10 @@ pub const RenderSessionHandle = enum(c.mln_render_session) {
     /// Resizes this attached render session.
     ///
     /// Surface and owned-texture sessions resize in place. Borrowed texture
-    /// targets are sized by their owner and return `error.Unsupported`: close
-    /// this session, recreate the texture, and attach a new session. A map
-    /// holds at most one attached session, so close before attaching the
-    /// replacement.
+    /// targets are sized by their owner and return `error.Unsupported`:
+    /// allocate a texture at the new size and hand it over with the
+    /// `set*BorrowedTextureTarget` method for the backend, which keeps this
+    /// session.
     ///
     /// The session keeps its renderer across a resize, so renderer-held state
     /// such as feature state carries over. A scale factor change is the
@@ -451,6 +451,95 @@ pub const RenderSessionHandle = enum(c.mln_render_session) {
             c.mln_render_session_resize(lease.native, extent.width, extent.height, extent.scale_factor),
             lease.diagnostic_store,
         );
+    }
+
+    /// Presents this attached surface session through a new Metal surface.
+    ///
+    /// A host surface can be destroyed and recreated while the map goes on
+    /// living, which is what Android rotation, a Flutter `SurfaceProducer`
+    /// lifecycle change, and a window resize that reallocates all look like
+    /// from here. Replacing the surface in place keeps this session's renderer,
+    /// and with it the tile pyramid, glyph and image atlases, symbol placement,
+    /// and feature state.
+    ///
+    /// The descriptor names the graphics context this session attached with,
+    /// and its extent applies exactly as `resize` applies one, so the map
+    /// publishes an update matching the new size only once pumped. A descriptor
+    /// naming another device returns `error.InvalidArgument`, and a replacement
+    /// this session's compiled state cannot serve returns `error.Unsupported`;
+    /// both leave the session rendering into the surface it has, and closing it
+    /// and attaching again is what takes the new target.
+    pub fn setMetalSurfaceTarget(self: *RenderSessionHandle, descriptor: MetalSurfaceDescriptor) status.Error!void {
+        var raw = metalSurfaceDescriptorToNative(descriptor);
+        return try setTarget(self.*, c.mln_metal_surface_set_target, &raw);
+    }
+
+    /// Presents this attached surface session through a new Vulkan surface.
+    ///
+    /// See `setMetalSurfaceTarget` for what replacing a surface preserves. The
+    /// outgoing `VkSurfaceKHR` must still be valid: this session holds a
+    /// swapchain built from it, and Vulkan destroys every swapchain before its
+    /// surface. A host that has to release its surface first closes this
+    /// session and attaches again instead.
+    pub fn setVulkanSurfaceTarget(self: *RenderSessionHandle, descriptor: VulkanSurfaceDescriptor) status.Error!void {
+        var raw = vulkanSurfaceDescriptorToNative(descriptor);
+        return try setTarget(self.*, c.mln_vulkan_surface_set_target, &raw);
+    }
+
+    /// Presents this attached surface session through a new OpenGL surface.
+    ///
+    /// See `setMetalSurfaceTarget` for what replacing a surface preserves. The
+    /// new surface is made current on the next render, so a host may hand over
+    /// a replacement for one it has already destroyed. A surface accepted here
+    /// can still prove unusable, which the next `renderUpdate` reports as
+    /// `error.NativeError` rather than this call.
+    pub fn setOpenGLSurfaceTarget(self: *RenderSessionHandle, descriptor: OpenGLSurfaceDescriptor) status.Error!void {
+        var raw = openglSurfaceDescriptorToNative(descriptor);
+        return try setTarget(self.*, c.mln_opengl_surface_set_target, &raw);
+    }
+
+    /// Renders this attached texture session into a new caller-owned Metal
+    /// texture.
+    ///
+    /// A caller-owned texture is sized by its owner, so a host that follows a
+    /// resize reallocates rather than resizing and `resize` returns
+    /// `error.Unsupported`. Handing the replacement over here keeps this
+    /// session's renderer instead, so the map does not go cold on every resize,
+    /// and the new extent applies exactly as `resize` applies one.
+    ///
+    /// The replacement belongs to the device this session attached with and
+    /// carries the pixel format it attached with; one that does not returns
+    /// `error.InvalidArgument` or `error.Unsupported` with this session still
+    /// rendering into the texture it has. The caller owns the replacement and
+    /// keeps it valid until the next replacement, detach, or close. This
+    /// session never retained the outgoing texture and never releases it, but
+    /// reads from it during this call, so keep it valid until the call returns.
+    pub fn setMetalBorrowedTextureTarget(self: *RenderSessionHandle, descriptor: MetalBorrowedTextureDescriptor) status.Error!void {
+        var raw = metalBorrowedTextureDescriptorToNative(descriptor);
+        return try setTarget(self.*, c.mln_metal_borrowed_texture_set_target, &raw);
+    }
+
+    /// Renders this attached texture session into a new caller-owned Vulkan
+    /// image.
+    ///
+    /// See `setMetalBorrowedTextureTarget` for what replacing a target
+    /// preserves. The replacement carries the format and both layouts this
+    /// session attached with, since its render pass was built around them.
+    pub fn setVulkanBorrowedTextureTarget(self: *RenderSessionHandle, descriptor: VulkanBorrowedTextureDescriptor) status.Error!void {
+        var raw = vulkanBorrowedTextureDescriptorToNative(descriptor);
+        return try setTarget(self.*, c.mln_vulkan_borrowed_texture_set_target, &raw);
+    }
+
+    /// Renders this attached texture session into a new caller-owned OpenGL
+    /// texture.
+    ///
+    /// See `setMetalBorrowedTextureTarget` for what replacing a target
+    /// preserves. The replacement belongs to the context this session attached
+    /// with, or one in its share group, and that context must be current on
+    /// this thread.
+    pub fn setOpenGLBorrowedTextureTarget(self: *RenderSessionHandle, descriptor: OpenGLBorrowedTextureDescriptor) status.Error!void {
+        var raw = openglBorrowedTextureDescriptorToNative(descriptor);
+        return try setTarget(self.*, c.mln_opengl_borrowed_texture_set_target, &raw);
     }
 
     /// Renders the latest available map render update. The map retains its
@@ -930,11 +1019,7 @@ pub fn attachMetalOwnedTexture(map: *map_module.MapHandle, descriptor: MetalOwne
 }
 
 pub fn attachMetalBorrowedTexture(map: *map_module.MapHandle, descriptor: MetalBorrowedTextureDescriptor) status.Error!RenderSessionHandle {
-    var raw = c.mln_metal_borrowed_texture_descriptor_default();
-    raw.extent = renderTargetExtentToNative(descriptor.extent);
-    raw.physical_width = descriptor.physical_width;
-    raw.physical_height = descriptor.physical_height;
-    raw.texture = descriptor.texture.toPtr();
+    var raw = metalBorrowedTextureDescriptorToNative(descriptor);
     return try attach(map, c.mln_metal_borrowed_texture_attach, &raw);
 }
 
@@ -946,16 +1031,7 @@ pub fn attachVulkanOwnedTexture(map: *map_module.MapHandle, descriptor: VulkanOw
 }
 
 pub fn attachVulkanBorrowedTexture(map: *map_module.MapHandle, descriptor: VulkanBorrowedTextureDescriptor) status.Error!RenderSessionHandle {
-    var raw = c.mln_vulkan_borrowed_texture_descriptor_default();
-    raw.extent = renderTargetExtentToNative(descriptor.extent);
-    raw.physical_width = descriptor.physical_width;
-    raw.physical_height = descriptor.physical_height;
-    raw.context = vulkanContextToNative(descriptor.context);
-    raw.image = descriptor.image.toPtr();
-    raw.image_view = descriptor.image_view.toPtr();
-    raw.format = descriptor.format;
-    raw.initial_layout = descriptor.initial_layout;
-    raw.final_layout = descriptor.final_layout;
+    var raw = vulkanBorrowedTextureDescriptorToNative(descriptor);
     return try attach(map, c.mln_vulkan_borrowed_texture_attach, &raw);
 }
 
@@ -967,37 +1043,22 @@ pub fn attachOpenGLOwnedTexture(map: *map_module.MapHandle, descriptor: OpenGLOw
 }
 
 pub fn attachOpenGLBorrowedTexture(map: *map_module.MapHandle, descriptor: OpenGLBorrowedTextureDescriptor) status.Error!RenderSessionHandle {
-    var raw = c.mln_opengl_borrowed_texture_descriptor_default();
-    raw.extent = renderTargetExtentToNative(descriptor.extent);
-    raw.physical_width = descriptor.physical_width;
-    raw.physical_height = descriptor.physical_height;
-    raw.context = openglContextToNative(descriptor.context);
-    raw.texture = descriptor.texture;
-    raw.target = descriptor.target;
+    var raw = openglBorrowedTextureDescriptorToNative(descriptor);
     return try attach(map, c.mln_opengl_borrowed_texture_attach, &raw);
 }
 
 pub fn attachMetalSurface(map: *map_module.MapHandle, descriptor: MetalSurfaceDescriptor) status.Error!RenderSessionHandle {
-    var raw = c.mln_metal_surface_descriptor_default();
-    raw.extent = renderTargetExtentToNative(descriptor.extent);
-    raw.context = metalContextToNative(descriptor.context);
-    raw.layer = descriptor.layer.toPtr();
+    var raw = metalSurfaceDescriptorToNative(descriptor);
     return try attach(map, c.mln_metal_surface_attach, &raw);
 }
 
 pub fn attachVulkanSurface(map: *map_module.MapHandle, descriptor: VulkanSurfaceDescriptor) status.Error!RenderSessionHandle {
-    var raw = c.mln_vulkan_surface_descriptor_default();
-    raw.extent = renderTargetExtentToNative(descriptor.extent);
-    raw.context = vulkanContextToNative(descriptor.context);
-    raw.surface = descriptor.surface.toPtr();
+    var raw = vulkanSurfaceDescriptorToNative(descriptor);
     return try attach(map, c.mln_vulkan_surface_attach, &raw);
 }
 
 pub fn attachOpenGLSurface(map: *map_module.MapHandle, descriptor: OpenGLSurfaceDescriptor) status.Error!RenderSessionHandle {
-    var raw = c.mln_opengl_surface_descriptor_default();
-    raw.extent = renderTargetExtentToNative(descriptor.extent);
-    raw.context = openglContextToNative(descriptor.context);
-    raw.surface = descriptor.surface.toPtr();
+    var raw = openglSurfaceDescriptorToNative(descriptor);
     return try attach(map, c.mln_opengl_surface_attach, &raw);
 }
 
@@ -1015,6 +1076,21 @@ fn attach(
     );
     errdefer _ = c.mln_render_session_destroy(session);
     return try newRenderSession(session, map.*, registration.diagnostic_store);
+}
+
+/// Shared body for the `set*Target` methods.
+///
+/// The native descriptor is materialized by the caller and lives for the
+/// duration of this call, which is all the C API borrows it for.
+fn setTarget(
+    handle: RenderSessionHandle,
+    comptime setTargetFn: anytype,
+    descriptor: anytype,
+) status.Error!void {
+    const lease = try renderSessionLease(handle);
+    defer lease.release();
+    try ensureNoActiveOwnedFrame(lease);
+    try status.checkStatus(setTargetFn(lease.native, descriptor), lease.diagnostic_store);
 }
 
 fn newRenderSession(
@@ -1542,6 +1618,64 @@ fn copyFeatureIdentifier(allocator: std.mem.Allocator, raw: c.mln_feature) statu
 fn copyStringView(allocator: std.mem.Allocator, view: c.mln_string_view) std.mem.Allocator.Error![]const u8 {
     if (view.size == 0) return allocator.dupe(u8, "");
     return allocator.dupe(u8, view.data[0..view.size]);
+}
+
+fn metalSurfaceDescriptorToNative(descriptor: MetalSurfaceDescriptor) c.mln_metal_surface_descriptor {
+    var raw = c.mln_metal_surface_descriptor_default();
+    raw.extent = renderTargetExtentToNative(descriptor.extent);
+    raw.context = metalContextToNative(descriptor.context);
+    raw.layer = descriptor.layer.toPtr();
+    return raw;
+}
+
+fn vulkanSurfaceDescriptorToNative(descriptor: VulkanSurfaceDescriptor) c.mln_vulkan_surface_descriptor {
+    var raw = c.mln_vulkan_surface_descriptor_default();
+    raw.extent = renderTargetExtentToNative(descriptor.extent);
+    raw.context = vulkanContextToNative(descriptor.context);
+    raw.surface = descriptor.surface.toPtr();
+    return raw;
+}
+
+fn openglSurfaceDescriptorToNative(descriptor: OpenGLSurfaceDescriptor) c.mln_opengl_surface_descriptor {
+    var raw = c.mln_opengl_surface_descriptor_default();
+    raw.extent = renderTargetExtentToNative(descriptor.extent);
+    raw.context = openglContextToNative(descriptor.context);
+    raw.surface = descriptor.surface.toPtr();
+    return raw;
+}
+
+fn metalBorrowedTextureDescriptorToNative(descriptor: MetalBorrowedTextureDescriptor) c.mln_metal_borrowed_texture_descriptor {
+    var raw = c.mln_metal_borrowed_texture_descriptor_default();
+    raw.extent = renderTargetExtentToNative(descriptor.extent);
+    raw.physical_width = descriptor.physical_width;
+    raw.physical_height = descriptor.physical_height;
+    raw.texture = descriptor.texture.toPtr();
+    return raw;
+}
+
+fn vulkanBorrowedTextureDescriptorToNative(descriptor: VulkanBorrowedTextureDescriptor) c.mln_vulkan_borrowed_texture_descriptor {
+    var raw = c.mln_vulkan_borrowed_texture_descriptor_default();
+    raw.extent = renderTargetExtentToNative(descriptor.extent);
+    raw.physical_width = descriptor.physical_width;
+    raw.physical_height = descriptor.physical_height;
+    raw.context = vulkanContextToNative(descriptor.context);
+    raw.image = descriptor.image.toPtr();
+    raw.image_view = descriptor.image_view.toPtr();
+    raw.format = descriptor.format;
+    raw.initial_layout = descriptor.initial_layout;
+    raw.final_layout = descriptor.final_layout;
+    return raw;
+}
+
+fn openglBorrowedTextureDescriptorToNative(descriptor: OpenGLBorrowedTextureDescriptor) c.mln_opengl_borrowed_texture_descriptor {
+    var raw = c.mln_opengl_borrowed_texture_descriptor_default();
+    raw.extent = renderTargetExtentToNative(descriptor.extent);
+    raw.physical_width = descriptor.physical_width;
+    raw.physical_height = descriptor.physical_height;
+    raw.context = openglContextToNative(descriptor.context);
+    raw.texture = descriptor.texture;
+    raw.target = descriptor.target;
+    return raw;
 }
 
 fn metalContextToNative(context: MetalContextDescriptor) c.mln_metal_context_descriptor {

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -514,7 +514,8 @@ pub const RenderSessionHandle = enum(c.mln_render_session) {
     /// leave this session rendering into the texture it has. The caller owns the replacement and
     /// keeps it valid until the next replacement, detach, or close. This
     /// session never retained the outgoing texture and never releases it, but
-    /// reads from it during this call, so keep it valid until the call returns.
+    /// never reads it here, so a host that already released it hands over the
+    /// replacement all the same.
     pub fn setMetalBorrowedTextureTarget(self: *RenderSessionHandle, descriptor: MetalBorrowedTextureDescriptor) status.Error!void {
         var raw = metalBorrowedTextureDescriptorToNative(descriptor);
         return try setTarget(self.*, c.mln_metal_borrowed_texture_set_target, &raw);

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -507,10 +507,10 @@ pub const RenderSessionHandle = enum(c.mln_render_session) {
     /// session's renderer instead, so the map does not go cold on every resize,
     /// and the new extent applies exactly as `resize` applies one.
     ///
-    /// The replacement belongs to the device this session attached with and
-    /// carries the pixel format it attached with; one that does not returns
-    /// `error.InvalidArgument` or `error.Unsupported` with this session still
-    /// rendering into the texture it has. The caller owns the replacement and
+    /// The replacement belongs to the device this session attached with, which
+    /// returns `error.InvalidArgument` otherwise, and carries the pixel format
+    /// it attached with, which returns `error.Unsupported` otherwise. Both
+    /// leave this session rendering into the texture it has. The caller owns the replacement and
     /// keeps it valid until the next replacement, detach, or close. This
     /// session never retained the outgoing texture and never releases it, but
     /// reads from it during this call, so keep it valid until the call returns.

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -438,9 +438,11 @@ pub const RenderSessionHandle = enum(c.mln_render_session) {
     /// holds at most one attached session, so close before attaching the
     /// replacement.
     ///
-    /// Resizing discards the session renderer, so renderer-held state such as
-    /// feature state does not survive. Map state such as camera, style, and
-    /// sources lives on the map and survives both resize and reattach.
+    /// The session keeps its renderer across a resize, so renderer-held state
+    /// such as feature state carries over. A scale factor change is the
+    /// exception: a renderer compiles its shaders for one pixel ratio, so that
+    /// resize starts a new one with renderer-held state empty. Map state such as
+    /// camera, style, and sources lives on the map and survives either way.
     pub fn resize(self: *RenderSessionHandle, extent: RenderTargetExtent) status.Error!void {
         const lease = try renderSessionLease(self.*);
         defer lease.release();

--- a/bindings/zig/tests/render.zig
+++ b/bindings/zig/tests/render.zig
@@ -251,6 +251,7 @@ fn readTestImage(session: *maplibre.RenderSessionHandle, allocator: std.mem.Allo
 const RenderSessionThreadCall = enum {
     render_update,
     resize,
+    set_target,
     detach,
     reduce_memory_use,
     clear_data,
@@ -268,6 +269,7 @@ fn callRenderSessionOnThread(session: *maplibre.RenderSessionHandle, call: Rende
             break :blk {};
         },
         .resize => session.resize(.{ .width = 16, .height = 16, .scale_factor = 1.0 }),
+        .set_target => setPlaceholderBorrowedTextureTarget(session),
         .detach => session.detach(),
         .reduce_memory_use => session.reduceMemoryUse(),
         .clear_data => session.clearData(),
@@ -470,13 +472,32 @@ const WglBorrowedTexture = if (supports_wgl) struct {
         self.context.deinit();
     }
 
+    /// Allocates a replacement in this helper's own context, the way a host
+    /// that reallocates on resize does. The outgoing texture stays live so the
+    /// caller can hand the replacement over before releasing it.
+    pub fn allocateReplacement(self: *const WglBorrowedTexture, width: u32, height: u32) !gl.uint {
+        return self.context.context.createRgbaTexture(width, height);
+    }
+
+    /// Tracks a replacement the session has taken and releases the outgoing one.
+    pub fn adopt(self: *WglBorrowedTexture, texture: gl.uint, width: u32, height: u32) void {
+        if (self.texture != 0) self.context.context.destroyTexture(self.texture);
+        self.texture = texture;
+        self.width = width;
+        self.height = height;
+    }
+
     pub fn descriptor(self: *const WglBorrowedTexture) maplibre.OpenGLBorrowedTextureDescriptor {
+        return self.descriptorFor(self.texture, self.width, self.height);
+    }
+
+    pub fn descriptorFor(self: *const WglBorrowedTexture, texture: gl.uint, width: u32, height: u32) maplibre.OpenGLBorrowedTextureDescriptor {
         return .{
-            .extent = .{ .width = self.width, .height = self.height },
-            .physical_width = self.width,
-            .physical_height = self.height,
+            .extent = .{ .width = width, .height = height },
+            .physical_width = width,
+            .physical_height = height,
             .context = self.context.descriptor(),
-            .texture = self.texture,
+            .texture = texture,
             .target = gl.TEXTURE_2D,
         };
     }
@@ -712,13 +733,32 @@ const OpenGLBorrowedTexture = if (supports_wgl) WglBorrowedTexture else if (supp
         self.context.deinit();
     }
 
+    /// Allocates a replacement in this helper's own context, the way a host
+    /// that reallocates on resize does. The outgoing texture stays live so the
+    /// caller can hand the replacement over before releasing it.
+    pub fn allocateReplacement(self: *const @This(), width: u32, height: u32) !gl.uint {
+        return self.context.createRgbaTexture(width, height);
+    }
+
+    /// Tracks a replacement the session has taken and releases the outgoing one.
+    pub fn adopt(self: *@This(), texture: gl.uint, width: u32, height: u32) void {
+        if (self.texture != 0) self.context.destroyTexture(self.texture);
+        self.texture = texture;
+        self.width = width;
+        self.height = height;
+    }
+
     pub fn descriptor(self: *const @This()) maplibre.OpenGLBorrowedTextureDescriptor {
+        return self.descriptorFor(self.texture, self.width, self.height);
+    }
+
+    pub fn descriptorFor(self: *const @This(), texture: gl.uint, width: u32, height: u32) maplibre.OpenGLBorrowedTextureDescriptor {
         return .{
-            .extent = .{ .width = self.width, .height = self.height },
-            .physical_width = self.width,
-            .physical_height = self.height,
+            .extent = .{ .width = width, .height = height },
+            .physical_width = width,
+            .physical_height = height,
             .context = self.context.descriptor(),
-            .texture = self.texture,
+            .texture = texture,
             .target = gl.TEXTURE_2D,
         };
     }
@@ -787,6 +827,44 @@ fn expectInvalidOwnedTextureExtent(map: *maplibre.MapHandle, extent: maplibre.Re
             .extent = extent,
             .context = .{ .device = fakeNativePointer() },
         }));
+    } else {
+        unreachable;
+    }
+}
+
+/// Hands a session a caller-owned texture target for the configured backend,
+/// carrying placeholder backend handles. Call sites expect a rejection that
+/// lands before the C API reads the descriptor.
+fn setPlaceholderBorrowedTextureTarget(session: *maplibre.RenderSessionHandle) maplibre.Error!void {
+    const extent = maplibre.RenderTargetExtent{ .width = 16, .height = 16, .scale_factor = 1.0 };
+    if (build_options.supports_vulkan) {
+        return session.setVulkanBorrowedTextureTarget(.{
+            .extent = extent,
+            .physical_width = extent.width,
+            .physical_height = extent.height,
+            .context = fakeVulkanContext(),
+            .image = fakeNativePointer(),
+            .image_view = fakeNativePointer(),
+            .format = @as(u32, vk.VK_FORMAT_R8G8B8A8_UNORM),
+            .initial_layout = @as(u32, vk.VK_IMAGE_LAYOUT_UNDEFINED),
+            .final_layout = @as(u32, vk.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL),
+        });
+    } else if (build_options.supports_opengl) {
+        return session.setOpenGLBorrowedTextureTarget(.{
+            .extent = extent,
+            .physical_width = extent.width,
+            .physical_height = extent.height,
+            .context = fakeOpenGLContext(),
+            .texture = 1,
+            .target = gl_texture_2d,
+        });
+    } else if (build_options.supports_metal) {
+        return session.setMetalBorrowedTextureTarget(.{
+            .extent = extent,
+            .physical_width = extent.width,
+            .physical_height = extent.height,
+            .texture = fakeNativePointer(),
+        });
     } else {
         unreachable;
     }
@@ -1025,10 +1103,29 @@ const VulkanBorrowedImage = if (build_options.supports_vulkan) struct {
     width: u32,
     height: u32,
 
+    /// A caller-owned image with the memory and view that go with it.
+    pub const Allocation = struct {
+        image: vk.VkImage,
+        image_view: vk.VkImageView,
+        memory: vk.VkDeviceMemory,
+    };
+
     pub fn create(width: u32, height: u32) !VulkanBorrowedImage {
         var context = try VulkanAttachContext.init();
         errdefer context.deinit();
 
+        const allocation = try allocate(&context, width, height);
+        return .{
+            .context = context,
+            .image = allocation.image,
+            .image_view = allocation.image_view,
+            .memory = allocation.memory,
+            .width = width,
+            .height = height,
+        };
+    }
+
+    fn allocate(context: *const VulkanAttachContext, width: u32, height: u32) !Allocation {
         var image: vk.VkImage = null;
         var memory: vk.VkDeviceMemory = null;
         var image_view: vk.VkImageView = null;
@@ -1076,25 +1173,51 @@ const VulkanBorrowedImage = if (build_options.supports_vulkan) struct {
         };
         try expectVk(context.dispatch.create_image_view.?(context.device, &view_info, null, &image_view));
 
-        return .{ .context = context, .image = image, .image_view = image_view, .memory = memory, .width = width, .height = height };
+        return .{ .image = image, .image_view = image_view, .memory = memory };
     }
 
     pub fn deinit(self: *VulkanBorrowedImage) void {
         _ = self.context.dispatch.device_wait_idle.?(self.context.device);
-        self.context.dispatch.destroy_image_view.?(self.context.device, self.image_view, null);
-        self.context.dispatch.destroy_image.?(self.context.device, self.image, null);
-        self.context.dispatch.free_memory.?(self.context.device, self.memory, null);
+        self.release(.{ .image = self.image, .image_view = self.image_view, .memory = self.memory });
         self.context.deinit();
     }
 
+    /// Allocates a replacement on this helper's own device, the way a host that
+    /// reallocates on resize does. The outgoing image stays live so the caller
+    /// can hand the replacement over before releasing it.
+    pub fn allocateReplacement(self: *const VulkanBorrowedImage, width: u32, height: u32) !Allocation {
+        return allocate(&self.context, width, height);
+    }
+
+    /// Tracks a replacement the session has taken and releases the outgoing one.
+    pub fn adopt(self: *VulkanBorrowedImage, allocation: Allocation, width: u32, height: u32) void {
+        _ = self.context.dispatch.device_wait_idle.?(self.context.device);
+        self.release(.{ .image = self.image, .image_view = self.image_view, .memory = self.memory });
+        self.image = allocation.image;
+        self.image_view = allocation.image_view;
+        self.memory = allocation.memory;
+        self.width = width;
+        self.height = height;
+    }
+
+    fn release(self: *const VulkanBorrowedImage, allocation: Allocation) void {
+        self.context.dispatch.destroy_image_view.?(self.context.device, allocation.image_view, null);
+        self.context.dispatch.destroy_image.?(self.context.device, allocation.image, null);
+        self.context.dispatch.free_memory.?(self.context.device, allocation.memory, null);
+    }
+
     pub fn descriptor(self: *const VulkanBorrowedImage) maplibre.VulkanBorrowedTextureDescriptor {
+        return self.descriptorFor(.{ .image = self.image, .image_view = self.image_view, .memory = self.memory }, self.width, self.height);
+    }
+
+    pub fn descriptorFor(self: *const VulkanBorrowedImage, allocation: Allocation, width: u32, height: u32) maplibre.VulkanBorrowedTextureDescriptor {
         return .{
-            .extent = .{ .width = self.width, .height = self.height },
-            .physical_width = self.width,
-            .physical_height = self.height,
+            .extent = .{ .width = width, .height = height },
+            .physical_width = width,
+            .physical_height = height,
             .context = self.context.descriptor(),
-            .image = maplibre.NativePointer.fromPtr(@ptrCast(self.image.?)),
-            .image_view = maplibre.NativePointer.fromPtr(@ptrCast(self.image_view.?)),
+            .image = maplibre.NativePointer.fromPtr(@ptrCast(allocation.image.?)),
+            .image_view = maplibre.NativePointer.fromPtr(@ptrCast(allocation.image_view.?)),
             .format = @as(u32, vk.VK_FORMAT_R8G8B8A8_UNORM),
             .initial_layout = @as(u32, vk.VK_IMAGE_LAYOUT_UNDEFINED),
             .final_layout = @as(u32, vk.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL),
@@ -1217,6 +1340,30 @@ test "map size follows attach and resize and keeps the creation scale factor" {
     try testing.expectEqual(@as(u32, 48), resized.width);
     try testing.expectEqual(@as(u32, 24), resized.height);
     try testing.expectEqual(@as(f64, 2.0), resized.scale_factor);
+}
+
+test "set target reports unsupported for a session-owned texture" {
+    if (!supports_test_owned_texture) return error.SkipZigTest;
+    var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);
+    defer runtime.close() catch @panic("runtime close failed");
+
+    var map = try maplibre.MapHandle.create(&runtime, .{});
+    defer map.close() catch @panic("map close failed");
+
+    var owned = try attachTestOwnedTexture(&map, .{
+        .extent = .{ .width = 32, .height = 32, .scale_factor = 1.0 },
+    });
+    defer owned.close() catch {};
+
+    // A session-owned texture is sized and replaced by its own session, which
+    // resize covers. The session is checked before the descriptor, so the
+    // placeholder handles below are never read.
+    try testing.expectError(error.Unsupported, setPlaceholderBorrowedTextureTarget(&owned.session));
+
+    // The rejection left the session usable.
+    try map.setStyleJson(testing.allocator, support.style_json);
+    try testing.expect(try waitForEvent(&runtime, .map_render_update_available));
+    try testing.expect(try owned.session.renderUpdate());
 }
 
 test "an ease pumped through rendered frames reports its transition finish once" {
@@ -1856,6 +2003,7 @@ test "OpenGL owned texture frame scopes public binding access" {
 
     try expectOpenGLFrameReleaseWrongThread(&frame);
 
+    try testing.expectError(error.ActiveBorrow, setPlaceholderBorrowedTextureTarget(&session));
     try testing.expectError(error.ActiveBorrow, session.renderUpdate());
     try testing.expectError(error.ActiveBorrow, session.detach());
     try testing.expectError(error.ActiveBorrow, session.acquireOpenGLOwnedTextureFrame());
@@ -1897,6 +2045,57 @@ test "OpenGL borrowed texture renders through public bindings" {
     try testing.expectError(error.Unsupported, session.acquireOpenGLOwnedTextureFrame());
     var readback_buffer: [128 * 128 * 4]u8 = undefined;
     try testing.expectError(error.Unsupported, session.readPremultipliedRgba8Into(&readback_buffer));
+}
+
+test "OpenGL borrowed texture set target renders into a replacement texture" {
+    if (!build_options.supports_opengl) return error.SkipZigTest;
+
+    var borrowed = try OpenGLBorrowedTexture.create(128, 128);
+    defer borrowed.deinit();
+
+    var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);
+    defer runtime.close() catch @panic("runtime close failed");
+
+    var map = try maplibre.MapHandle.create(&runtime, .{});
+    defer map.close() catch @panic("map close failed");
+
+    var session = try maplibre.attachOpenGLBorrowedTexture(&map, borrowed.descriptor());
+    defer session.close() catch {};
+
+    try map.setStyleJson(testing.allocator, support.style_json);
+    try testing.expect(try waitForEvent(&runtime, .map_render_update_available));
+    try testing.expect(try session.renderUpdate());
+
+    // A caller-owned texture is sized by its owner, so a host that follows a
+    // resize allocates at the new size and hands the texture over instead.
+    try testing.expectError(error.Unsupported, session.resize(.{ .width = 64, .height = 96, .scale_factor = 1.0 }));
+
+    const replacement = try borrowed.allocateReplacement(64, 96);
+    try session.setOpenGLBorrowedTextureTarget(borrowed.descriptorFor(replacement, 64, 96));
+    borrowed.adopt(replacement, 64, 96);
+
+    // A surface descriptor names a target this session does not have, and the
+    // rejection leaves it rendering into the texture it was just handed.
+    try testing.expectError(error.Unsupported, session.setOpenGLSurfaceTarget(.{
+        .extent = .{ .width = 64, .height = 96 },
+        .context = borrowed.context.descriptor(),
+        .surface = fakeNativePointer(),
+    }));
+
+    // Replacing the target hands the new size to the map's owner thread, as a
+    // resize does, so the map publishes a matching update only once pumped.
+    try testing.expect(!try session.renderUpdate());
+    try runtime.pump(0);
+    const resized = try map.getSize();
+    try testing.expectEqual(@as(u32, 64), resized.width);
+    try testing.expectEqual(@as(u32, 96), resized.height);
+    try testing.expect(try session.renderUpdate());
+
+    const pixels = try testing.allocator.alloc(u8, 64 * 96 * 4);
+    defer testing.allocator.free(pixels);
+    @memset(pixels, 0);
+    try borrowed.readRGBA8(pixels);
+    try expectPixelApprox(pixels[0..4].*, .{ 0xd8, 0xf1, 0xff, 0xff }, 8);
 }
 
 test "OpenGL surface renders through public bindings" {
@@ -1969,6 +2168,7 @@ test "Metal owned texture frame handle scopes native pointers" {
     try expectMetalFrameReleaseWrongThread(&frame);
 
     try testing.expectError(error.ActiveBorrow, session.resize(.{ .width = 16, .height = 16, .scale_factor = 1.0 }));
+    try testing.expectError(error.ActiveBorrow, setPlaceholderBorrowedTextureTarget(&session));
     try testing.expectError(error.ActiveBorrow, session.renderUpdate());
     try testing.expectError(error.ActiveBorrow, session.detach());
     try testing.expectError(error.ActiveBorrow, session.acquireMetalOwnedTextureFrame());
@@ -2026,6 +2226,7 @@ test "render session rejects wrong-thread calls through public bindings" {
     inline for (.{
         RenderSessionThreadCall.render_update,
         .resize,
+        .set_target,
         .detach,
         .reduce_memory_use,
         .clear_data,
@@ -2073,6 +2274,68 @@ test "Metal borrowed texture renders through public bindings" {
     try testing.expectError(error.Unsupported, session.readPremultipliedRgba8Into(&readback_buffer));
 }
 
+test "Metal borrowed texture set target renders into a replacement texture" {
+    if (!build_options.supports_metal) return error.SkipZigTest;
+    const device = MTLCreateSystemDefaultDevice() orelse return error.MetalDeviceUnavailable;
+
+    const pool = try metal_support.AutoreleasePool.init();
+    defer pool.deinit();
+
+    // The replacement is allocated up front so the host outlives the session
+    // that borrows it, the way a host that owns both textures does.
+    const borrowed = try metal_support.createTexture(device, 128, 128);
+    defer metal_support.releaseObject(borrowed);
+    const replacement = try metal_support.createTexture(device, 64, 96);
+    defer metal_support.releaseObject(replacement);
+    try metal_support.clearTextureRGBA8(replacement, .{ 0, 0, 0, 0 });
+
+    var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);
+    defer runtime.close() catch @panic("runtime close failed");
+
+    var map = try maplibre.MapHandle.create(&runtime, .{});
+    defer map.close() catch @panic("map close failed");
+
+    var session = try maplibre.attachMetalBorrowedTexture(&map, .{
+        .extent = .{ .width = 128, .height = 128 },
+        .physical_width = 128,
+        .physical_height = 128,
+        .texture = maplibre.NativePointer.fromPtr(borrowed),
+    });
+    defer session.close() catch {};
+
+    try map.setStyleJson(testing.allocator, support.style_json);
+    try testing.expect(try waitForEvent(&runtime, .map_render_update_available));
+    try testing.expect(try session.renderUpdate());
+
+    // A caller-owned texture is sized by its owner, so a host that follows a
+    // resize allocates at the new size and hands the texture over instead.
+    try testing.expectError(error.Unsupported, session.resize(.{ .width = 64, .height = 96, .scale_factor = 1.0 }));
+
+    try session.setMetalBorrowedTextureTarget(.{
+        .extent = .{ .width = 64, .height = 96 },
+        .physical_width = 64,
+        .physical_height = 96,
+        .texture = maplibre.NativePointer.fromPtr(replacement),
+    });
+
+    // A surface descriptor names a target this session does not have, and the
+    // rejection leaves it rendering into the texture it was just handed.
+    try testing.expectError(error.Unsupported, session.setMetalSurfaceTarget(.{
+        .extent = .{ .width = 64, .height = 96 },
+        .layer = fakeNativePointer(),
+    }));
+
+    // Replacing the target hands the new size to the map's owner thread, as a
+    // resize does, so the map publishes a matching update only once pumped.
+    try testing.expect(!try session.renderUpdate());
+    try runtime.pump(0);
+    const resized = try map.getSize();
+    try testing.expectEqual(@as(u32, 64), resized.width);
+    try testing.expectEqual(@as(u32, 96), resized.height);
+    try testing.expect(try session.renderUpdate());
+    try expectPixelApprox(try metal_support.readTexturePixelRGBA8(replacement, 0, 0), .{ 0xd8, 0xf1, 0xff, 0xff }, 8);
+}
+
 test "Vulkan owned texture frame handle scopes native pointers" {
     if (!build_options.supports_vulkan) return error.SkipZigTest;
 
@@ -2111,6 +2374,7 @@ test "Vulkan owned texture frame handle scopes native pointers" {
     try expectVulkanFrameReleaseWrongThread(&frame);
 
     try testing.expectError(error.ActiveBorrow, session.resize(.{ .width = 16, .height = 16, .scale_factor = 1.0 }));
+    try testing.expectError(error.ActiveBorrow, setPlaceholderBorrowedTextureTarget(&session));
     try testing.expectError(error.ActiveBorrow, session.renderUpdate());
     try testing.expectError(error.ActiveBorrow, session.detach());
     try testing.expectError(error.ActiveBorrow, session.acquireVulkanOwnedTextureFrame());
@@ -2161,4 +2425,49 @@ test "Vulkan borrowed texture renders through public bindings" {
     try testing.expectError(error.Unsupported, session.resize(.{ .width = 64, .height = 64, .scale_factor = 1.0 }));
     var readback_buffer: [128 * 128 * 4]u8 = undefined;
     try testing.expectError(error.Unsupported, session.readPremultipliedRgba8Into(&readback_buffer));
+}
+
+test "Vulkan borrowed texture set target renders into a replacement image" {
+    if (!build_options.supports_vulkan) return error.SkipZigTest;
+
+    var borrowed = try VulkanBorrowedImage.create(128, 128);
+    defer borrowed.deinit();
+
+    var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);
+    defer runtime.close() catch @panic("runtime close failed");
+
+    var map = try maplibre.MapHandle.create(&runtime, .{});
+    defer map.close() catch @panic("map close failed");
+
+    var session = try maplibre.attachVulkanBorrowedTexture(&map, borrowed.descriptor());
+    defer session.close() catch {};
+
+    try map.setStyleJson(testing.allocator, support.style_json);
+    try testing.expect(try waitForEvent(&runtime, .map_render_update_available));
+    try testing.expect(try session.renderUpdate());
+
+    // A caller-owned image is sized by its owner, so a host that follows a
+    // resize allocates at the new size and hands the image over instead.
+    try testing.expectError(error.Unsupported, session.resize(.{ .width = 64, .height = 96, .scale_factor = 1.0 }));
+
+    const replacement = try borrowed.allocateReplacement(64, 96);
+    try session.setVulkanBorrowedTextureTarget(borrowed.descriptorFor(replacement, 64, 96));
+    borrowed.adopt(replacement, 64, 96);
+
+    // A surface descriptor names a target this session does not have, and the
+    // rejection leaves it rendering into the image it was just handed.
+    try testing.expectError(error.Unsupported, session.setVulkanSurfaceTarget(.{
+        .extent = .{ .width = 64, .height = 96 },
+        .context = borrowed.context.descriptor(),
+        .surface = fakeNativePointer(),
+    }));
+
+    // Replacing the target hands the new size to the map's owner thread, as a
+    // resize does, so the map publishes a matching update only once pumped.
+    try testing.expect(!try session.renderUpdate());
+    try runtime.pump(0);
+    const resized = try map.getSize();
+    try testing.expectEqual(@as(u32, 64), resized.width);
+    try testing.expectEqual(@as(u32, 96), resized.height);
+    try testing.expect(try session.renderUpdate());
 }

--- a/bindings/zig/tests/render.zig
+++ b/bindings/zig/tests/render.zig
@@ -671,6 +671,11 @@ const EglAttachContext = if (supports_egl) struct {
         self.procs.BindTexture(gl.TEXTURE_2D, texture);
         self.procs.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
         self.procs.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        // Zeroed rather than left undefined: a test that reads this back to
+        // prove a session rendered into it needs a known starting value.
+        const blank = testing.allocator.alloc(u8, width * height * 4) catch @panic("oom");
+        defer testing.allocator.free(blank);
+        @memset(blank, 0);
         self.procs.TexImage2D(
             gl.TEXTURE_2D,
             0,
@@ -680,7 +685,7 @@ const EglAttachContext = if (supports_egl) struct {
             0,
             gl.RGBA,
             gl.UNSIGNED_BYTE,
-            null,
+            blank.ptr,
         );
         self.procs.BindTexture(gl.TEXTURE_2D, 0);
         try testing.expectEqual(@as(gl.@"enum", gl.NO_ERROR), self.procs.GetError());

--- a/bindings/zig/tests/surface.zig
+++ b/bindings/zig/tests/surface.zig
@@ -75,6 +75,61 @@ test "Metal surface render acquires one drawable per frame through public bindin
     try testing.expectEqual(@as(u32, 1), metal_support.nextDrawableCount(window_layer.layer.?));
 }
 
+test "Metal surface set target presents through a replacement layer" {
+    if (!build_options.supports_metal) return error.SkipZigTest;
+
+    const pool = try metal_support.AutoreleasePool.init();
+    defer pool.deinit();
+
+    var window_layer = try metal_support.createCountingWindowLayer(64, 64);
+    defer window_layer.deinit();
+    var replacement_layer = try metal_support.createCountingWindowLayer(48, 32);
+    defer replacement_layer.deinit();
+
+    var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);
+    defer runtime.close() catch @panic("runtime close failed");
+    var map = try maplibre.MapHandle.create(&runtime, .{});
+    defer map.close() catch @panic("map close failed");
+
+    var surface = try maplibre.attachMetalSurface(&map, .{
+        .extent = .{ .width = 64, .height = 64 },
+        .layer = nativePointer(window_layer.layer.?),
+    });
+    defer surface.close() catch {};
+
+    try map.setStyleJson(testing.allocator, support.style_json);
+    try testing.expect(try waitForEvent(&runtime, .map_render_update_available));
+    try testing.expect(try surface.renderUpdate());
+    try testing.expectEqual(@as(u32, 1), metal_support.nextDrawableCount(window_layer.layer.?));
+
+    // A host surface can be destroyed and recreated while the map goes on
+    // living, and the session presents through the replacement it is handed.
+    try surface.setMetalSurfaceTarget(.{
+        .extent = .{ .width = 48, .height = 32 },
+        .layer = nativePointer(replacement_layer.layer.?),
+    });
+
+    // A caller-owned texture descriptor names a target this session does not
+    // have, and the rejection leaves it presenting through the new layer.
+    try testing.expectError(error.Unsupported, surface.setMetalBorrowedTextureTarget(.{
+        .extent = .{ .width = 48, .height = 32 },
+        .physical_width = 48,
+        .physical_height = 32,
+        .texture = nativePointer(@ptrFromInt(1)),
+    }));
+
+    // Replacing the surface hands the new size to the map's owner thread, as a
+    // resize does, so the map publishes a matching update only once pumped.
+    try testing.expect(!try surface.renderUpdate());
+    try runtime.pump(0);
+    const resized = try map.getSize();
+    try testing.expectEqual(@as(u32, 48), resized.width);
+    try testing.expectEqual(@as(u32, 32), resized.height);
+    try testing.expect(try surface.renderUpdate());
+    try testing.expectEqual(@as(u32, 1), metal_support.nextDrawableCount(replacement_layer.layer.?));
+    try testing.expectEqual(@as(u32, 1), metal_support.nextDrawableCount(window_layer.layer.?));
+}
+
 test "surface public descriptors report invalid native arguments" {
     if (!build_options.supports_metal and !build_options.supports_vulkan) return error.SkipZigTest;
     var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);

--- a/docs/src/content/docs/development/binding-specification.md
+++ b/docs/src/content/docs/development/binding-specification.md
@@ -646,9 +646,9 @@ The public handle exposes:
 a host builds a replacement target the way it built the first one. It is exposed
 per backend and target kind, matching the C API's `mln_*_surface_set_target()`
 and `mln_*_borrowed_texture_set_target()` functions, and it is bound to the
-thread that attached the session like every other session operation. Bindings do
-not compare the descriptor's graphics context against the session's; the C API
-rejects a mismatch.
+thread that attached the session like every other session operation. The C API
+rejects a descriptor whose graphics context differs from the session's, so
+bindings pass the descriptor through.
 
 ### Texture frames
 
@@ -860,7 +860,7 @@ When the binding routes provider requests through
 | BND-164 | `render_update` reports no-update-available as a false result without closing the session.                                                                |
 | BND-165 | Resize updates extent through the public render session API.                                                                                              |
 | BND-175 | `set_target` replaces a host-owned render target through the public render session API and updates the session's extent.                                  |
-| BND-176 | `set_target` on a session whose target the session owns reports unsupported, and on a session of another backend reports unsupported.                     |
+| BND-176 | `set_target` reports unsupported for a target kind the session does not have, covering a session-owned texture and a mismatched surface/texture pairing.  |
 | BND-166 | CPU readback copies metadata; undersized buffers fail without losing ownership, and sufficiently sized reusable buffers receive image bytes.              |
 | BND-167 | Owned texture frame acquire returns an explicit frame handle with copied metadata and active-checked backend handles.                                     |
 | BND-168 | Owned texture frame access after release fails before exposing backend handles.                                                                           |

--- a/docs/src/content/docs/development/binding-specification.md
+++ b/docs/src/content/docs/development/binding-specification.md
@@ -634,11 +634,21 @@ window.
 The public handle exposes:
 
 - `resize` for session kinds that support resize;
+- `set_target` for session kinds whose target the host owns, which is surface
+  sessions and caller-owned texture sessions;
 - `render_update` for the latest available map render update, reporting whether
   an update was rendered;
 - `detach`, which keeps the public handle live after backend resources detach;
 - `close` or `destroy`, using the owned-handle release operation, on the thread
   that attached the session.
+
+`set_target` takes the same public descriptor type its attach function takes, so
+a host builds a replacement target the way it built the first one. It is exposed
+per backend and target kind, matching the C API's `mln_*_surface_set_target()`
+and `mln_*_borrowed_texture_set_target()` functions, and it is bound to the
+thread that attached the session like every other session operation. Bindings do
+not compare the descriptor's graphics context against the session's; the C API
+rejects a mismatch.
 
 ### Texture frames
 
@@ -849,6 +859,8 @@ When the binding routes provider requests through
 | BND-163 | Attaching a second render session to the same map reports invalid state.                                                                                  |
 | BND-164 | `render_update` reports no-update-available as a false result without closing the session.                                                                |
 | BND-165 | Resize updates extent through the public render session API.                                                                                              |
+| BND-175 | `set_target` replaces a host-owned render target through the public render session API and updates the session's extent.                                  |
+| BND-176 | `set_target` on a session whose target the session owns reports unsupported, and on a session of another backend reports unsupported.                     |
 | BND-166 | CPU readback copies metadata; undersized buffers fail without losing ownership, and sufficiently sized reusable buffers receive image bytes.              |
 | BND-167 | Owned texture frame acquire returns an explicit frame handle with copied metadata and active-checked backend handles.                                     |
 | BND-168 | Owned texture frame access after release fails before exposing backend handles.                                                                           |

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -578,8 +578,10 @@ table:
   [Graphics API](#graphics-api)).
 - `render_update` presents through the surface render target directly.
 - `drawTexture` MUST NOT be called for this mode.
-- On resize, call session `resize` and rebuild host presentation; reattach when
-  the host toolkit supplies a new surface handle.
+- On resize, call session `resize` and rebuild host presentation. When the host
+  toolkit supplies a new surface handle for the same graphics context, call
+  `set_target` with it; reattach only when the context itself changed or was
+  lost.
 
 ### Compositor shaders
 
@@ -607,8 +609,10 @@ that pass.
   resources for texture modes, and session extent in place.
 - When it returns `true`, recreate the texture and call `set_target`; otherwise
   resize the graphics context and active render target in place. Either way the
-  session and its renderer stay live, so the map keeps its tiles and atlases
-  across the change.
+  session stays live. Its renderer stays live too, so the map keeps its tiles
+  and atlases, except where the C API documents a rebuild: a scale factor change
+  on either path, and a replacement target whose format or layouts differ from
+  the outgoing one's.
 - Reserve [reattach](#reattach) for a target the live session cannot take: a new
   graphics context or device, or a context that was lost.
 - Set the render request after any resize.

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -622,11 +622,11 @@ that pass.
   because the session destroys the swapchain built from it first.
 - `MLN_STATUS_NATIVE_ERROR` may mean the replacement was already under way, and
   a caller cannot tell it apart from a failure that came earlier. The session
-  may therefore hold either target, so close it before releasing either one, and
-  attach again rather than reusing it. An example that treats the failure as
-  fatal satisfies this by stopping before the next frame. Every other status is
-  reported before the target changes, which is what makes rolling back to the
-  outgoing target safe.
+  may therefore hold either target. Detach or close it before releasing either
+  one, and attach again rather than reusing it; stopping before the next frame
+  is not enough on its own, because the release still happens while the session
+  holds the target. Every other status is reported before the target changes,
+  which is what makes rolling back to the outgoing target safe.
 - Build the replacement to match what the session attached with, which the C API
   states per backend and per function. `set_target` reports
   `MLN_STATUS_UNSUPPORTED` for a target that differs, leaving the session on the

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -612,9 +612,9 @@ that pass.
   session stays live, and so does its renderer, so the map keeps its tiles and
   atlases. A scale factor change is the exception the C API documents,
   rebuilding the renderer for the new pixel ratio.
-- Build the replacement with the format, layouts, and sample count the session
-  attached with. `set_target` reports `MLN_STATUS_UNSUPPORTED` for a target that
-  differs, leaving the session on the one it has.
+- Build the replacement with the format and layouts the session attached with.
+  `set_target` reports `MLN_STATUS_UNSUPPORTED` for a target that differs,
+  leaving the session on the one it has.
 - Reserve [reattach](#reattach) for a target the live session cannot take: a new
   graphics context or device, a target that `set_target` reports as unsupported,
   or a context that was lost.

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -609,12 +609,15 @@ that pass.
   resources for texture modes, and session extent in place.
 - When it returns `true`, recreate the texture and call `set_target`; otherwise
   resize the graphics context and active render target in place. Either way the
-  session stays live. Its renderer stays live too, so the map keeps its tiles
-  and atlases, except where the C API documents a rebuild: a scale factor change
-  on either path, and a replacement target whose format or layouts differ from
-  the outgoing one's.
+  session stays live, and so does its renderer, so the map keeps its tiles and
+  atlases. A scale factor change is the exception the C API documents,
+  rebuilding the renderer for the new pixel ratio.
+- Build the replacement with the format, layouts, and sample count the session
+  attached with. `set_target` reports `MLN_STATUS_UNSUPPORTED` for a target that
+  differs, leaving the session on the one it has.
 - Reserve [reattach](#reattach) for a target the live session cannot take: a new
-  graphics context or device, or a context that was lost.
+  graphics context or device, a target that `set_target` reports as unsupported,
+  or a context that was lost.
 - Set the render request after any resize.
 - The render loop owns the session, so an in-place resize is a local call. The
   map applies the new logical size on the runtime loop's next `pump`, so

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -359,7 +359,7 @@ polling.
    and enqueue them for the runtime loop; signal the runtime loop's wake source;
    set the render request.
 2. Apply pending viewport changes to graphics resources and to the render
-   session, or run the [reattach](#reattach).
+   target, which follows them without losing its session.
 3. Consume the render request; when it was set, call `render_update`.
 4. Run `finishFrame()`.
 
@@ -521,11 +521,10 @@ map-specific setup.
 
 #### Resize API
 
-Expose `resize(viewport)` for the active render target. Resize API-level
-resources separately when the graphics context requires it. When the active
-render target reports `needsSetTargetOnResize`, rebuild the mode-specific
-resources for the new viewport and hand them to the live session with
-`set_target`.
+Expose `resize(viewport)` for the active render target, and resize API-level
+resources separately when the graphics context requires it. The render target
+decides for itself how to follow the new viewport, so a host resizes every mode
+through the same call.
 
 ### Render-target modes
 
@@ -568,9 +567,9 @@ table:
 - Attach with the borrowed-texture descriptor referencing host-owned handles.
 - On `render_update`, sample that texture through the same compositor path as
   `owned-texture`.
-- On resize, recreate the host texture and hand it to the live session with
-  `set_target` (see [Resize mechanics](#resize-mechanics);
-  `needsSetTargetOnResize` is `true` for this mode).
+- On resize, allocate a host texture at the new size and hand it to the live
+  session with `set_target`, which the render target does inside its own
+  `resize` (see [Resize mechanics](#resize-mechanics)).
 
 #### `native-surface`
 
@@ -601,17 +600,20 @@ that pass.
 
 - Recompute viewport on host size or scale changes; skip rendering if extent is
   empty.
-- `needsSetTargetOnResize()` is a render-target method. It returns `true` for
-  `borrowed-texture` because the host-owned exportable texture is fixed to the
-  viewport size: resize recreates the texture and hands it to the live session
-  through `set_target`. It returns `false` for `owned-texture` and
-  `native-surface`, where resize updates graphics-context resources, compositor
-  resources for texture modes, and session extent in place.
-- When it returns `true`, recreate the texture and call `set_target`; otherwise
-  resize the graphics context and active render target in place. Either way the
-  session stays live, and so does its renderer, so the map keeps its tiles and
-  atlases. A scale factor change is the exception the C API documents,
-  rebuilding the renderer for the new pixel ratio.
+- `resize(viewport)` is a render-target method, and each mode follows the new
+  viewport its own way. `owned-texture` and `native-surface` resize
+  graphics-context resources, compositor resources for texture modes, and
+  session extent in place. `borrowed-texture` cannot: the host-owned exportable
+  texture is fixed to the viewport size, so it allocates one at the new size and
+  hands it to the live session with `set_target`. A host calls `resize` for
+  every mode and branches on none of them.
+- The session stays live either way, and so does its renderer, so the map keeps
+  its tiles and atlases across a resize. A scale factor change is the exception
+  the C API documents, rebuilding the renderer for the new pixel ratio.
+- A `set_target` that fails leaves the session on the target it already had, so
+  keep that one and release the replacement rather than the reverse. The session
+  never reads the outgoing target, so an example whose graphics layer frees it
+  before handing over the replacement is conformant.
 - Build the replacement to match what the session attached with, which the C API
   states per backend and per function. `set_target` reports
   `MLN_STATUS_UNSUPPORTED` for a target that differs, leaving the session on the
@@ -626,11 +628,11 @@ that pass.
 
 #### Reattach
 
-Reattaching happens entirely on the render loop thread, which owns both the
-session and the graphics resources. The sequence MUST be:
+Reattaching is for a target the live session cannot take, not for a resize. It
+happens entirely on the render loop thread, which owns both the session and the
+graphics resources. The sequence MUST be:
 
-1. Close the session, then destroy and recreate the host texture or surface at
-   the new size.
+1. Close the session, then destroy and recreate the host texture or surface.
 2. Attach the render target again against the published map.
 3. Set the render request.
 
@@ -813,10 +815,16 @@ render loop only while the view is visible and the app is in the foreground. The
 runtime loop keeps running across these transitions, so loading continues while
 the view is off screen.
 
-When the host toolkit destroys or invalidates the presentation surface, close
-the render target on the render loop thread, which is the thread that attached
-it. Keep runtime and map handles alive. Attach again on that same thread when a
-fresh surface is available, per [Reattach](#reattach).
+When the host toolkit supplies a fresh presentation surface on the graphics
+context the session attached with, hand it over with `set_target` on the render
+loop thread, which is the thread that attached the session. The session keeps
+its renderer, so the map returns warm rather than rebuilding its tiles and
+atlases.
+
+Close the render target only when the graphics context itself is gone, on that
+same render loop thread. Keep runtime and map handles alive either way, and
+attach again on that thread once a context and surface exist, per
+[Reattach](#reattach).
 
 | Transition                       | Behavior                                                                                                                                                           |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -612,9 +612,10 @@ that pass.
   session stays live, and so does its renderer, so the map keeps its tiles and
   atlases. A scale factor change is the exception the C API documents,
   rebuilding the renderer for the new pixel ratio.
-- Build the replacement with the format and layouts the session attached with.
-  `set_target` reports `MLN_STATUS_UNSUPPORTED` for a target that differs,
-  leaving the session on the one it has.
+- Build the replacement to match what the session attached with, which the C API
+  states per backend and per function. `set_target` reports
+  `MLN_STATUS_UNSUPPORTED` for a target that differs, leaving the session on the
+  one it has.
 - Reserve [reattach](#reattach) for a target the live session cannot take: a new
   graphics context or device, a target that `set_target` reports as unsupported,
   or a context that was lost.

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -610,10 +610,18 @@ that pass.
 - The session stays live either way, and so does its renderer, so the map keeps
   its tiles and atlases across a resize. A scale factor change is the exception
   the C API documents, rebuilding the renderer for the new pixel ratio.
-- A `set_target` that fails leaves the session on the target it already had, so
-  keep that one and release the replacement rather than the reverse. The session
-  never reads the outgoing target, so an example whose graphics layer frees it
-  before handing over the replacement is conformant.
+- Pick an ownership strategy for the handover and follow the C API's rules for
+  it. An example that keeps the outgoing target until the call returns can roll
+  back: a rejected replacement leaves the session on the target it had, so it
+  releases the replacement and keeps rendering. An example whose graphics layer
+  frees the outgoing target first cannot roll back, and treats a rejected
+  handover as a session to close and attach again. Caller-owned textures allow
+  either, because no backend reads the outgoing texture.
+- A Vulkan surface is the exception, and requires the retaining strategy: its
+  outgoing `VkSurfaceKHR` must still be valid when `set_target` is called,
+  because the session destroys the swapchain built from it first.
+- `MLN_STATUS_NATIVE_ERROR` means the replacement was already under way, so the
+  session is closed rather than reused whichever strategy an example picked.
 - Build the replacement to match what the session attached with, which the C API
   states per backend and per function. `set_target` reports
   `MLN_STATUS_UNSUPPORTED` for a target that differs, leaving the session on the
@@ -826,13 +834,13 @@ same render loop thread. Keep runtime and map handles alive either way, and
 attach again on that thread once a context and surface exist, per
 [Reattach](#reattach).
 
-| Transition                       | Behavior                                                                                                                                                           |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| View will appear                 | Mark the view visible. If the app is in the foreground, start the render loop, refresh viewport, attach or reattach the render target, and set the render request. |
-| View did disappear               | Mark the view not visible. Stop the render loop. Close the render target when the presentation surface is destroyed or invalidated.                                |
-| App foreground                   | Mark the app foreground. If the view is visible, start the render loop, refresh viewport, attach or reattach the render target, and set the render request.        |
-| App background                   | Mark the app background. Stop the render loop. Close the render target when the presentation surface is destroyed or invalidated.                                  |
-| View destroyed / app termination | Run [Shared shutdown](#shutdown).                                                                                                                                  |
+| Transition                       | Behavior                                                                                                                                                                                             |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| View will appear                 | Mark the view visible. If the app is in the foreground, start the render loop, refresh viewport, hand a parked session its surface or attach the render target, and set the render request.          |
+| View did disappear               | Mark the view not visible. Stop the render loop. Park the session when the presentation surface goes away and the graphics context survives; close the render target only when that context is gone. |
+| App foreground                   | Mark the app foreground. If the view is visible, start the render loop, refresh viewport, hand a parked session its surface or attach the render target, and set the render request.                 |
+| App background                   | Mark the app background. Stop the render loop. Park the session when the presentation surface goes away and the graphics context survives; close the render target only when that context is gone.   |
+| View destroyed / app termination | Run [Shared shutdown](#shutdown).                                                                                                                                                                    |
 
 ### Entry and shell
 

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -226,9 +226,9 @@ current on another thread. Attaching where the host context is already current
 avoids both failure modes. Vulkan and Metal have no thread-current context and
 are unaffected.
 
-Reattaching, which the borrowed-texture mode requires on resize, is entirely
-local to the render loop thread: close the session, rebuild the mode-specific
-resources, attach again.
+Reattaching, which a graphics context change requires, is entirely local to the
+render loop thread: close the session, rebuild the mode-specific resources,
+attach again.
 
 ##### Thread identity on Apple platforms and managed runtimes
 
@@ -523,8 +523,9 @@ map-specific setup.
 
 Expose `resize(viewport)` for the active render target. Resize API-level
 resources separately when the graphics context requires it. When the active
-render target reports `needsReattachOnResize`, destroy it and attach a
-replacement for the same graphics context, map, and mode.
+render target reports `needsSetTargetOnResize`, rebuild the mode-specific
+resources for the new viewport and hand them to the live session with
+`set_target`.
 
 ### Render-target modes
 
@@ -567,9 +568,9 @@ table:
 - Attach with the borrowed-texture descriptor referencing host-owned handles.
 - On `render_update`, sample that texture through the same compositor path as
   `owned-texture`.
-- On resize, recreate the host texture and re-attach the session (see
-  [Resize mechanics](#resize-mechanics); `needsReattachOnResize` is `true` for
-  this mode).
+- On resize, recreate the host texture and hand it to the live session with
+  `set_target` (see [Resize mechanics](#resize-mechanics);
+  `needsSetTargetOnResize` is `true` for this mode).
 
 #### `native-surface`
 
@@ -598,14 +599,18 @@ that pass.
 
 - Recompute viewport on host size or scale changes; skip rendering if extent is
   empty.
-- `needsReattachOnResize()` is a render-target method. It returns `true` for
+- `needsSetTargetOnResize()` is a render-target method. It returns `true` for
   `borrowed-texture` because the host-owned exportable texture is fixed to the
-  viewport size: resize destroys the render target, recreates the texture, and
-  attaches again. It returns `false` for `owned-texture` and `native-surface`,
-  where resize updates graphics-context resources, compositor resources for
-  texture modes, and session extent in place.
-- When it returns `true`, use the [reattach](#reattach); otherwise resize the
-  graphics context and active render target in place.
+  viewport size: resize recreates the texture and hands it to the live session
+  through `set_target`. It returns `false` for `owned-texture` and
+  `native-surface`, where resize updates graphics-context resources, compositor
+  resources for texture modes, and session extent in place.
+- When it returns `true`, recreate the texture and call `set_target`; otherwise
+  resize the graphics context and active render target in place. Either way the
+  session and its renderer stay live, so the map keeps its tiles and atlases
+  across the change.
+- Reserve [reattach](#reattach) for a target the live session cannot take: a new
+  graphics context or device, or a context that was lost.
 - Set the render request after any resize.
 - The render loop owns the session, so an in-place resize is a local call. The
   map applies the new logical size on the runtime loop's next `pump`, so

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -620,8 +620,13 @@ that pass.
 - A Vulkan surface is the exception, and requires the retaining strategy: its
   outgoing `VkSurfaceKHR` must still be valid when `set_target` is called,
   because the session destroys the swapchain built from it first.
-- `MLN_STATUS_NATIVE_ERROR` means the replacement was already under way, so the
-  session is closed rather than reused whichever strategy an example picked.
+- `MLN_STATUS_NATIVE_ERROR` may mean the replacement was already under way, and
+  a caller cannot tell it apart from a failure that came earlier. The session
+  may therefore hold either target, so close it before releasing either one, and
+  attach again rather than reusing it. An example that treats the failure as
+  fatal satisfies this by stopping before the next frame. Every other status is
+  reported before the target changes, which is what makes rolling back to the
+  outgoing target safe.
 - Build the replacement to match what the session attached with, which the C API
   states per backend and per function. `set_target` reports
   `MLN_STATUS_UNSUPPORTED` for a target that differs, leaving the session on the

--- a/docs/src/content/docs/guides/query-map-data.mdx
+++ b/docs/src/content/docs/guides/query-map-data.mdx
@@ -68,7 +68,9 @@ change while the style stays put.
 
 State lives on the session's renderer, which has two consequences. The renderer
 has to exist first, so render once after the style loads before you set state.
-State also does not survive a resize or a reattach, so reapply it after either.
+State rides along with the renderer, so it survives a resize and a target
+replacement. It starts empty again whenever the renderer does: after a scale
+factor change, and after a reattach.
 Setting or removing state requests a repaint.
 
 The selector picks the target. `source_id` is required, `source_layer_id`

--- a/docs/src/content/docs/guides/render-to-a-surface.mdx
+++ b/docs/src/content/docs/guides/render-to-a-surface.mdx
@@ -79,8 +79,10 @@ sleep, which is simple and burns CPU.
 
 When the window changes size, call `mln_render_session_resize()` with the new
 logical size and scale factor, then render again. Camera, style, and sources
-live on the map and survive the resize. Renderer-held state such as feature
-state does not, so reapply it afterward.
+live on the map, and the session keeps its renderer, so tiles, atlases, and
+renderer-held state such as feature state carry over. Changing the scale factor
+is the exception: a renderer compiles its shaders for one pixel ratio, so that
+resize starts a new one and renderer-held state starts empty.
 
 A scale factor that disagrees with the map's own logs a warning, and MapLibre
 renders imagery chosen for the map's density. Choose the map's `scale_factor`
@@ -88,15 +90,22 @@ for the displays you target.
 
 ## Follow the surface's life
 
-Surfaces come and go as windows close and views detach. When the surface goes
-away:
+Surfaces come and go as windows close, views detach, and devices rotate. When a
+new surface arrives on the same graphics context, hand it to the live session
+with `mln_<backend>_surface_set_target()`. The session keeps its renderer, so
+the map comes back with the tiles and atlases it already had instead of
+rebuilding them. This is the path for Android rotation, a Flutter
+`SurfaceProducer` lifecycle change, and any window resize that reallocates.
+
+Tear the session down when the graphics context itself goes away, or when the
+replacement belongs to a different one:
 
 1. Call `mln_render_session_destroy()` on the thread that attached the session.
    To release the map's slot first, call `mln_render_session_detach()` and
    destroy the handle afterward. A detached handle can only be destroyed.
 2. Release your surface and context.
 3. When a new surface arrives, attach a fresh session. The map keeps its camera
-   and style throughout.
+   and style throughout, and the new session starts with a cold renderer.
 
 Complete working loops for each backend live in the example apps: `zig-map`,
 `rust-map`, `lwjgl-map`, `swift-map`, `dotnet-map`, and `android-map`.

--- a/docs/src/content/docs/guides/render-to-a-texture.mdx
+++ b/docs/src/content/docs/guides/render-to-a-texture.mdx
@@ -70,12 +70,11 @@ across that, so the map keeps its tiles and atlases every time the window
 changes size. A scale factor change is the exception, starting a new renderer
 for the new pixel ratio.
 
-Hand over a replacement with the same format, layouts, and sample count the
-session attached with. Pipelines are built against those, so one that differs
-comes back as
-`MLN_STATUS_UNSUPPORTED` with the session still rendering into the texture it
-has. Destroying and re-attaching is what changes them, and what a new graphics
-context needs.
+Hand over a replacement with the same format and layouts the session attached
+with. Pipelines are built against those and cached without them in the key, so
+one that differs comes back as `MLN_STATUS_UNSUPPORTED` with the session still
+rendering into the texture it has. Destroying and re-attaching is what changes
+them, and what a new graphics context needs.
 
 How much synchronization you owe depends on the backend. An OpenGL session
 finishes its render before `render_update()` returns, so you can sample the

--- a/docs/src/content/docs/guides/render-to-a-texture.mdx
+++ b/docs/src/content/docs/guides/render-to-a-texture.mdx
@@ -67,10 +67,14 @@ and resize only for the session-owned mode. You own the texture's size, so to
 follow a resize you allocate a new texture and hand it over with
 `mln_<backend>_borrowed_texture_set_target()`. The session keeps its renderer
 across that, so the map keeps its tiles and atlases every time the window
-changes size. It starts a new renderer when the scale factor changes, or when
-the replacement's format or layouts differ from the outgoing one's, since
-pipelines are built against those. Destroying and re-attaching stays the path
-for a new graphics context.
+changes size. A scale factor change is the exception, starting a new renderer
+for the new pixel ratio.
+
+Hand over a replacement with the same format and layouts the session attached
+with. Pipelines are built against those, so a target that differs comes back as
+`MLN_STATUS_UNSUPPORTED` with the session still rendering into the texture it
+has. Destroying and re-attaching is what changes them, and what a new graphics
+context needs.
 
 How much synchronization you owe depends on the backend. An OpenGL session
 finishes its render before `render_update()` returns, so you can sample the

--- a/docs/src/content/docs/guides/render-to-a-texture.mdx
+++ b/docs/src/content/docs/guides/render-to-a-texture.mdx
@@ -70,11 +70,13 @@ across that, so the map keeps its tiles and atlases every time the window
 changes size. A scale factor change is the exception, starting a new renderer
 for the new pixel ratio.
 
-Hand over a replacement with the same format and layouts the session attached
-with. Pipelines are built against those and cached without them in the key, so
-one that differs comes back as `MLN_STATUS_UNSUPPORTED` with the session still
-rendering into the texture it has. Destroying and re-attaching is what changes
-them, and what a new graphics context needs.
+Hand over a replacement that matches what the session attached with. What has to
+match is per backend, because each builds its pipelines against something
+different: a Metal texture's pixel format, a Vulkan image's format and layouts.
+The [C API reference](/maplibre-native-ffi/reference/c/) states it per function.
+A target that differs comes back as `MLN_STATUS_UNSUPPORTED`, with the session
+still rendering into the texture it has. Destroying and re-attaching is what
+changes it, and what a new graphics context needs.
 
 How much synchronization you owe depends on the backend. An OpenGL session
 finishes its render before `render_update()` returns, so you can sample the

--- a/docs/src/content/docs/guides/render-to-a-texture.mdx
+++ b/docs/src/content/docs/guides/render-to-a-texture.mdx
@@ -13,12 +13,12 @@ the pixels back to the CPU, or use the texture in your own rendering.
 
 ## Who owns the texture
 
-|                 | Session-owned ("owned")                  | Caller-owned ("borrowed")            |
-| --------------- | ---------------------------------------- | ------------------------------------ |
-| Created by      | The session, on your device or context   | You                                  |
-| Resizing        | `mln_render_session_resize()` in place   | Recreate the texture and the session |
-| Using the frame | Acquire it, use it, release it           | It is already yours                  |
-| CPU readback    | `mln_texture_read_premultiplied_rgba8()` | Read it back yourself                |
+|                 | Session-owned ("owned")                  | Caller-owned ("borrowed")               |
+| --------------- | ---------------------------------------- | --------------------------------------- |
+| Created by      | The session, on your device or context   | You                                     |
+| Resizing        | `mln_render_session_resize()` in place   | Recreate the texture, then `set_target` |
+| Using the frame | Acquire it, use it, release it           | It is already yours                     |
+| CPU readback    | `mln_texture_read_premultiplied_rgba8()` | Read it back yourself                   |
 
 Both modes attach through a backend-specific function,
 `mln_<backend>_owned_texture_attach()` or
@@ -62,9 +62,12 @@ resizing, detaching, destroying, and a second acquire all return
 
 A borrowed texture skips all of that, since the texture was yours to begin with.
 You allocate it and keep it valid until the session detaches. The session
-renders into it when you call `render_update()`, and offers no acquire,
-readback, or resize. To follow a resize, destroy the session, make a new
-texture, and attach again.
+renders into it when you call `render_update()`, and offers no acquire or
+readback. It offers no resize either, because you own the texture's size: to
+follow a resize, allocate a new texture and hand it over with
+`mln_<backend>_borrowed_texture_set_target()`. The session keeps its renderer
+across that, so the map does not go cold every time the window changes size.
+Destroying and re-attaching stays the path for a new graphics context.
 
 How much synchronization you owe depends on the backend. An OpenGL session
 finishes its render before `render_update()` returns, so you can sample the
@@ -77,5 +80,5 @@ function, along with the state each backend requires of the texture itself.
 
 <Aside type="tip">
   `compose-map` is a complete borrowed-texture integration, including
-  reattach-on-resize.
+  set-target-on-resize.
 </Aside>

--- a/docs/src/content/docs/guides/render-to-a-texture.mdx
+++ b/docs/src/content/docs/guides/render-to-a-texture.mdx
@@ -62,12 +62,15 @@ resizing, detaching, destroying, and a second acquire all return
 
 A borrowed texture skips all of that, since the texture was yours to begin with.
 You allocate it and keep it valid until the session detaches. The session
-renders into it when you call `render_update()`, and offers no acquire or
-readback. It offers no resize either, because you own the texture's size: to
-follow a resize, allocate a new texture and hand it over with
+renders into it when you call `render_update()`, and offers acquire, readback,
+and resize only for the session-owned mode. You own the texture's size, so to
+follow a resize you allocate a new texture and hand it over with
 `mln_<backend>_borrowed_texture_set_target()`. The session keeps its renderer
-across that, so the map does not go cold every time the window changes size.
-Destroying and re-attaching stays the path for a new graphics context.
+across that, so the map keeps its tiles and atlases every time the window
+changes size. It starts a new renderer when the scale factor changes, or when
+the replacement's format or layouts differ from the outgoing one's, since
+pipelines are built against those. Destroying and re-attaching stays the path
+for a new graphics context.
 
 How much synchronization you owe depends on the backend. An OpenGL session
 finishes its render before `render_update()` returns, so you can sample the

--- a/docs/src/content/docs/guides/render-to-a-texture.mdx
+++ b/docs/src/content/docs/guides/render-to-a-texture.mdx
@@ -70,8 +70,9 @@ across that, so the map keeps its tiles and atlases every time the window
 changes size. A scale factor change is the exception, starting a new renderer
 for the new pixel ratio.
 
-Hand over a replacement with the same format and layouts the session attached
-with. Pipelines are built against those, so a target that differs comes back as
+Hand over a replacement with the same format, layouts, and sample count the
+session attached with. Pipelines are built against those, so one that differs
+comes back as
 `MLN_STATUS_UNSUPPORTED` with the session still rendering into the texture it
 has. Destroying and re-attaching is what changes them, and what a new graphics
 context needs.

--- a/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/AndroidMapView.kt
+++ b/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/AndroidMapView.kt
@@ -190,7 +190,18 @@ internal class AndroidMapView(context: Context) :
     val currentGraphics = graphics ?: return
     val currentViewport = viewport?.takeUnless { it.isEmpty } ?: return
     val target = renderTarget ?: return
-    target.resize(currentGraphics, currentViewport)
+    try {
+      target.resize(currentGraphics, currentViewport)
+    } catch (error: RuntimeException) {
+      // The surface this session was presenting through is already gone by now,
+      // and a failed handover may have left it holding either that one or the
+      // replacement. Close it here rather than let a lifecycle callback throw
+      // with a live session naming a destroyed surface; the next surface
+      // attaches a new one.
+      Log.w(TAG, "$change: handing the surface over failed; the session is closed", error)
+      detachSurface()
+      return
+    }
     Log.i(TAG, "$change: the live session followed it and kept its renderer")
   }
 

--- a/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/AndroidMapView.kt
+++ b/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/AndroidMapView.kt
@@ -13,6 +13,12 @@ import android.view.SurfaceView
  * The UI thread owns the surface, touch input, the viewport, the graphics context, and the render
  * session it attaches. It touches the map only to attach, which native serves from any thread;
  * every other map call belongs to [MapRuntimeLoop].
+ *
+ * The platform destroys and recreates this view's surface across a rotation and across a trip to
+ * the background. A graphics context that outlives its surface keeps the session attached to it,
+ * which follows the replacement and keeps its renderer, so the map comes back with its tiles,
+ * atlases, and symbol placement rather than building them again. A context that goes with its
+ * surface takes the session with it, and the next frame attaches a cold one.
  */
 internal class AndroidMapView(context: Context) :
   SurfaceView(context), SurfaceHolder.Callback2, Choreographer.FrameCallback, AutoCloseable {
@@ -27,6 +33,9 @@ internal class AndroidMapView(context: Context) :
 
   /** Set when a frame threw, so the view stops scheduling against a broken target. */
   private var frameFailed = false
+
+  /** Set when a failed frame spent its one rebuild, until a rendered frame earns another. */
+  private var contextRebuildSpent = false
   private var closed = false
   private val pendingDrawingFinished = ArrayDeque<Runnable>()
 
@@ -61,15 +70,15 @@ internal class AndroidMapView(context: Context) :
   }
 
   override fun surfaceCreated(holder: SurfaceHolder) {
-    recreateSurface(holder)
+    surfaceAvailable(holder)
   }
 
   override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
-    recreateSurface(holder)
+    surfaceAvailable(holder)
   }
 
   override fun surfaceDestroyed(holder: SurfaceHolder) {
-    detachSurface()
+    surfaceLost()
   }
 
   override fun surfaceRedrawNeeded(holder: SurfaceHolder) {
@@ -96,6 +105,7 @@ internal class AndroidMapView(context: Context) :
         // is not discarded.
         if (target != null && loop.renderRequest.consume()) {
           if (target.renderUpdate()) {
+            contextRebuildSpent = false
             finishPendingDrawing()
           } else {
             // The map applies its logical size on the runtime loop's next pump, so an attach is
@@ -104,11 +114,8 @@ internal class AndroidMapView(context: Context) :
           }
         }
       } catch (error: RuntimeException) {
-        // Re-arming here would repost every vsync against a target that keeps throwing. Close it
-        // so the map can be destroyed, and stop scheduling frames.
         Log.e(TAG, "frame failed", error)
-        frameFailed = true
-        detachSurface()
+        rebuildAfterFrameFailure()
       }
     }
     startLoopIfReady()
@@ -135,9 +142,9 @@ internal class AndroidMapView(context: Context) :
     requestRender()
   }
 
-  private fun recreateSurface(holder: SurfaceHolder) {
+  /** Presents through the surface the platform just handed over, at the size it comes with. */
+  private fun surfaceAvailable(holder: SurfaceHolder) {
     if (closed) return
-    detachSurface()
     val nextViewport =
       Viewport.fromView(width, height, resources.displayMetrics.density).also { it.log("surface") }
     viewport = nextViewport
@@ -145,15 +152,73 @@ internal class AndroidMapView(context: Context) :
       finishPendingDrawing()
       return
     }
-    val nextGraphics = GraphicsContext.create(holder.surface)
-    graphics = nextGraphics
+    if (graphics?.setSurface(holder.surface) != true) {
+      // No context yet, or one that cannot present through this surface. The session goes with it,
+      // since a session outlives only the context it attached against, and the next frame attaches
+      // a cold one against the context built here.
+      detachSurface()
+      val nextGraphics = GraphicsContext.create(holder.surface)
+      graphics = nextGraphics
+      Log.i(TAG, "render-target=native-surface status=${nextGraphics.backendName}")
+    }
     // The runtime loop outlives surface changes: it keeps the runtime and the map alive so loading
     // continues while there is nothing to present to.
     if (runtimeLoop == null) {
       runtimeLoop = MapRuntimeLoop(nextViewport)
     }
-    Log.i(TAG, "render-target=native-surface status=${nextGraphics.backendName}")
+    followSurface("surface available")
     requestRender()
+  }
+
+  /** Gives back the surface the platform is taking, keeping what outlives it. */
+  private fun surfaceLost() {
+    if (graphics?.releaseSurface() == true) {
+      // The context outlived the surface, so the session parks on it and keeps its renderer until
+      // a surface returns. Frames stop meanwhile: there is nothing to present to.
+      followSurface("surface released")
+    } else {
+      detachSurface()
+    }
+    finishPendingDrawing()
+  }
+
+  /**
+   * Points the live session at the surface its graphics context presents through now, and at the
+   * current viewport. A session yet to be attached takes both from [SurfaceRenderTarget.attach].
+   */
+  private fun followSurface(change: String) {
+    val currentGraphics = graphics ?: return
+    val currentViewport = viewport?.takeUnless { it.isEmpty } ?: return
+    val target = renderTarget ?: return
+    target.resize(currentGraphics, currentViewport)
+    Log.i(TAG, "$change: the live session followed it and kept its renderer")
+  }
+
+  /**
+   * Builds again after a failed frame, once.
+   *
+   * A lost graphics context is the one change a session cannot be carried across: nothing in it
+   * survives, so the session goes with it and the next frame attaches a cold one against a context
+   * built from the surface the platform still holds. A second failure with no good frame in between
+   * is a target that keeps throwing rather than a context that was lost, so stop scheduling instead
+   * of reposting every vsync against it.
+   */
+  private fun rebuildAfterFrameFailure() {
+    detachSurface()
+    val surface = holder.surface
+    if (contextRebuildSpent || !surface.isValid) {
+      frameFailed = true
+      return
+    }
+    contextRebuildSpent = true
+    graphics =
+      try {
+        GraphicsContext.create(surface)
+      } catch (error: RuntimeException) {
+        Log.e(TAG, "rebuilding the graphics context failed", error)
+        frameFailed = true
+        null
+      }
   }
 
   private fun detachSurface() {
@@ -191,7 +256,8 @@ internal class AndroidMapView(context: Context) :
     !closed &&
       viewVisible &&
       appForeground &&
-      graphics != null &&
+      // A parked context has no surface to present to, so its session waits rather than renders.
+      graphics?.hasSurface == true &&
       !frameFailed &&
       runtimeLoop != null &&
       // A loop whose setup failed never publishes a map, so reposting every

--- a/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/EglGraphicsContext.kt
+++ b/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/EglGraphicsContext.kt
@@ -5,11 +5,20 @@ import android.opengl.EGLConfig
 import android.opengl.EGLContext
 import android.opengl.EGLDisplay
 import android.opengl.EGLSurface
+import android.util.Log
 import android.view.Surface
 import org.maplibre.nativeffi.render.EglContextDescriptor
 import org.maplibre.nativeffi.render.NativePointer
 import org.maplibre.nativeffi.render.OpenGLContextDescriptor
 
+/**
+ * The EGL context.
+ *
+ * The display, the config, and the share context are independent of any one host surface: EGL keeps
+ * them across a window that is destroyed and recreated, which is what a rotation and a trip to the
+ * background look like from here. Only the window surface is rebuilt, so a session attached against
+ * this context is pointed at the replacement rather than closed.
+ */
 internal class EglGraphicsContext
 private constructor(
   private val display: EGLDisplay,
@@ -18,6 +27,18 @@ private constructor(
   private var windowSurface: EGLSurface,
 ) : GraphicsContext {
   override val backendName: String = "opengl-egl"
+
+  /**
+   * Where a parked session presents while the platform has taken the window away.
+   *
+   * An EGL surface session always names a surface, and this one stays valid with no window behind
+   * it, so the session survives the gap holding something it can still make current when it closes.
+   * Nothing renders into it: the view stops scheduling frames while [hasSurface] is false.
+   */
+  private var parkedSurface: EGLSurface = EGL14.EGL_NO_SURFACE
+
+  override val hasSurface: Boolean
+    get() = windowSurface != EGL14.EGL_NO_SURFACE
 
   val descriptor: OpenGLContextDescriptor
     get() =
@@ -28,13 +49,51 @@ private constructor(
         NativePointer.NULL,
       )
 
+  /** The EGL surface a session presents through: the host window, or the parking surface. */
   val surfacePointer: NativePointer
-    get() = NativePointer.ofAddress(windowSurface.nativeHandle)
+    get() = NativePointer.ofAddress((if (hasSurface) windowSurface else parkedSurface).nativeHandle)
+
+  override fun setSurface(surface: Surface): Boolean {
+    if (hasSurface) {
+      // The window this context already presents through, handed back after a size or format
+      // change. An EGL window surface follows its window's size, so there is nothing to rebuild;
+      // the session takes the new extent through the descriptor it is handed.
+      return true
+    }
+    val next = EGL14.eglCreateWindowSurface(display, config, surface, WINDOW_ATTRIBUTES, 0)
+    if (next == EGL14.EGL_NO_SURFACE) {
+      // Reported rather than thrown. A display or context that can no longer serve a window
+      // surface is what a lost EGL context looks like from here, and the caller answers that by
+      // building this context and its session again.
+      Log.w(TAG, eglFailure("creating an EGL window surface"))
+      return false
+    }
+    windowSurface = next
+    return true
+  }
+
+  override fun releaseSurface(): Boolean {
+    if (!hasSurface) {
+      return true
+    }
+    if (!ensureParkedSurface()) {
+      // Nowhere for a session to park, so this context cannot outlive the window after all. The
+      // caller closes the session before the window surface goes with this context.
+      return false
+    }
+    EGL14.eglDestroySurface(display, windowSurface)
+    windowSurface = EGL14.EGL_NO_SURFACE
+    return true
+  }
 
   override fun close() {
     if (windowSurface != EGL14.EGL_NO_SURFACE) {
       EGL14.eglDestroySurface(display, windowSurface)
       windowSurface = EGL14.EGL_NO_SURFACE
+    }
+    if (parkedSurface != EGL14.EGL_NO_SURFACE) {
+      EGL14.eglDestroySurface(display, parkedSurface)
+      parkedSurface = EGL14.EGL_NO_SURFACE
     }
     if (shareContext != EGL14.EGL_NO_CONTEXT) {
       EGL14.eglDestroyContext(display, shareContext)
@@ -44,7 +103,22 @@ private constructor(
     EGL14.eglReleaseThread()
   }
 
+  private fun ensureParkedSurface(): Boolean {
+    if (parkedSurface != EGL14.EGL_NO_SURFACE) {
+      return true
+    }
+    val attributes = intArrayOf(EGL14.EGL_WIDTH, 1, EGL14.EGL_HEIGHT, 1, EGL14.EGL_NONE)
+    parkedSurface = EGL14.eglCreatePbufferSurface(display, config, attributes, 0)
+    if (parkedSurface == EGL14.EGL_NO_SURFACE) {
+      Log.w(TAG, eglFailure("creating the EGL parking surface"))
+      return false
+    }
+    return true
+  }
+
   companion object {
+    private const val TAG = "MapLibreAndroidMap"
+
     fun create(surface: Surface): EglGraphicsContext {
       val display = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY)
       check(display != EGL14.EGL_NO_DISPLAY) { "EGL display is unavailable" }
@@ -58,9 +132,8 @@ private constructor(
         EGL14.eglCreateContext(display, config, EGL14.EGL_NO_CONTEXT, contextAttributes, 0)
       check(context != EGL14.EGL_NO_CONTEXT) { "creating EGL share context failed" }
 
-      val surfaceAttributes = intArrayOf(EGL14.EGL_NONE)
       val windowSurface =
-        EGL14.eglCreateWindowSurface(display, config, surface, surfaceAttributes, 0)
+        EGL14.eglCreateWindowSurface(display, config, surface, WINDOW_ATTRIBUTES, 0)
       check(windowSurface != EGL14.EGL_NO_SURFACE) { "creating EGL window surface failed" }
       return EglGraphicsContext(display, config, context, windowSurface)
     }
@@ -71,7 +144,9 @@ private constructor(
           EGL14.EGL_RENDERABLE_TYPE,
           EGL_OPENGL_ES3_BIT,
           EGL14.EGL_SURFACE_TYPE,
-          EGL14.EGL_WINDOW_BIT,
+          // The parking surface is a pbuffer, and a session makes it current with the context it
+          // was given at attach, so one config has to serve both kinds of surface.
+          EGL14.EGL_WINDOW_BIT or EGL14.EGL_PBUFFER_BIT,
           EGL14.EGL_RED_SIZE,
           8,
           EGL14.EGL_GREEN_SIZE,
@@ -93,16 +168,21 @@ private constructor(
         "choose EGL config",
       )
       check(count[0] > 0 && configs[0] != null) {
-        "no EGL config supports OpenGL ES 3 window rendering"
+        "no EGL config supports OpenGL ES 3 window and pbuffer rendering"
       }
       return configs[0]!!
     }
 
     private fun eglCheck(ok: Boolean, operation: String) {
       if (!ok) {
-        error("$operation failed with EGL error 0x${EGL14.eglGetError().toString(16)}")
+        error(eglFailure(operation))
       }
     }
+
+    private fun eglFailure(operation: String): String =
+      "$operation failed with EGL error 0x${EGL14.eglGetError().toString(16)}"
+
+    private val WINDOW_ATTRIBUTES = intArrayOf(EGL14.EGL_NONE)
 
     private const val EGL_OPENGL_ES3_BIT = 0x00000040
   }

--- a/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/GraphicsContext.kt
+++ b/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/GraphicsContext.kt
@@ -2,8 +2,42 @@ package org.maplibre.nativeffi.examples.androidmap
 
 import android.view.Surface
 
+/**
+ * The host graphics context.
+ *
+ * A `SurfaceView` destroys and recreates its surface across a rotation and across a trip to the
+ * background, while the map goes on living. A context whose handles outlive that keeps presenting
+ * through whatever surface it holds now, so the render session attached against it stays live and
+ * keeps its renderer. A context built from the surface itself says so instead, and the caller
+ * closes the session with it.
+ */
 internal interface GraphicsContext : AutoCloseable {
   val backendName: String
+
+  /** Whether this context presents through a live host surface, so a frame has somewhere to go. */
+  val hasSurface: Boolean
+
+  /**
+   * Presents through the host surface the platform just handed over, reporting whether this context
+   * took it.
+   *
+   * `false` means this context cannot present through it, either because its handles belong to the
+   * surface it was built for or because the graphics API context itself is gone. The caller then
+   * closes the session attached against this context, closes this context, and builds both again,
+   * accepting a cold renderer.
+   */
+  fun setSurface(surface: Surface): Boolean
+
+  /**
+   * Releases the host surface the platform is taking back, reporting whether this context outlived
+   * it.
+   *
+   * `true` leaves this context presenting somewhere harmless until a surface returns, so a session
+   * attached against it stays live and keeps its renderer across the gap. `false` means the surface
+   * and this context share one lifetime, so the caller closes the session and this context
+   * together.
+   */
+  fun releaseSurface(): Boolean
 
   companion object {
     fun create(surface: Surface): GraphicsContext =

--- a/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/SurfaceRenderTarget.kt
+++ b/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/SurfaceRenderTarget.kt
@@ -15,6 +15,35 @@ internal class SurfaceRenderTarget private constructor(private val session: Rend
   AutoCloseable {
   fun renderUpdate(): Boolean = session.renderUpdate()
 
+  /**
+   * Follows the host viewport and the surface [graphics] presents through now.
+   *
+   * The platform destroys and recreates a `SurfaceView`'s surface while the map goes on living, so
+   * following it means handing the live session whatever surface its graphics context holds now
+   * rather than closing the session. The session keeps its renderer across that, and with it the
+   * tile pyramid, glyph and image atlases, symbol placement, and feature state, so a rotation or a
+   * return from the background comes back to a warm map. A scale factor change is the exception the
+   * C API documents, starting a new renderer for the new pixel ratio.
+   *
+   * The OpenGL path carries a resize and a surface replacement through one call: the extent applies
+   * as a resize applies one, and the surface is made current on the next render, which is what lets
+   * it name a replacement for a surface the platform has already destroyed. The surface a Vulkan
+   * session presents through cannot be replaced this way, because the session destroys its
+   * swapchain before taking the new one and the outgoing surface has to still be valid for that;
+   * only a resized window reaches here, and the session resizes against the surface it has.
+   */
+  fun resize(graphics: GraphicsContext, viewport: Viewport) {
+    when (graphics) {
+      is EglGraphicsContext ->
+        session.setOpenGLSurfaceTarget(
+          OpenGLSurfaceDescriptor(viewport.extent, graphics.descriptor, graphics.surfacePointer)
+        )
+      is VulkanGraphicsContext ->
+        session.resize(viewport.logicalWidth, viewport.logicalHeight, viewport.scaleFactor)
+      else -> error("Unsupported graphics context: ${graphics::class.java.name}")
+    }
+  }
+
   override fun close() {
     session.close()
   }

--- a/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/VulkanGraphicsContext.kt
+++ b/examples/android-map/src/main/kotlin/org/maplibre/nativeffi/examples/androidmap/VulkanGraphicsContext.kt
@@ -4,9 +4,20 @@ import android.view.Surface
 import org.maplibre.nativeffi.render.NativePointer
 import org.maplibre.nativeffi.render.VulkanContextDescriptor
 
+/**
+ * The Vulkan context.
+ *
+ * The instance, the device, and the queue are chosen for the `VkSurfaceKHR` this context created
+ * from the host window, and a session attached against it holds a swapchain built from that
+ * surface. Vulkan destroys every swapchain before its surface, so a window the platform takes away
+ * takes this context and its session with it.
+ */
 internal class VulkanGraphicsContext private constructor(private var handle: Long) :
   GraphicsContext {
   override val backendName: String = "vulkan"
+
+  override val hasSurface: Boolean
+    get() = handle != 0L
 
   val descriptor: VulkanContextDescriptor
     get() =
@@ -22,6 +33,26 @@ internal class VulkanGraphicsContext private constructor(private var handle: Lon
 
   val surfacePointer: NativePointer
     get() = NativePointer.ofAddress(VulkanNativeBridge.surface(handle))
+
+  /**
+   * Takes the window this context was built for, which is the only one that reaches here.
+   *
+   * [releaseSurface] is the only way the platform takes a window away from this context, and it
+   * closes this context, so a context still alive at this call is presenting through the window the
+   * platform is handing back. Only its size changed, and the session follows that by resizing.
+   */
+  override fun setSurface(surface: Surface): Boolean = hasSurface
+
+  /**
+   * Reports that this context cannot outlive its window.
+   *
+   * A session attached against this context holds a swapchain built from its `VkSurfaceKHR`, and
+   * replacing that surface requires the outgoing one to still be valid, because Vulkan destroys
+   * every swapchain before its surface. The platform is taking that surface away here, so the
+   * session and this context close together and attach again against the next window, accepting a
+   * cold renderer.
+   */
+  override fun releaseSurface(): Boolean = false
 
   override fun close() {
     if (handle == 0L) {

--- a/examples/compose-map/mise.toml
+++ b/examples/compose-map/mise.toml
@@ -12,10 +12,14 @@ run = '''
 '''
 
 [tasks.run]
-depends = ["//:build"]
+# The preset picks the backend: the example takes it from the render backend the
+# native library was built with, so a bridge other than the host default's is
+# reached by running against that preset.
+usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
+depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
 run = '''
 ./gradlew \
-  -PmaplibreNativeCInstallDir="build/{{vars.host_native_preset}}/install" \
+  -PmaplibreNativeCInstallDir="build/$usage_preset/install" \
   :examples:compose-map:run
 '''

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapChannels.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapChannels.kt
@@ -43,17 +43,9 @@ internal sealed interface CameraCommand {
  */
 internal class CameraCommandQueue {
   private val queue = ConcurrentLinkedQueue<CameraCommand>()
-  private val wakeLock = Any()
-  private var wakeAction: (() -> Unit)? = null
 
-  /**
-   * Set once the runtime loop has acquired its wake source, and cleared before it closes that
-   * source. Reads and writes take the same lock as [wake], so the loop cannot close the source out
-   * from under a signal already on its way.
-   */
-  var onEnqueue: (() -> Unit)?
-    get() = synchronized(wakeLock) { wakeAction }
-    set(value) = synchronized(wakeLock) { wakeAction = value }
+  /** Set once the runtime loop has acquired its wake source. */
+  @Volatile var onEnqueue: (() -> Unit)? = null
 
   fun enqueue(command: CameraCommand) {
     queue.add(command)
@@ -68,7 +60,7 @@ internal class CameraCommandQueue {
   }
 
   fun wake() {
-    synchronized(wakeLock) { wakeAction?.invoke() }
+    onEnqueue?.invoke()
   }
 }
 

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapChannels.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapChannels.kt
@@ -43,9 +43,17 @@ internal sealed interface CameraCommand {
  */
 internal class CameraCommandQueue {
   private val queue = ConcurrentLinkedQueue<CameraCommand>()
+  private val wakeLock = Any()
+  private var wakeAction: (() -> Unit)? = null
 
-  /** Set once the runtime loop has acquired its wake source. */
-  @Volatile var onEnqueue: (() -> Unit)? = null
+  /**
+   * Set once the runtime loop has acquired its wake source, and cleared before it closes that
+   * source. Reads and writes take the same lock as [wake], so the loop cannot close the source out
+   * from under a signal already on its way.
+   */
+  var onEnqueue: (() -> Unit)?
+    get() = synchronized(wakeLock) { wakeAction }
+    set(value) = synchronized(wakeLock) { wakeAction = value }
 
   fun enqueue(command: CameraCommand) {
     queue.add(command)
@@ -60,7 +68,7 @@ internal class CameraCommandQueue {
   }
 
   fun wake() {
-    onEnqueue?.invoke()
+    synchronized(wakeLock) { wakeAction?.invoke() }
   }
 }
 

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreNativeSurfaceAdapter.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreNativeSurfaceAdapter.kt
@@ -32,100 +32,119 @@ internal object MapLibreNativeSurfaceAdapter {
         "Expected exactly one MapLibre render backend, found ${Maplibre.supportedRenderBackends()}"
       )
 
-  fun descriptor(target: NativeSurfaceTarget, extent: SurfaceExtent): BorrowedDescriptor =
+  fun borrowedTarget(target: NativeSurfaceTarget, extent: SurfaceExtent): BorrowedTarget =
     when (target) {
-      is MetalTextureTarget -> metalDescriptor(target, extent)
-      is VulkanImageTarget -> vulkanDescriptor(target, extent)
-      is OpenGlTextureTarget -> openGlDescriptor(target, extent)
+      is MetalTextureTarget -> metalTarget(target, extent)
+      is VulkanImageTarget -> vulkanTarget(target, extent)
+      is OpenGlTextureTarget -> openGlTarget(target, extent)
     }
 
-  private fun metalDescriptor(
-    target: MetalTextureTarget,
-    extent: SurfaceExtent,
-  ): BorrowedDescriptor =
-    BorrowedDescriptor(
-      key = targetKey(target.backend, target.generation, extent),
-      attach = { map ->
-        map.attachMetalBorrowedTexture(
-          MetalBorrowedTextureDescriptor(
-            extent.toRenderTargetExtent(),
-            extent.physicalWidth,
-            extent.physicalHeight,
-            target.texture.toPointer(),
-          )
+  private fun metalTarget(target: MetalTextureTarget, extent: SurfaceExtent): BorrowedTarget {
+    val descriptor =
+      MetalBorrowedTextureDescriptor(
+        extent.toRenderTargetExtent(),
+        extent.physicalWidth,
+        extent.physicalHeight,
+        target.texture.toPointer(),
+      )
+    return BorrowedTarget(
+      sessionKey = SessionKey.Metal(target.device, target.pixelFormat),
+      targetKey = TargetKey(target.generation, extent),
+      attach = { map -> map.attachMetalBorrowedTexture(descriptor) },
+      setTarget = { session -> session.setMetalBorrowedTextureTarget(descriptor) },
+    )
+  }
+
+  private fun vulkanTarget(target: VulkanImageTarget, extent: SurfaceExtent): BorrowedTarget {
+    val descriptor =
+      VulkanBorrowedTextureDescriptor(
+          extent.toRenderTargetExtent(),
+          extent.physicalWidth,
+          extent.physicalHeight,
+          target.context.toDescriptor(),
+          target.image.toPointer(),
+          target.imageView.toPointer(),
+          target.format,
+          target.initialLayout,
         )
-      },
+        .apply { finalLayout = target.finalLayout }
+    return BorrowedTarget(
+      sessionKey =
+        SessionKey.Vulkan(
+          context = target.context,
+          format = target.format,
+          initialLayout = target.initialLayout,
+          finalLayout = target.finalLayout,
+        ),
+      targetKey = TargetKey(target.generation, extent),
+      attach = { map -> map.attachVulkanBorrowedTexture(descriptor) },
+      setTarget = { session -> session.setVulkanBorrowedTextureTarget(descriptor) },
     )
+  }
 
-  private fun vulkanDescriptor(
-    target: VulkanImageTarget,
-    extent: SurfaceExtent,
-  ): BorrowedDescriptor =
-    BorrowedDescriptor(
-      key = targetKey(target.backend, target.generation, extent),
-      attach = { map ->
-        map.attachVulkanBorrowedTexture(
-          VulkanBorrowedTextureDescriptor(
-              extent.toRenderTargetExtent(),
-              extent.physicalWidth,
-              extent.physicalHeight,
-              target.context.toDescriptor(),
-              target.image.toPointer(),
-              target.imageView.toPointer(),
-              target.format,
-              target.initialLayout,
-            )
-            .apply { finalLayout = target.finalLayout }
-        )
-      },
+  private fun openGlTarget(target: OpenGlTextureTarget, extent: SurfaceExtent): BorrowedTarget {
+    val descriptor =
+      OpenGLBorrowedTextureDescriptor(
+        extent.toRenderTargetExtent(),
+        extent.physicalWidth,
+        extent.physicalHeight,
+        target.context.toDescriptor(),
+        target.textureName,
+        target.textureTarget,
+      )
+    return BorrowedTarget(
+      sessionKey = SessionKey.OpenGl(target.context),
+      targetKey = TargetKey(target.generation, extent),
+      attach = { map -> map.attachOpenGLBorrowedTexture(descriptor) },
+      setTarget = { session -> session.setOpenGLBorrowedTextureTarget(descriptor) },
     )
+  }
 
-  private fun openGlDescriptor(
-    target: OpenGlTextureTarget,
-    extent: SurfaceExtent,
-  ): BorrowedDescriptor =
-    BorrowedDescriptor(
-      key = targetKey(target.backend, target.generation, extent),
-      attach = { map ->
-        map.attachOpenGLBorrowedTexture(
-          OpenGLBorrowedTextureDescriptor(
-            extent.toRenderTargetExtent(),
-            extent.physicalWidth,
-            extent.physicalHeight,
-            target.context.toDescriptor(),
-            target.textureName,
-            target.textureTarget,
-          )
-        )
-      },
-    )
+  /**
+   * The part of a target a live render session cannot be moved across.
+   *
+   * A session takes a replacement texture for the graphics context it attached with. One naming
+   * another context or device is reported as an invalid argument, and one carrying another format
+   * as unsupported, both leaving the session rendering into the texture it has. So a target whose
+   * key still matches is handed over, and one whose key changed is a session to close and attach
+   * again, accepting a cold renderer.
+   *
+   * Extent and scale factor are absent on purpose: a session follows both through the same
+   * set-target call.
+   */
+  sealed interface SessionKey {
+    /**
+     * A Metal texture carries its device and pixel format, which is what a session compares against
+     * its own. Sample count needs no entry: attach admits only single-sample textures.
+     */
+    data class Metal(val device: NativeHandle, val pixelFormat: Long) : SessionKey
 
-  private fun targetKey(
-    backend: ProducerBackend,
-    generation: Long,
-    extent: SurfaceExtent,
-  ): TargetKey =
-    TargetKey(
-      backend = backend,
-      generation = generation,
-      width = extent.width,
-      height = extent.height,
-      scaleFactor = extent.scaleFactor,
-      physicalWidth = extent.physicalWidth,
-      physicalHeight = extent.physicalHeight,
-    )
+    /** A Vulkan session built its render pass around the format and both layouts. */
+    data class Vulkan(
+      val context: VulkanContextHandles,
+      val format: Int,
+      val initialLayout: Int,
+      val finalLayout: Int,
+    ) : SessionKey
 
-  data class TargetKey(
-    val backend: ProducerBackend,
-    val generation: Long,
-    val width: Int,
-    val height: Int,
-    val scaleFactor: Double,
-    val physicalWidth: Int,
-    val physicalHeight: Int,
+    /** An OpenGL session names its context provider data and nothing else. */
+    data class OpenGl(val context: OpenGlContextHandles) : SessionKey
+  }
+
+  /**
+   * The texture a session is rendering into right now.
+   *
+   * A bridge counts a generation up every time it allocates, so a key that still matches means the
+   * session already renders into this texture at this size and nothing has to be handed over.
+   */
+  data class TargetKey(val generation: Long, val extent: SurfaceExtent)
+
+  class BorrowedTarget(
+    val sessionKey: SessionKey,
+    val targetKey: TargetKey,
+    val attach: (MapHandle) -> RenderSessionHandle,
+    val setTarget: (RenderSessionHandle) -> Unit,
   )
-
-  class BorrowedDescriptor(val key: TargetKey, val attach: (MapHandle) -> RenderSessionHandle)
 }
 
 private fun SurfaceExtent.toRenderTargetExtent(): RenderTargetExtent =

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreSurfaceRenderer.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreSurfaceRenderer.kt
@@ -15,8 +15,9 @@ import org.maplibre.nativeffi.render.RenderSessionHandle
  * The render loop.
  *
  * [render] runs on the bridge's producer thread, which owns the host graphics context and the
- * borrowed texture, so that thread attaches the render session, renders through it, reattaches it
- * on resize, and closes it. It touches the map only to attach, which native serves from any thread.
+ * borrowed texture, so that thread attaches the render session, renders through it, hands it each
+ * texture the bridge allocates for a resize, and closes it. It touches the map only to attach,
+ * which native serves from any thread.
  *
  * Input decoding runs on the Compose thread and only enqueues camera commands; [MapRuntimeLoop]
  * applies them on the thread that owns the map.
@@ -189,19 +190,37 @@ internal class MapLibreSurfaceRenderer : NativeSurfaceRenderer {
     stopping?.close()
   }
 
+  /**
+   * Renders through a session that is already attached to the texture this frame carries.
+   *
+   * Skiko reallocates its texture on every resize, so the frame arrives with a new one whenever the
+   * window changes size. That is not a new session: as long as the texture belongs to the same
+   * graphics context the session attached with, handing it over keeps the session's renderer, and
+   * with it the tile pyramid, glyph and image atlases, and symbol placement, so the map stays warm
+   * across the resize. Closing and attaching again is reserved for the context itself changing,
+   * which is a session this one's renderer holds nothing usable for.
+   */
   private fun ensureAttachedRenderSession(
     map: MapHandle,
     frame: NativeSurfaceFrame,
   ): AttachedRenderSession {
-    val descriptor = MapLibreNativeSurfaceAdapter.descriptor(frame.target, frame.extent)
+    val borrowed = MapLibreNativeSurfaceAdapter.borrowedTarget(frame.target, frame.extent)
     renderSession?.let { existing ->
-      if (existing.key == descriptor.key) {
-        return existing
+      if (existing.sessionKey == borrowed.sessionKey) {
+        if (existing.targetKey == borrowed.targetKey) {
+          return existing
+        }
+        borrowed.setTarget(existing.session)
+        val retargeted = existing.copy(targetKey = borrowed.targetKey)
+        renderSession = retargeted
+        renderRequest.set()
+        return retargeted
       }
     }
 
     closeRenderSession()
-    val attached = AttachedRenderSession(descriptor.key, descriptor.attach(map))
+    val attached =
+      AttachedRenderSession(borrowed.sessionKey, borrowed.targetKey, borrowed.attach(map))
     renderSession = attached
     renderRequest.set()
     return attached
@@ -219,7 +238,8 @@ internal class MapLibreSurfaceRenderer : NativeSurfaceRenderer {
   }
 
   private data class AttachedRenderSession(
-    val key: MapLibreNativeSurfaceAdapter.TargetKey,
+    val sessionKey: MapLibreNativeSurfaceAdapter.SessionKey,
+    val targetKey: MapLibreNativeSurfaceAdapter.TargetKey,
     val session: RenderSessionHandle,
   )
 

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreSurfaceRenderer.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreSurfaceRenderer.kt
@@ -210,7 +210,20 @@ internal class MapLibreSurfaceRenderer : NativeSurfaceRenderer {
         if (existing.targetKey == borrowed.targetKey) {
           return existing
         }
-        borrowed.setTarget(existing.session)
+        try {
+          borrowed.setTarget(existing.session)
+        } catch (error: RuntimeException) {
+          // A native error may mean the session took the replacement before failing, and nothing
+          // here can tell that apart from a rejection that came first. Skiko owns both textures and
+          // frees the outgoing one as soon as it moves on, so closing the session is the only way
+          // to be sure it is holding neither by the time that happens.
+          try {
+            closeRenderSession()
+          } catch (cleanupError: Exception) {
+            error.addSuppressed(cleanupError)
+          }
+          throw error
+        }
         val retargeted = existing.copy(targetKey = borrowed.targetKey)
         renderSession = retargeted
         renderRequest.set()

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreSurfaceRenderer.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreSurfaceRenderer.kt
@@ -120,10 +120,6 @@ internal class MapLibreSurfaceRenderer : NativeSurfaceRenderer {
 
   fun requestRender() {
     renderRequest.set()
-    // A session applies its extent on the map's owner thread, so a resize renders nothing here
-    // until that thread picks it up. Release its parked pump rather than let the new size wait out
-    // the parking bound, which is long enough to see as a gap in the map while a window is dragged.
-    commands.wake()
     surfaceSession?.requestFrame()
   }
 
@@ -230,7 +226,7 @@ internal class MapLibreSurfaceRenderer : NativeSurfaceRenderer {
         }
         val retargeted = existing.copy(targetKey = borrowed.targetKey)
         renderSession = retargeted
-        requestRender()
+        renderRequest.set()
         return retargeted
       }
     }
@@ -239,7 +235,7 @@ internal class MapLibreSurfaceRenderer : NativeSurfaceRenderer {
     val attached =
       AttachedRenderSession(borrowed.sessionKey, borrowed.targetKey, borrowed.attach(map))
     renderSession = attached
-    requestRender()
+    renderRequest.set()
     return attached
   }
 

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreSurfaceRenderer.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreSurfaceRenderer.kt
@@ -181,7 +181,7 @@ internal class MapLibreSurfaceRenderer : NativeSurfaceRenderer {
       closeRenderSession()
       stopRuntimeLoop()
     }
-    return MapRuntimeLoop(extent, commands, renderRequest).also { runtimeLoop = it }
+    return MapRuntimeLoop(extent, commands, ::requestRender).also { runtimeLoop = it }
   }
 
   private fun stopRuntimeLoop() {

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreSurfaceRenderer.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapLibreSurfaceRenderer.kt
@@ -120,6 +120,10 @@ internal class MapLibreSurfaceRenderer : NativeSurfaceRenderer {
 
   fun requestRender() {
     renderRequest.set()
+    // A session applies its extent on the map's owner thread, so a resize renders nothing here
+    // until that thread picks it up. Release its parked pump rather than let the new size wait out
+    // the parking bound, which is long enough to see as a gap in the map while a window is dragged.
+    commands.wake()
     surfaceSession?.requestFrame()
   }
 
@@ -226,7 +230,7 @@ internal class MapLibreSurfaceRenderer : NativeSurfaceRenderer {
         }
         val retargeted = existing.copy(targetKey = borrowed.targetKey)
         renderSession = retargeted
-        renderRequest.set()
+        requestRender()
         return retargeted
       }
     }
@@ -235,7 +239,7 @@ internal class MapLibreSurfaceRenderer : NativeSurfaceRenderer {
     val attached =
       AttachedRenderSession(borrowed.sessionKey, borrowed.targetKey, borrowed.attach(map))
     renderSession = attached
-    renderRequest.set()
+    requestRender()
     return attached
   }
 

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapRuntimeLoop.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/map/MapRuntimeLoop.kt
@@ -30,7 +30,7 @@ import org.maplibre.nativeffi.runtime.WakeSource
 internal class MapRuntimeLoop(
   private val initialExtent: SurfaceExtent,
   private val commands: CameraCommandQueue,
-  private val renderRequest: RenderRequest,
+  private val requestRender: () -> Unit,
 ) : AutoCloseable {
   /** The map's scale factor is fixed at creation, so a density change restarts the whole loop. */
   val scaleFactor: Double
@@ -136,7 +136,10 @@ internal class MapRuntimeLoop(
       // backstop rather than the cadence.
       runtime.pump(PARK_TIMEOUT_MS)
       if (drainEvents(runtime, map)) {
-        renderRequest.set()
+        // Compose draws on demand, so a map update is worth a frame only if something asks for
+        // one. Tiles, style loads, and animation ticks all arrive here with no host input behind
+        // them, and the frame after a resize is one of them.
+        requestRender()
       }
     }
   }

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/ComposeNativeSurface.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/ComposeNativeSurface.kt
@@ -98,7 +98,6 @@ public fun ComposeNativeSurface(
       try {
         extent.log("compose viewport")
         bridge.resize(extent)
-        drawState.resetForExtent(extent)
         renderer.onSurfaceChanged(extent)
         session?.requestFrame()
       } catch (error: Throwable) {
@@ -167,17 +166,17 @@ public fun ComposeNativeSurface(
 }
 
 private class NativeSurfaceDrawState {
-  private var extent = SurfaceExtent.Empty
   private var nextFrameId = 1L
 
+  /**
+   * The target a frame last rendered into, drawn again whenever a frame has nothing new.
+   *
+   * A resize keeps it rather than clearing it: the bridge holds that target until one lands in the
+   * texture it allocated for the new size, and drawing the old one stretched over the new bounds is
+   * what a resized window shows before its next frame. A bridge that no longer holds the target
+   * refuses to draw it, which falls back to the placeholder.
+   */
   var lastRenderedTarget: NativeSurfaceTarget? = null
-
-  fun resetForExtent(next: SurfaceExtent) {
-    if (next != extent) {
-      extent = next
-      lastRenderedTarget = null
-    }
-  }
 
   fun nextFrameId(): Long = nextFrameId++
 }

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/ComposeNativeSurface.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/ComposeNativeSurface.kt
@@ -48,6 +48,10 @@ public fun ComposeNativeSurface(
   DisposableEffect(renderer, bridgeSelection, bridge, session, activeController) {
     when (bridgeSelection) {
       is NativeSurfaceBridgeSelection.Failed -> {
+        // Also to the console, because a bridge that never initializes is the
+        // one failure whose only other report is a window that may not be
+        // showing anything else worth reading.
+        bridgeSelection.error.printStackTrace()
         activeController.setState(
           NativeSurfaceState.Failed(
             message = "Native surface bridge initialization failed: ${bridgeSelection.message}",

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/LinuxOpenGlBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/LinuxOpenGlBridge.kt
@@ -79,8 +79,20 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
   private var exportedTexture: LinuxExportedVulkanTexture? = null
   private var producerTexture: LinuxEglImportedTexture? = null
   private var consumerTexture: LinuxOpenGlImportedTexture? = null
-  private var generation = 0L
   private var currentExtent = SurfaceExtent.Empty
+
+  @Volatile private var generation = 0L
+  @Volatile private var renderedGeneration = 0L
+
+  // The consumer texture a frame last landed in, kept alive with the memory it
+  // imports until one lands in its replacement. Skiko allocates a new texture
+  // for every resize and the map needs a frame or two to fill it, so this is
+  // what the consumer draws in between rather than having nothing to show. The
+  // producer import is not kept: the session already renders through the new
+  // texture.
+  private var retiredConsumerTexture: LinuxOpenGlImportedTexture? = null
+  private var retiredExportedTexture: LinuxExportedVulkanTexture? = null
+  @Volatile private var retiredGeneration = 0L
 
   override val backend: ProducerBackend = ProducerBackend.OPENGL
 
@@ -113,6 +125,12 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
     extent: SurfaceExtent,
     presentationTimeNanos: Long?,
   ): NativeSurfaceFrame {
+    // Runs a frame after the replacement first rendered, so the consumer's last
+    // recorded frame from the retired texture has been flushed by then. The
+    // consumer context is current here, which is what closing it needs.
+    if (retiredConsumerTexture != null && renderedGeneration == generation) {
+      disposeRetiredTexture(consumerContextCurrent = true)
+    }
     if (producerTexture == null || consumerTexture == null || extent != currentExtent) {
       recreateTexture(extent)
     }
@@ -125,6 +143,7 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
   }
 
   override fun completeProducerAccess(frame: NativeSurfaceFrame) {
+    renderedGeneration = frame.target.generation
     runOnProducerThread { egl.waitIdle() }
   }
 
@@ -137,13 +156,21 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
     if (target !is OpenGlTextureTarget) {
       return false
     }
-    val texture = consumerTexture ?: return false
+    // Only a texture this bridge still holds is safe to draw, which is the
+    // current one and the retired one behind it.
+    val texture =
+      when (target.generation) {
+        generation -> consumerTexture
+        retiredGeneration -> retiredConsumerTexture
+        else -> null
+      } ?: return false
     return SkikoHost.drawOpenGlTexture(scope, texture.target(target.generation))
   }
 
   override fun close() {
     try {
       disposeTexture(consumerContextCurrent = false)
+      disposeRetiredTexture(consumerContextCurrent = false)
     } finally {
       try {
         runOnProducerThread { egl.close() }
@@ -166,7 +193,7 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
       return
     }
 
-    disposeTexture(consumerContextCurrent = true)
+    retireTexture()
     val context =
       vulkan ?: LinuxVulkanContext.create(currentOpenGlDeviceUuids()).also { vulkan = it }
     val exported = context.createExportedTexture(extent)
@@ -196,6 +223,41 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
       exported.close()
       throw error
     }
+  }
+
+  // Holds the outgoing consumer texture for drawing while the replacement is
+  // still empty. A texture nothing ever rendered into has nothing to show, so
+  // it goes the way it always did.
+  private fun retireTexture() {
+    if (renderedGeneration != generation || consumerTexture == null) {
+      disposeTexture(consumerContextCurrent = true)
+      return
+    }
+    disposeRetiredTexture(consumerContextCurrent = true)
+    val oldProducerTexture = producerTexture
+    producerTexture = null
+    if (oldProducerTexture != null) {
+      runOnProducerThread { oldProducerTexture.close() }
+    }
+    retiredConsumerTexture = consumerTexture
+    retiredExportedTexture = exportedTexture
+    retiredGeneration = generation
+    consumerTexture = null
+    exportedTexture = null
+  }
+
+  private fun disposeRetiredTexture(consumerContextCurrent: Boolean = true) {
+    retiredConsumerTexture?.let { texture ->
+      if (consumerContextCurrent) {
+        texture.close()
+      } else {
+        SkikoHost.withLinuxOpenGlContext { texture.close() }
+      }
+    }
+    retiredConsumerTexture = null
+    retiredExportedTexture?.close()
+    retiredExportedTexture = null
+    retiredGeneration = 0
   }
 
   private fun disposeTexture(consumerContextCurrent: Boolean = true) {

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/LinuxOpenGlBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/LinuxOpenGlBridge.kt
@@ -94,6 +94,13 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
   private var retiredExportedTexture: LinuxExportedVulkanTexture? = null
   @Volatile private var retiredGeneration = 0L
 
+  // The Skiko OpenGL context both consumer imports were made in. Skiko destroys
+  // this context with the redrawer it belongs to and builds a new one for the
+  // replacement, and a GL name means nothing in a context that did not issue
+  // it. The producer imports live in this bridge's own EGL context, which
+  // Skiko does not touch.
+  private var consumerContext: SkikoOpenGlContext? = null
+
   override val backend: ProducerBackend = ProducerBackend.OPENGL
 
   override val consumerBackend: ConsumerBackend = ConsumerBackend.OPENGL
@@ -125,6 +132,7 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
     extent: SurfaceExtent,
     presentationTimeNanos: Long?,
   ): NativeSurfaceFrame {
+    abandonConsumerTexturesIfContextChanged()
     // Runs a frame after the replacement first rendered, so the consumer's last
     // recorded frame from the retired texture has been flushed by then. The
     // consumer context is current here, which is what closing it needs.
@@ -169,8 +177,15 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
 
   override fun close() {
     try {
-      disposeTexture(consumerContextCurrent = false)
-      disposeRetiredTexture(consumerContextCurrent = false)
+      // Skiko may have replaced or torn down the context these were imported
+      // into before the bridge is closed, and a name deleted there is an
+      // unrelated object in whatever context is current now.
+      if (consumerContextStillCurrent()) {
+        disposeTexture(consumerContextCurrent = false)
+        disposeRetiredTexture(consumerContextCurrent = false)
+      } else {
+        abandonConsumerTextures()
+      }
     } finally {
       try {
         runOnProducerThread { egl.close() }
@@ -213,6 +228,7 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
       exportedTexture = exported
       producerTexture = producer
       consumerTexture = consumer
+      consumerContext = SkikoHost.requireLinuxOpenGlContext()
       currentExtent = extent
       generation += 1
     } catch (error: RuntimeException) {
@@ -223,6 +239,53 @@ internal class LinuxOpenGlBridge : NativeSurfaceBridge {
       exported.close()
       throw error
     }
+  }
+
+  // Skiko destroys its OpenGL context along with the redrawer that owns it and
+  // builds a new one for the replacement, which happens while this bridge is
+  // running: the layer recreates its redrawer whenever AWT hands the component
+  // a new peer, and again whenever a draw fails and it falls back to another
+  // render API. Names from the old context cannot be drawn, and deleting them
+  // in the new one takes out whatever now answers to them, so both the current
+  // consumer import and the retired one behind it are given up untouched.
+  private fun abandonConsumerTexturesIfContextChanged() {
+    val recorded = consumerContext ?: return
+    if (recorded.matches(SkikoHost.requireLinuxOpenGlContext())) {
+      return
+    }
+    abandonConsumerTextures()
+  }
+
+  // Answers false when Skiko has no OpenGL context to ask about at all, which
+  // is what a torn-down window looks like and is reason enough to delete
+  // nothing.
+  private fun consumerContextStillCurrent(): Boolean {
+    val recorded = consumerContext ?: return false
+    val current = runCatching { SkikoHost.requireLinuxOpenGlContext() }.getOrNull() ?: return false
+    return recorded.matches(current)
+  }
+
+  private fun abandonConsumerTextures() {
+    consumerTexture?.abandon()
+    consumerTexture = null
+    retiredConsumerTexture?.abandon()
+    retiredConsumerTexture = null
+    retiredGeneration = 0
+    consumerContext = null
+    // The producer import lives in this bridge's own EGL context and the images
+    // in its own Vulkan device, neither of which Skiko's context change
+    // touches, so those are released rather than given up.
+    val oldProducerTexture = producerTexture
+    producerTexture = null
+    if (oldProducerTexture != null) {
+      runOnProducerThread { oldProducerTexture.close() }
+    }
+    exportedTexture?.close()
+    exportedTexture = null
+    retiredExportedTexture?.close()
+    retiredExportedTexture = null
+    currentExtent = SurfaceExtent.Empty
+    generation += 1
   }
 
   // Holds the outgoing consumer texture for drawing while the replacement is

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/LinuxVulkanOpenGlBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/LinuxVulkanOpenGlBridge.kt
@@ -111,8 +111,18 @@ internal class LinuxVulkanOpenGlBridge : NativeSurfaceBridge {
   private var vulkan: LinuxVulkanContext? = null
   private var exportedTexture: LinuxExportedVulkanTexture? = null
   private var importedTexture: LinuxOpenGlImportedTexture? = null
-  private var generation = 0L
   private var currentExtent = SurfaceExtent.Empty
+
+  @Volatile private var generation = 0L
+  @Volatile private var renderedGeneration = 0L
+
+  // The consumer texture a frame last landed in, kept alive with the image it
+  // imports until one lands in its replacement. Skiko allocates a new texture
+  // for every resize and the map needs a frame or two to fill it, so this is
+  // what the consumer draws in between rather than having nothing to show.
+  private var retiredImportedTexture: LinuxOpenGlImportedTexture? = null
+  private var retiredExportedTexture: LinuxExportedVulkanTexture? = null
+  @Volatile private var retiredGeneration = 0L
 
   override val backend: ProducerBackend = ProducerBackend.VULKAN
 
@@ -136,6 +146,12 @@ internal class LinuxVulkanOpenGlBridge : NativeSurfaceBridge {
     extent: SurfaceExtent,
     presentationTimeNanos: Long?,
   ): NativeSurfaceFrame {
+    // Runs a frame after the replacement first rendered, so the consumer's last
+    // recorded frame from the retired texture has been flushed by then. The
+    // consumer context is current here, which is what closing it needs.
+    if (retiredImportedTexture != null && renderedGeneration == generation) {
+      disposeRetiredTexture(consumerContextCurrent = true)
+    }
     if (importedTexture == null || exportedTexture == null || extent != currentExtent) {
       recreateTexture(extent)
     }
@@ -148,6 +164,7 @@ internal class LinuxVulkanOpenGlBridge : NativeSurfaceBridge {
   }
 
   override fun completeProducerAccess(frame: NativeSurfaceFrame) {
+    renderedGeneration = frame.target.generation
     rendererDispatcher.run { vulkan?.waitIdle() }
   }
 
@@ -160,13 +177,21 @@ internal class LinuxVulkanOpenGlBridge : NativeSurfaceBridge {
     if (target !is VulkanImageTarget) {
       return false
     }
-    val texture = importedTexture ?: return false
+    // Only a texture this bridge still holds is safe to draw, which is the
+    // current one and the retired one behind it.
+    val texture =
+      when (target.generation) {
+        generation -> importedTexture
+        retiredGeneration -> retiredImportedTexture
+        else -> null
+      } ?: return false
     return SkikoHost.drawOpenGlTexture(scope, texture.target(target.generation))
   }
 
   override fun close() {
     try {
       disposeTexture(consumerContextCurrent = false)
+      disposeRetiredTexture(consumerContextCurrent = false)
     } finally {
       val closingVulkan = vulkan
       vulkan = null
@@ -189,7 +214,7 @@ internal class LinuxVulkanOpenGlBridge : NativeSurfaceBridge {
       return
     }
 
-    disposeTexture(consumerContextCurrent = true)
+    retireTexture()
     val context =
       vulkan ?: LinuxVulkanContext.create(currentOpenGlDeviceUuids()).also { vulkan = it }
     val exported = context.createExportedTexture(extent)
@@ -204,6 +229,36 @@ internal class LinuxVulkanOpenGlBridge : NativeSurfaceBridge {
       exported.close()
       throw error
     }
+  }
+
+  // Holds the outgoing consumer texture for drawing while the replacement is
+  // still empty. A texture nothing ever rendered into has nothing to show, so
+  // it goes the way it always did.
+  private fun retireTexture() {
+    if (renderedGeneration != generation || importedTexture == null) {
+      disposeTexture(consumerContextCurrent = true)
+      return
+    }
+    disposeRetiredTexture(consumerContextCurrent = true)
+    retiredImportedTexture = importedTexture
+    retiredExportedTexture = exportedTexture
+    retiredGeneration = generation
+    importedTexture = null
+    exportedTexture = null
+  }
+
+  private fun disposeRetiredTexture(consumerContextCurrent: Boolean = true) {
+    retiredImportedTexture?.let { texture ->
+      if (consumerContextCurrent) {
+        texture.close()
+      } else {
+        SkikoHost.withLinuxOpenGlContext { texture.close() }
+      }
+    }
+    retiredImportedTexture = null
+    retiredExportedTexture?.close()
+    retiredExportedTexture = null
+    retiredGeneration = 0
   }
 
   private fun disposeTexture(consumerContextCurrent: Boolean = true) {

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/LinuxVulkanOpenGlBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/LinuxVulkanOpenGlBridge.kt
@@ -124,6 +124,11 @@ internal class LinuxVulkanOpenGlBridge : NativeSurfaceBridge {
   private var retiredExportedTexture: LinuxExportedVulkanTexture? = null
   @Volatile private var retiredGeneration = 0L
 
+  // The Skiko OpenGL context both imports were made in. Skiko destroys this
+  // context with the redrawer it belongs to and builds a new one for the
+  // replacement, and a GL name means nothing in a context that did not issue it.
+  private var consumerContext: SkikoOpenGlContext? = null
+
   override val backend: ProducerBackend = ProducerBackend.VULKAN
 
   override val consumerBackend: ConsumerBackend = ConsumerBackend.OPENGL
@@ -146,6 +151,7 @@ internal class LinuxVulkanOpenGlBridge : NativeSurfaceBridge {
     extent: SurfaceExtent,
     presentationTimeNanos: Long?,
   ): NativeSurfaceFrame {
+    abandonTexturesIfConsumerContextChanged()
     // Runs a frame after the replacement first rendered, so the consumer's last
     // recorded frame from the retired texture has been flushed by then. The
     // consumer context is current here, which is what closing it needs.
@@ -190,8 +196,15 @@ internal class LinuxVulkanOpenGlBridge : NativeSurfaceBridge {
 
   override fun close() {
     try {
-      disposeTexture(consumerContextCurrent = false)
-      disposeRetiredTexture(consumerContextCurrent = false)
+      // Skiko may have replaced or torn down the context these were imported
+      // into before the bridge is closed, and a name deleted there is an
+      // unrelated object in whatever context is current now.
+      if (consumerContextStillCurrent()) {
+        disposeTexture(consumerContextCurrent = false)
+        disposeRetiredTexture(consumerContextCurrent = false)
+      } else {
+        abandonTextures()
+      }
     } finally {
       val closingVulkan = vulkan
       vulkan = null
@@ -223,12 +236,54 @@ internal class LinuxVulkanOpenGlBridge : NativeSurfaceBridge {
         LinuxOpenGlImportedTexture.create(exported.exportFd(), exported.memorySize(), extent)
       exportedTexture = exported
       importedTexture = imported
+      consumerContext = SkikoHost.requireLinuxOpenGlContext()
       currentExtent = extent
       generation += 1
     } catch (error: RuntimeException) {
       exported.close()
       throw error
     }
+  }
+
+  // Skiko destroys its OpenGL context along with the redrawer that owns it and
+  // builds a new one for the replacement, which happens while this bridge is
+  // running: the layer recreates its redrawer whenever AWT hands the component
+  // a new peer, and again whenever a draw fails and it falls back to another
+  // render API. Names from the old context cannot be drawn, and deleting them
+  // in the new one takes out whatever now answers to them, so both the current
+  // import and the retired one behind it are given up untouched.
+  private fun abandonTexturesIfConsumerContextChanged() {
+    val recorded = consumerContext ?: return
+    if (recorded.matches(SkikoHost.requireLinuxOpenGlContext())) {
+      return
+    }
+    abandonTextures()
+  }
+
+  // Answers false when Skiko has no OpenGL context to ask about at all, which
+  // is what a torn-down window looks like and is reason enough to delete
+  // nothing.
+  private fun consumerContextStillCurrent(): Boolean {
+    val recorded = consumerContext ?: return false
+    val current = runCatching { SkikoHost.requireLinuxOpenGlContext() }.getOrNull() ?: return false
+    return recorded.matches(current)
+  }
+
+  private fun abandonTextures() {
+    importedTexture?.abandon()
+    importedTexture = null
+    retiredImportedTexture?.abandon()
+    retiredImportedTexture = null
+    retiredGeneration = 0
+    consumerContext = null
+    // The images belong to this bridge's own Vulkan device, which Skiko's
+    // context change leaves alone, so they are released rather than given up.
+    exportedTexture?.close()
+    exportedTexture = null
+    retiredExportedTexture?.close()
+    retiredExportedTexture = null
+    currentExtent = SurfaceExtent.Empty
+    generation += 1
   }
 
   // Holds the outgoing consumer texture for drawing while the replacement is
@@ -707,6 +762,23 @@ private constructor(
         memoryObject = 0
       }
     }
+  }
+
+  /**
+   * Gives up the texture and memory object without deleting them, for when the context that issued
+   * them is gone.
+   *
+   * GL names are per context. Once Skiko destroys the context these came from, the names are the
+   * replacement's to hand out, and deleting them there takes out whatever now answers to them —
+   * Skiko's own objects among the candidates. The imported device memory goes with the context that
+   * held it, so what is given up here is the name, not the allocation.
+   */
+  fun abandon() {
+    if (textureName != 0) {
+      SkikoHost.abandonOpenGlTexture(textureName)
+      textureName = 0
+    }
+    memoryObject = 0
   }
 
   companion object {

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacMetalBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacMetalBridge.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 internal class MacMetalBridge : NativeSurfaceBridge {
   private val rendererDispatcher = NativeSurfaceRendererDispatcher("compose-map-mac-metal-renderer")
   private var texture = NativeHandle(0)
+  private var metalDevice = NativeHandle(0)
   private var pixelFormat = 0L
   private var generation = 0L
   private var currentExtent = SurfaceExtent.Empty
@@ -22,15 +23,15 @@ internal class MacMetalBridge : NativeSurfaceBridge {
     )
 
   override fun resize(extent: SurfaceExtent) {
-    val metalDevice = if (extent.isEmpty) null else SkikoHost.requireMetalDevice()
-    rendererDispatcher.run { resizeOnRendererThread(extent, metalDevice) }
+    val skikoDevice = if (extent.isEmpty) null else SkikoHost.requireMetalDevice()
+    rendererDispatcher.run { resizeOnRendererThread(extent, skikoDevice) }
   }
 
-  private fun resizeOnRendererThread(extent: SurfaceExtent, metalDevice: SkikoMetalDevice? = null) {
+  private fun resizeOnRendererThread(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
     if (extent == currentExtent && texture.address != 0L) {
       return
     }
-    recreateTexture(extent, metalDevice)
+    recreateTexture(extent, skikoDevice)
     currentExtent = extent
     generation += 1
   }
@@ -56,6 +57,7 @@ internal class MacMetalBridge : NativeSurfaceBridge {
       texture =
         texture.takeIf { it.address != 0L }
           ?: throw NativeSurfaceBridgeException("Skiko Metal texture allocation returned null"),
+      device = metalDevice,
       pixelFormat = pixelFormat,
       extent = extent,
       generation = generation,
@@ -83,16 +85,21 @@ internal class MacMetalBridge : NativeSurfaceBridge {
     }
   }
 
-  private fun recreateTexture(extent: SurfaceExtent, metalDevice: SkikoMetalDevice? = null) {
+  private fun recreateTexture(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
     if (extent.isEmpty) {
       disposeTexture()
       return
     }
     val oldTexture = texture
+    val requiredMetalDevice = skikoDevice ?: SkikoHost.requireMetalDevice()
+    // Only the device that allocated it can take it back, so a Skiko device change allocates
+    // rather than reusing and this bridge never names one device while holding the other's texture.
+    val reusableTexture =
+      if (metalDevice.address == requiredMetalDevice.ptr) oldTexture.address else 0L
     val textureAddress =
       MacMetalBridgeNative.createMetalTexture(
-        metalDevice = (metalDevice ?: SkikoHost.requireMetalDevice()).ptr,
-        oldTexture = oldTexture.address,
+        metalDevice = requiredMetalDevice.ptr,
+        oldTexture = reusableTexture,
         width = extent.physicalWidth,
         height = extent.physicalHeight,
       )
@@ -100,12 +107,14 @@ internal class MacMetalBridge : NativeSurfaceBridge {
       releaseMetalTexture(oldTexture)
     }
     texture = NativeHandle(textureAddress)
+    metalDevice = NativeHandle(requiredMetalDevice.ptr)
     pixelFormat = MacMetalBridgeNative.texturePixelFormat(textureAddress)
   }
 
   private fun disposeTexture() {
     releaseMetalTexture(texture)
     texture = NativeHandle(0)
+    metalDevice = NativeHandle(0)
     pixelFormat = 0
   }
 

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacMetalBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacMetalBridge.kt
@@ -7,8 +7,18 @@ internal class MacMetalBridge : NativeSurfaceBridge {
   private var texture = NativeHandle(0)
   private var metalDevice = NativeHandle(0)
   private var pixelFormat = 0L
-  private var generation = 0L
   private var currentExtent = SurfaceExtent.Empty
+
+  // Read on the Compose thread while the renderer thread writes them.
+  @Volatile private var generation = 0L
+  @Volatile private var renderedGeneration = 0L
+
+  // The texture a frame last landed in, kept alive until one lands in its
+  // replacement. Skiko allocates a new texture for every resize and the map
+  // needs a frame or two to fill it, so this is what the consumer draws in
+  // between rather than having nothing to show.
+  private var retiredTexture = NativeHandle(0)
+  @Volatile private var retiredGeneration = 0L
 
   override val backend: ProducerBackend = ProducerBackend.METAL
 
@@ -63,8 +73,23 @@ internal class MacMetalBridge : NativeSurfaceBridge {
       generation = generation,
     )
 
+  override fun completeProducerAccess(frame: NativeSurfaceFrame) {
+    renderedGeneration = frame.target.generation
+  }
+
   override fun draw(scope: DrawScope, target: NativeSurfaceTarget): Boolean {
-    if (target !is MetalTextureTarget || target.texture.address == 0L) {
+    if (target !is MetalTextureTarget) {
+      return false
+    }
+    // Only a texture this bridge still holds is safe to draw, which is the
+    // current one and the retired one behind it.
+    val held =
+      when (target.generation) {
+        generation -> texture
+        retiredGeneration -> retiredTexture
+        else -> NativeHandle(0)
+      }
+    if (held.address == 0L || held.address != target.texture.address) {
       return false
     }
     return SkikoHost.drawMetalTexture(scope, target)
@@ -72,6 +97,7 @@ internal class MacMetalBridge : NativeSurfaceBridge {
 
   override fun <T> withProducerAccess(frame: NativeSurfaceFrame, action: () -> T): T =
     rendererDispatcher.run {
+      releaseRetiredOnceReplaced()
       MacMetalBridgeNative.runInAutoreleasePool(action)
     }
 
@@ -104,16 +130,57 @@ internal class MacMetalBridge : NativeSurfaceBridge {
         height = extent.physicalHeight,
       )
     if (textureAddress != oldTexture.address) {
-      releaseMetalTexture(oldTexture)
+      retire(oldTexture, deviceChanged = metalDevice.address != requiredMetalDevice.ptr)
     }
     texture = NativeHandle(textureAddress)
     metalDevice = NativeHandle(requiredMetalDevice.ptr)
     pixelFormat = MacMetalBridgeNative.texturePixelFormat(textureAddress)
   }
 
+  // Holds the outgoing texture for the consumer to draw while the replacement
+  // is still empty. A texture nothing ever rendered into has nothing to show,
+  // and one from a device Skiko has replaced cannot be drawn on the new one.
+  private fun retire(outgoing: NativeHandle, deviceChanged: Boolean) {
+    if (outgoing.address == 0L) {
+      return
+    }
+    if (deviceChanged) {
+      // Both belong to the device Skiko replaced, and neither can be drawn on
+      // the new one.
+      releaseMetalTexture(outgoing)
+      releaseMetalTexture(retiredTexture)
+      retiredTexture = NativeHandle(0)
+      retiredGeneration = 0
+      return
+    }
+    if (renderedGeneration != generation) {
+      // Keeps whatever is already retired: it is still the last texture a frame
+      // landed in, and this one never held a frame at all.
+      releaseMetalTexture(outgoing)
+      return
+    }
+    releaseMetalTexture(retiredTexture)
+    retiredTexture = outgoing
+    retiredGeneration = generation
+  }
+
+  // Runs a frame after the replacement first rendered, so the consumer's last
+  // recorded frame from the retired texture has been flushed by then.
+  private fun releaseRetiredOnceReplaced() {
+    if (retiredTexture.address == 0L || renderedGeneration != generation) {
+      return
+    }
+    releaseMetalTexture(retiredTexture)
+    retiredTexture = NativeHandle(0)
+    retiredGeneration = 0
+  }
+
   private fun disposeTexture() {
     releaseMetalTexture(texture)
     texture = NativeHandle(0)
+    releaseMetalTexture(retiredTexture)
+    retiredTexture = NativeHandle(0)
+    retiredGeneration = 0
     metalDevice = NativeHandle(0)
     pixelFormat = 0
   }

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacMetalBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacMetalBridge.kt
@@ -37,7 +37,7 @@ internal class MacMetalBridge : NativeSurfaceBridge {
     rendererDispatcher.run { resizeOnRendererThread(extent, skikoDevice) }
   }
 
-  private fun resizeOnRendererThread(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
+  private fun resizeOnRendererThread(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice?) {
     if (extent == currentExtent && texture.address != 0L) {
       return
     }
@@ -111,13 +111,17 @@ internal class MacMetalBridge : NativeSurfaceBridge {
     }
   }
 
-  private fun recreateTexture(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
+  private fun recreateTexture(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice?) {
     if (extent.isEmpty) {
       disposeTexture()
       return
     }
     val oldTexture = texture
-    val requiredMetalDevice = skikoDevice ?: SkikoHost.requireMetalDevice()
+    // Resolved by the caller, on a thread that may ask Skiko for it. Reaching
+    // for it here would ask from the renderer thread, and answering that waits
+    // on the event dispatch thread, which is already waiting on this one.
+    val requiredMetalDevice =
+      checkNotNull(skikoDevice) { "The Skiko Metal device is resolved before this hop" }
     // Only the device that allocated it can take it back, so a Skiko device change allocates
     // rather than reusing and this bridge never names one device while holding the other's texture.
     val reusableTexture =

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacOpenGlMetalBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacOpenGlMetalBridge.kt
@@ -113,7 +113,7 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
     rendererDispatcher.run { resizeOnRendererThread(extent, skikoDevice) }
   }
 
-  private fun resizeOnRendererThread(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
+  private fun resizeOnRendererThread(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice?) {
     if (extent == currentExtent && importedTexture != null) {
       return
     }
@@ -206,7 +206,7 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
   private fun target(generation: Long): NativeSurfaceTarget =
     checkNotNull(importedTexture) { "ANGLE texture is not initialized" }.target(generation)
 
-  private fun recreateTexture(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
+  private fun recreateTexture(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice?) {
     if (extent.isEmpty) {
       disposeTexture()
       return
@@ -214,7 +214,11 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
 
     val oldTexture = metalTexture
     val oldPixelFormat = pixelFormat
-    val requiredMetalDevice = skikoDevice ?: SkikoHost.requireMetalDevice()
+    // Resolved by the caller, on a thread that may ask Skiko for it. Reaching
+    // for it here would ask from the renderer thread, and answering that waits
+    // on the event dispatch thread, which is already waiting on this one.
+    val requiredMetalDevice =
+      checkNotNull(skikoDevice) { "The Skiko Metal device is resolved before this hop" }
     // Only the device that allocated it can take it back, so a Skiko device change allocates
     // rather than reusing and this bridge never names one device while holding the other's texture.
     val reusableTexture =

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacOpenGlMetalBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacOpenGlMetalBridge.kt
@@ -81,8 +81,20 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
   private var metalDevice = NativeHandle(0)
   private var pixelFormat = 0L
   private var importedTexture: MacAngleImportedTexture? = null
-  private var generation = 0L
   private var currentExtent = SurfaceExtent.Empty
+
+  // Read on the Compose thread while the renderer thread writes them.
+  @Volatile private var generation = 0L
+  @Volatile private var renderedGeneration = 0L
+
+  // The Metal texture a frame last landed in, kept alive until one lands in its
+  // replacement. Skiko allocates a new texture for every resize and the map
+  // needs a frame or two to fill it, so this is what the consumer draws in
+  // between rather than having nothing to show. Only the Metal side is kept:
+  // the session already renders through the new ANGLE texture.
+  private var retiredTexture = NativeHandle(0)
+  private var retiredPixelFormat = 0L
+  @Volatile private var retiredGeneration = 0L
 
   override val backend: ProducerBackend = ProducerBackend.OPENGL
 
@@ -127,19 +139,38 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
   }
 
   override fun completeProducerAccess(frame: NativeSurfaceFrame) {
+    renderedGeneration = frame.target.generation
     rendererDispatcher.run { egl.waitIdle() }
   }
 
   override fun draw(scope: DrawScope, target: NativeSurfaceTarget): Boolean {
-    if (target !is OpenGlTextureTarget || metalTexture.address == 0L) {
+    if (target !is OpenGlTextureTarget) {
+      return false
+    }
+    // Only a texture this bridge still holds is safe to draw, which is the
+    // current one and the retired one behind it.
+    val texture: NativeHandle
+    val format: Long
+    when (target.generation) {
+      generation -> {
+        texture = metalTexture
+        format = pixelFormat
+      }
+      retiredGeneration -> {
+        texture = retiredTexture
+        format = retiredPixelFormat
+      }
+      else -> return false
+    }
+    if (texture.address == 0L) {
       return false
     }
     return SkikoHost.drawMetalTexture(
       scope,
       MetalTextureTarget(
-        texture = metalTexture,
+        texture = texture,
         device = metalDevice,
-        pixelFormat = pixelFormat,
+        pixelFormat = format,
         origin = TextureOrigin.BOTTOM_LEFT,
         extent = target.extent,
         generation = target.generation,
@@ -149,6 +180,7 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
 
   override fun <T> withProducerAccess(frame: NativeSurfaceFrame, action: () -> T): T =
     rendererDispatcher.run {
+      releaseRetiredOnceReplaced()
       MacMetalBridgeNative.runInAutoreleasePool(action)
     }
 
@@ -175,6 +207,7 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
     }
 
     val oldTexture = metalTexture
+    val oldPixelFormat = pixelFormat
     val requiredMetalDevice = skikoDevice ?: SkikoHost.requireMetalDevice()
     // Only the device that allocated it can take it back, so a Skiko device change allocates
     // rather than reusing and this bridge never names one device while holding the other's texture.
@@ -195,7 +228,11 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
     importedTexture?.close()
     importedTexture = null
     if (newTexture != oldTexture) {
-      releaseMetalTexture(oldTexture)
+      retire(
+        oldTexture,
+        oldPixelFormat,
+        deviceChanged = metalDevice.address != requiredMetalDevice.ptr,
+      )
     }
     metalTexture = newTexture
     metalDevice = NativeHandle(requiredMetalDevice.ptr)
@@ -208,11 +245,56 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
     }
   }
 
+  // Holds the outgoing texture for the consumer to draw while the replacement
+  // is still empty. A texture nothing ever rendered into has nothing to show,
+  // and one from a device Skiko has replaced cannot be drawn on the new one.
+  private fun retire(outgoing: NativeHandle, outgoingPixelFormat: Long, deviceChanged: Boolean) {
+    if (outgoing.address == 0L) {
+      return
+    }
+    if (deviceChanged) {
+      // Both belong to the device Skiko replaced, and neither can be drawn on
+      // the new one.
+      releaseMetalTexture(outgoing)
+      releaseMetalTexture(retiredTexture)
+      retiredTexture = NativeHandle(0)
+      retiredPixelFormat = 0
+      retiredGeneration = 0
+      return
+    }
+    if (renderedGeneration != generation) {
+      // Keeps whatever is already retired: it is still the last texture a frame
+      // landed in, and this one never held a frame at all.
+      releaseMetalTexture(outgoing)
+      return
+    }
+    releaseMetalTexture(retiredTexture)
+    retiredTexture = outgoing
+    retiredPixelFormat = outgoingPixelFormat
+    retiredGeneration = generation
+  }
+
+  // Runs a frame after the replacement first rendered, so the consumer's last
+  // recorded frame from the retired texture has been flushed by then.
+  private fun releaseRetiredOnceReplaced() {
+    if (retiredTexture.address == 0L || renderedGeneration != generation) {
+      return
+    }
+    releaseMetalTexture(retiredTexture)
+    retiredTexture = NativeHandle(0)
+    retiredPixelFormat = 0
+    retiredGeneration = 0
+  }
+
   private fun disposeTexture() {
     importedTexture?.close()
     importedTexture = null
     releaseMetalTexture(metalTexture)
     metalTexture = NativeHandle(0)
+    releaseMetalTexture(retiredTexture)
+    retiredTexture = NativeHandle(0)
+    retiredPixelFormat = 0
+    retiredGeneration = 0
     metalDevice = NativeHandle(0)
     pixelFormat = 0
   }

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacOpenGlMetalBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacOpenGlMetalBridge.kt
@@ -78,6 +78,7 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
       throw error
     }
   private var metalTexture = NativeHandle(0)
+  private var metalDevice = NativeHandle(0)
   private var pixelFormat = 0L
   private var importedTexture: MacAngleImportedTexture? = null
   private var generation = 0L
@@ -96,15 +97,15 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
     )
 
   override fun resize(extent: SurfaceExtent) {
-    val metalDevice = if (extent.isEmpty) null else SkikoHost.requireMetalDevice()
-    rendererDispatcher.run { resizeOnRendererThread(extent, metalDevice) }
+    val skikoDevice = if (extent.isEmpty) null else SkikoHost.requireMetalDevice()
+    rendererDispatcher.run { resizeOnRendererThread(extent, skikoDevice) }
   }
 
-  private fun resizeOnRendererThread(extent: SurfaceExtent, metalDevice: SkikoMetalDevice? = null) {
+  private fun resizeOnRendererThread(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
     if (extent == currentExtent && importedTexture != null) {
       return
     }
-    recreateTexture(extent, metalDevice)
+    recreateTexture(extent, skikoDevice)
     currentExtent = extent
     generation += 1
   }
@@ -137,6 +138,7 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
       scope,
       MetalTextureTarget(
         texture = metalTexture,
+        device = metalDevice,
         pixelFormat = pixelFormat,
         origin = TextureOrigin.BOTTOM_LEFT,
         extent = target.extent,
@@ -166,17 +168,22 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
   private fun target(generation: Long): NativeSurfaceTarget =
     checkNotNull(importedTexture) { "ANGLE texture is not initialized" }.target(generation)
 
-  private fun recreateTexture(extent: SurfaceExtent, metalDevice: SkikoMetalDevice? = null) {
+  private fun recreateTexture(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
     if (extent.isEmpty) {
       disposeTexture()
       return
     }
 
     val oldTexture = metalTexture
+    val requiredMetalDevice = skikoDevice ?: SkikoHost.requireMetalDevice()
+    // Only the device that allocated it can take it back, so a Skiko device change allocates
+    // rather than reusing and this bridge never names one device while holding the other's texture.
+    val reusableTexture =
+      if (metalDevice.address == requiredMetalDevice.ptr) oldTexture.address else 0L
     val newTextureAddress =
       MacMetalBridgeNative.createMetalTexture(
-        metalDevice = (metalDevice ?: SkikoHost.requireMetalDevice()).ptr,
-        oldTexture = oldTexture.address,
+        metalDevice = requiredMetalDevice.ptr,
+        oldTexture = reusableTexture,
         width = extent.physicalWidth,
         height = extent.physicalHeight,
       )
@@ -191,6 +198,7 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
       releaseMetalTexture(oldTexture)
     }
     metalTexture = newTexture
+    metalDevice = NativeHandle(requiredMetalDevice.ptr)
     pixelFormat = MacMetalBridgeNative.texturePixelFormat(newTexture.address)
     try {
       importedTexture = egl.createImportedTexture(newTexture, extent)
@@ -205,6 +213,7 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
     importedTexture = null
     releaseMetalTexture(metalTexture)
     metalTexture = NativeHandle(0)
+    metalDevice = NativeHandle(0)
     pixelFormat = 0
   }
 

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacOpenGlMetalBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacOpenGlMetalBridge.kt
@@ -126,16 +126,22 @@ internal class MacOpenGlMetalBridge : NativeSurfaceBridge {
     frameId: Long,
     extent: SurfaceExtent,
     presentationTimeNanos: Long?,
-  ): NativeSurfaceFrame = rendererDispatcher.run {
+  ): NativeSurfaceFrame {
+    // Through resize, so the Skiko device is resolved on this thread. Resolving
+    // it reaches the event dispatch thread, and this call arrives on it: asking
+    // for the device from the renderer thread instead would leave each waiting
+    // on the other.
     if (importedTexture == null || extent != currentExtent) {
-      resizeOnRendererThread(extent)
+      resize(extent)
     }
-    NativeSurfaceFrameLease(
-      frameId = frameId,
-      extent = extent,
-      target = target(generation),
-      presentationTimeNanos = presentationTimeNanos,
-    )
+    return rendererDispatcher.run {
+      NativeSurfaceFrameLease(
+        frameId = frameId,
+        extent = extent,
+        target = target(generation),
+        presentationTimeNanos = presentationTimeNanos,
+      )
+    }
   }
 
   override fun completeProducerAccess(frame: NativeSurfaceFrame) {

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacVulkanMetalBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacVulkanMetalBridge.kt
@@ -7,6 +7,7 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
     NativeSurfaceRendererDispatcher("compose-map-mac-vulkan-renderer")
   private var vulkan: MacVulkanContext? = null
   private var metalTexture = NativeHandle(0)
+  private var metalDevice = NativeHandle(0)
   private var pixelFormat = 0L
   private var importedTexture: MacVulkanImportedTexture? = null
   private var generation = 0L
@@ -25,15 +26,15 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
     )
 
   override fun resize(extent: SurfaceExtent) {
-    val metalDevice = if (extent.isEmpty) null else SkikoHost.requireMetalDevice()
-    rendererDispatcher.run { resizeOnRendererThread(extent, metalDevice) }
+    val skikoDevice = if (extent.isEmpty) null else SkikoHost.requireMetalDevice()
+    rendererDispatcher.run { resizeOnRendererThread(extent, skikoDevice) }
   }
 
-  private fun resizeOnRendererThread(extent: SurfaceExtent, metalDevice: SkikoMetalDevice? = null) {
+  private fun resizeOnRendererThread(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
     if (extent == currentExtent && importedTexture != null) {
       return
     }
-    recreateTexture(extent, metalDevice)
+    recreateTexture(extent, skikoDevice)
     currentExtent = extent
     generation += 1
   }
@@ -71,6 +72,7 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
       scope,
       MetalTextureTarget(
         texture = metalTexture,
+        device = metalDevice,
         pixelFormat = pixelFormat,
         extent = target.extent,
         generation = target.generation,
@@ -94,19 +96,23 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
   private fun target(generation: Long): NativeSurfaceTarget =
     checkNotNull(importedTexture) { "Vulkan texture is not initialized" }.target(generation)
 
-  private fun recreateTexture(extent: SurfaceExtent, metalDevice: SkikoMetalDevice? = null) {
+  private fun recreateTexture(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
     if (extent.isEmpty) {
       disposeTexture()
       return
     }
 
     val oldTexture = metalTexture
-    val requiredMetalDevice = metalDevice ?: SkikoHost.requireMetalDevice()
+    val requiredMetalDevice = skikoDevice ?: SkikoHost.requireMetalDevice()
     val requiredMetalAdapter = MacMetalBridgeNative.metalAdapter(requiredMetalDevice.ptr)
+    // Only the device that allocated it can take it back, so a Skiko device change allocates
+    // rather than reusing and this bridge never names one device while holding the other's texture.
+    val reusableTexture =
+      if (metalDevice.address == requiredMetalDevice.ptr) oldTexture.address else 0L
     val newTextureAddress =
       MacMetalBridgeNative.createMetalTexture(
         metalDevice = requiredMetalDevice.ptr,
-        oldTexture = oldTexture.address,
+        oldTexture = reusableTexture,
         width = extent.physicalWidth,
         height = extent.physicalHeight,
       )
@@ -121,6 +127,7 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
       releaseMetalTexture(oldTexture)
     }
     metalTexture = newTexture
+    metalDevice = NativeHandle(requiredMetalDevice.ptr)
     pixelFormat = MacMetalBridgeNative.texturePixelFormat(newTexture.address)
     try {
       val context = vulkan ?: MacVulkanContext.create(requiredMetalAdapter).also { vulkan = it }
@@ -136,6 +143,7 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
     importedTexture = null
     releaseMetalTexture(metalTexture)
     metalTexture = NativeHandle(0)
+    metalDevice = NativeHandle(0)
     pixelFormat = 0
   }
 

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacVulkanMetalBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacVulkanMetalBridge.kt
@@ -42,7 +42,7 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
     rendererDispatcher.run { resizeOnRendererThread(extent, skikoDevice) }
   }
 
-  private fun resizeOnRendererThread(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
+  private fun resizeOnRendererThread(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice?) {
     if (extent == currentExtent && importedTexture != null) {
       return
     }
@@ -130,7 +130,7 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
   private fun target(generation: Long): NativeSurfaceTarget =
     checkNotNull(importedTexture) { "Vulkan texture is not initialized" }.target(generation)
 
-  private fun recreateTexture(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice? = null) {
+  private fun recreateTexture(extent: SurfaceExtent, skikoDevice: SkikoMetalDevice?) {
     if (extent.isEmpty) {
       disposeTexture()
       return
@@ -138,7 +138,11 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
 
     val oldTexture = metalTexture
     val oldPixelFormat = pixelFormat
-    val requiredMetalDevice = skikoDevice ?: SkikoHost.requireMetalDevice()
+    // Resolved by the caller, on a thread that may ask Skiko for it. Reaching
+    // for it here would ask from the renderer thread, and answering that waits
+    // on the event dispatch thread, which is already waiting on this one.
+    val requiredMetalDevice =
+      checkNotNull(skikoDevice) { "The Skiko Metal device is resolved before this hop" }
     val requiredMetalAdapter = MacMetalBridgeNative.metalAdapter(requiredMetalDevice.ptr)
     // Only the device that allocated it can take it back, so a Skiko device change allocates
     // rather than reusing and this bridge never names one device while holding the other's texture.

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacVulkanMetalBridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/MacVulkanMetalBridge.kt
@@ -10,8 +10,20 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
   private var metalDevice = NativeHandle(0)
   private var pixelFormat = 0L
   private var importedTexture: MacVulkanImportedTexture? = null
-  private var generation = 0L
   private var currentExtent = SurfaceExtent.Empty
+
+  // Read on the Compose thread while the renderer thread writes them.
+  @Volatile private var generation = 0L
+  @Volatile private var renderedGeneration = 0L
+
+  // The Metal texture a frame last landed in, kept alive until one lands in its
+  // replacement. Skiko allocates a new texture for every resize and the map
+  // needs a frame or two to fill it, so this is what the consumer draws in
+  // between rather than having nothing to show. Only the Metal side is kept:
+  // the session already presents through the new Vulkan image.
+  private var retiredTexture = NativeHandle(0)
+  private var retiredPixelFormat = 0L
+  @Volatile private var retiredGeneration = 0L
 
   override val backend: ProducerBackend = ProducerBackend.VULKAN
 
@@ -56,24 +68,46 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
   }
 
   override fun completeProducerAccess(frame: NativeSurfaceFrame) {
+    renderedGeneration = frame.target.generation
     rendererDispatcher.run { vulkan?.waitIdle() }
   }
 
   override fun <T> withProducerAccess(frame: NativeSurfaceFrame, action: () -> T): T =
-    rendererDispatcher.run(action)
+    rendererDispatcher.run {
+      releaseRetiredOnceReplaced()
+      action()
+    }
 
   override fun <T> withRendererAccess(action: () -> T): T = rendererDispatcher.run(action)
 
   override fun draw(scope: DrawScope, target: NativeSurfaceTarget): Boolean {
-    if (target !is VulkanImageTarget || metalTexture.address == 0L) {
+    if (target !is VulkanImageTarget) {
+      return false
+    }
+    // Only a texture this bridge still holds is safe to draw, which is the
+    // current one and the retired one behind it.
+    val texture: NativeHandle
+    val format: Long
+    when (target.generation) {
+      generation -> {
+        texture = metalTexture
+        format = pixelFormat
+      }
+      retiredGeneration -> {
+        texture = retiredTexture
+        format = retiredPixelFormat
+      }
+      else -> return false
+    }
+    if (texture.address == 0L) {
       return false
     }
     return SkikoHost.drawMetalTexture(
       scope,
       MetalTextureTarget(
-        texture = metalTexture,
+        texture = texture,
         device = metalDevice,
-        pixelFormat = pixelFormat,
+        pixelFormat = format,
         extent = target.extent,
         generation = target.generation,
       ),
@@ -103,6 +137,7 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
     }
 
     val oldTexture = metalTexture
+    val oldPixelFormat = pixelFormat
     val requiredMetalDevice = skikoDevice ?: SkikoHost.requireMetalDevice()
     val requiredMetalAdapter = MacMetalBridgeNative.metalAdapter(requiredMetalDevice.ptr)
     // Only the device that allocated it can take it back, so a Skiko device change allocates
@@ -124,7 +159,11 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
     importedTexture?.close()
     importedTexture = null
     if (newTexture != oldTexture) {
-      releaseMetalTexture(oldTexture)
+      retire(
+        oldTexture,
+        oldPixelFormat,
+        deviceChanged = metalDevice.address != requiredMetalDevice.ptr,
+      )
     }
     metalTexture = newTexture
     metalDevice = NativeHandle(requiredMetalDevice.ptr)
@@ -138,11 +177,56 @@ internal class MacVulkanMetalBridge : NativeSurfaceBridge {
     }
   }
 
+  // Holds the outgoing texture for the consumer to draw while the replacement
+  // is still empty. A texture nothing ever rendered into has nothing to show,
+  // and one from a device Skiko has replaced cannot be drawn on the new one.
+  private fun retire(outgoing: NativeHandle, outgoingPixelFormat: Long, deviceChanged: Boolean) {
+    if (outgoing.address == 0L) {
+      return
+    }
+    if (deviceChanged) {
+      // Both belong to the device Skiko replaced, and neither can be drawn on
+      // the new one.
+      releaseMetalTexture(outgoing)
+      releaseMetalTexture(retiredTexture)
+      retiredTexture = NativeHandle(0)
+      retiredPixelFormat = 0
+      retiredGeneration = 0
+      return
+    }
+    if (renderedGeneration != generation) {
+      // Keeps whatever is already retired: it is still the last texture a frame
+      // landed in, and this one never held a frame at all.
+      releaseMetalTexture(outgoing)
+      return
+    }
+    releaseMetalTexture(retiredTexture)
+    retiredTexture = outgoing
+    retiredPixelFormat = outgoingPixelFormat
+    retiredGeneration = generation
+  }
+
+  // Runs a frame after the replacement first rendered, so the consumer's last
+  // recorded frame from the retired texture has been flushed by then.
+  private fun releaseRetiredOnceReplaced() {
+    if (retiredTexture.address == 0L || renderedGeneration != generation) {
+      return
+    }
+    releaseMetalTexture(retiredTexture)
+    retiredTexture = NativeHandle(0)
+    retiredPixelFormat = 0
+    retiredGeneration = 0
+  }
+
   private fun disposeTexture() {
     importedTexture?.close()
     importedTexture = null
     releaseMetalTexture(metalTexture)
     metalTexture = NativeHandle(0)
+    releaseMetalTexture(retiredTexture)
+    retiredTexture = NativeHandle(0)
+    retiredPixelFormat = 0
+    retiredGeneration = 0
     metalDevice = NativeHandle(0)
     pixelFormat = 0
   }

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/SkikoHost.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/SkikoHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.skiaCanvas
 import java.awt.Component
 import java.awt.Container
 import java.awt.Window
+import java.lang.ref.WeakReference
 import javax.swing.SwingUtilities
 import org.jetbrains.skia.BackendRenderTarget
 import org.jetbrains.skia.ContentChangeMode
@@ -46,6 +47,7 @@ internal object SkikoHost {
   private val metalPresenters = mutableMapOf<Long, MetalTexturePresenter>()
   private val direct3DPresenters = mutableMapOf<Long, Direct3DTexturePresenter>()
   private val openGlPresenters = mutableMapOf<Int, OpenGlTexturePresenter>()
+  private var cachedSkiaLayer: Component? = null
 
   fun requireMetalDevice(): SkikoMetalDevice = onEdt {
     val layer =
@@ -128,11 +130,18 @@ internal object SkikoHost {
   fun drawOpenGlTexture(scope: DrawScope, target: OpenGlTextureTarget): Boolean {
     var drew = false
     scope.drawIntoCanvas { composeCanvas ->
-      val context = findLinuxOpenGlContext() ?: return@drawIntoCanvas
+      val contexts = findLinuxOpenGlContexts() ?: return@drawIntoCanvas
       ensureOpenGlCapabilities()
       val presenter =
         openGlPresenters.getOrPut(target.textureName) { OpenGlTexturePresenter(target.textureName) }
-      presenter.draw(composeCanvas.skiaCanvas, context, target, scope.size.width, scope.size.height)
+      presenter.draw(
+        composeCanvas.skiaCanvas,
+        contexts.skia,
+        contexts.gl,
+        target,
+        scope.size.width,
+        scope.size.height,
+      )
       drew = true
     }
     return drew
@@ -140,6 +149,30 @@ internal object SkikoHost {
 
   fun forgetOpenGlTexture(textureName: Int) {
     openGlPresenters.remove(textureName)?.close()
+  }
+
+  /**
+   * Drops the presenter for [textureName] without deleting the OpenGL objects it built, for when
+   * the context that issued them is gone. Its framebuffer name belongs to that context and names
+   * something else in the replacement.
+   */
+  fun abandonOpenGlTexture(textureName: Int) {
+    openGlPresenters.remove(textureName)?.abandon()
+  }
+
+  /**
+   * The OpenGL context Skiko's Linux redrawer currently owns.
+   *
+   * Skiko destroys this context along with the redrawer and builds a new one for the replacement,
+   * so anything holding a GL name has to record which context issued it.
+   */
+  fun requireLinuxOpenGlContext(): SkikoOpenGlContext = onEdt {
+    val layer =
+      findSkiaLayer()
+        ?: throw NativeSurfaceBridgeException(
+          "SkikoHost could not find a live $SKIA_LAYER_CLASS. ${describeWindows()}"
+        )
+    readLinuxOpenGlContext(requireLinuxOpenGlRedrawer(layer))
   }
 
   fun <T> withLinuxOpenGlContext(action: () -> T): T = onEdt {
@@ -176,6 +209,7 @@ internal object SkikoHost {
     val glPresenters = openGlPresenters.values.toList()
     openGlPresenters.clear()
     glPresenters.forEach { it.close() }
+    cachedSkiaLayer = null
   }
 
   private fun findMetalContext(): DirectContext? = onEdt {
@@ -232,24 +266,39 @@ internal object SkikoHost {
     return redrawer
   }
 
-  private fun findLinuxOpenGlContext(): DirectContext? = onEdt {
+  // Resolves both contexts from one redrawer lookup: the drawing path needs the
+  // Skia context to render and the GL context to tell whether the names it is
+  // about to use still belong to the context that issued them.
+  private fun findLinuxOpenGlContexts(): LinuxOpenGlContexts? = onEdt {
     val layer =
       findSkiaLayer()
         ?: throw NativeSurfaceBridgeException("SkikoHost could not find a live $SKIA_LAYER_CLASS")
-    val contextHandler = requireLinuxOpenGlContextHandler(layer)
-    (contextHandler.getField("context") as? DirectContext)
-      ?: run {
-        contextHandler.invokeDeclaredNoArg("initContext")
-        (contextHandler.getField("context") as? DirectContext)
-          ?: contextHandler.invokeDeclaredNoArg("getContext") as? DirectContext
-      }
+    val redrawer = requireLinuxOpenGlRedrawer(layer)
+    val gl = readLinuxOpenGlContext(redrawer)
+    val contextHandler =
+      redrawer.getField("contextHandler")
+        ?: throw NativeSurfaceBridgeException(
+          "$LINUX_OPENGL_REDRAWER_CLASS.contextHandler was null"
+        )
+    val skia =
+      (contextHandler.getField("context") as? DirectContext)
+        ?: run {
+          contextHandler.invokeDeclaredNoArg("initContext")
+          (contextHandler.getField("context") as? DirectContext)
+            ?: contextHandler.invokeDeclaredNoArg("getContext") as? DirectContext
+        }
+    skia?.let { LinuxOpenGlContexts(skia = it, gl = gl) }
   }
 
-  private fun requireLinuxOpenGlContextHandler(layer: Any): Any {
-    val redrawer = requireLinuxOpenGlRedrawer(layer)
-    return redrawer.getField("contextHandler")
-      ?: throw NativeSurfaceBridgeException("$LINUX_OPENGL_REDRAWER_CLASS.contextHandler was null")
+  private fun readLinuxOpenGlContext(redrawer: Any): SkikoOpenGlContext {
+    val handle =
+      redrawer.getField("context") as? Long
+        ?: throw NativeSurfaceBridgeException("$LINUX_OPENGL_REDRAWER_CLASS.context was null")
+    check(handle != 0L) { "$LINUX_OPENGL_REDRAWER_CLASS.context was zero" }
+    return SkikoOpenGlContext(redrawer, handle)
   }
+
+  private class LinuxOpenGlContexts(val skia: DirectContext, val gl: SkikoOpenGlContext)
 
   private fun requireLinuxOpenGlRedrawer(layer: Any): Any {
     val redrawer =
@@ -259,7 +308,20 @@ internal object SkikoHost {
     return redrawer
   }
 
-  private fun findSkiaLayer(): Any? = findSkiaLayerComponent() ?: findComposeWindowSkiaLayer()
+  // Walking every window's component tree is far too expensive to repeat per
+  // frame, so the layer is remembered until AWT takes its peer away. A layer
+  // that loses its peer is the one case that hands the work to a different
+  // layer, and it is also what drops the redrawer that owns the GL context.
+  private fun findSkiaLayer(): Any? {
+    cachedSkiaLayer?.let { cached ->
+      if (cached.isDisplayable) {
+        return cached
+      }
+    }
+    val layer = (findSkiaLayerComponent() ?: findComposeWindowSkiaLayer()) as Component?
+    cachedSkiaLayer = layer
+    return layer
+  }
 
   private fun findSkiaLayerComponent(): Any? =
     Window.getWindows()
@@ -577,6 +639,8 @@ internal object SkikoHost {
 
   private class OpenGlTexturePresenter(private val textureName: Int) : AutoCloseable {
     private var contextIdentity = 0
+    // The GL context that issued [framebuffer].
+    private var issuingGlContext: SkikoOpenGlContext? = null
     private var extent = SurfaceExtent.Empty
     private var origin = TextureOrigin.TOP_LEFT
     private var framebuffer = 0
@@ -587,11 +651,12 @@ internal object SkikoHost {
     fun draw(
       canvas: org.jetbrains.skia.Canvas,
       context: DirectContext,
+      glContext: SkikoOpenGlContext,
       target: OpenGlTextureTarget,
       destinationWidth: Float,
       destinationHeight: Float,
     ) {
-      ensureSurface(context, target)
+      ensureSurface(context, glContext, target)
       val currentSurface =
         surface
           ?: throw NativeSurfaceBridgeException(
@@ -611,21 +676,32 @@ internal object SkikoHost {
       )
     }
 
-    private fun ensureSurface(context: DirectContext, target: OpenGlTextureTarget) {
+    private fun ensureSurface(
+      context: DirectContext,
+      glContext: SkikoOpenGlContext,
+      target: OpenGlTextureTarget,
+    ) {
       val nextContextIdentity = System.identityHashCode(context)
+      val heldGlContext = issuingGlContext
       if (
         surface != null &&
           renderTarget != null &&
           framebuffer != 0 &&
           contextIdentity == nextContextIdentity &&
+          heldGlContext != null &&
+          heldGlContext.matches(glContext) &&
           extent == target.extent &&
           origin == target.origin
       ) {
         return
       }
 
+      if (heldGlContext != null && !heldGlContext.matches(glContext)) {
+        strandGpuResources()
+      }
       closeGpuResources()
       contextIdentity = nextContextIdentity
+      issuingGlContext = glContext
       extent = target.extent
       origin = target.origin
       framebuffer = createFramebuffer(target)
@@ -655,8 +731,38 @@ internal object SkikoHost {
     override fun close() {
       closeGpuResources()
       contextIdentity = 0
+      issuingGlContext = null
       extent = SurfaceExtent.Empty
       origin = TextureOrigin.TOP_LEFT
+    }
+
+    /** Gives up everything built for a context Skiko has destroyed. */
+    fun abandon() {
+      strandGpuResources()
+      closeGpuResources()
+      contextIdentity = 0
+      issuingGlContext = null
+      extent = SurfaceExtent.Empty
+      origin = TextureOrigin.TOP_LEFT
+    }
+
+    /**
+     * Gives up what belongs to a destroyed OpenGL context instead of releasing it.
+     *
+     * The framebuffer name is the replacement context's to hand out, so deleting it there takes out
+     * whatever now answers to it. The Skia objects are the same hazard one level up: freeing them
+     * runs Skia's GPU teardown for a context that is gone, and Skia issues that against the
+     * replacement. Both are handed to [strandedSkiaObjects] to hold rather than released.
+     */
+    private fun strandGpuResources() {
+      framebuffer = 0
+      strandSkiaObject(surface)
+      surface = null
+      strandSkiaObject(renderTarget)
+      renderTarget = null
+      while (retainedImages.isNotEmpty()) {
+        strandSkiaObject(retainedImages.removeFirst())
+      }
     }
 
     private fun createFramebuffer(target: OpenGlTextureTarget): Int {
@@ -712,6 +818,24 @@ internal object SkikoHost {
   }
 }
 
+/**
+ * Identity of an OpenGL context owned by a Skiko Linux redrawer.
+ *
+ * Skiko creates the context with the redrawer and destroys it with the redrawer, so the redrawer is
+ * what a context is known by. The redrawer is held weakly: a caller comparing against a context
+ * Skiko has dropped is asking about one that no longer exists, and the answer it needs is that the
+ * context is gone, not a reference that keeps the layer and its window alive.
+ */
+internal class SkikoOpenGlContext(redrawer: Any, private val handle: Long) {
+  private val redrawer = WeakReference(redrawer)
+
+  /** True when [other] names the same live context this one does. */
+  fun matches(other: SkikoOpenGlContext): Boolean {
+    val held = redrawer.get() ?: return false
+    return held === other.redrawer.get() && handle == other.handle
+  }
+}
+
 internal data class SkikoMetalDevice(val ptr: Long)
 
 internal data class SkikoDirect3DDevice(val ptr: Long)
@@ -733,6 +857,26 @@ private fun TextureOrigin.toSkiaOrigin(): SurfaceOrigin =
     TextureOrigin.TOP_LEFT -> SurfaceOrigin.TOP_LEFT
     TextureOrigin.BOTTOM_LEFT -> SurfaceOrigin.BOTTOM_LEFT
   }
+
+/**
+ * Skia objects whose OpenGL context Skiko has destroyed.
+ *
+ * Releasing one runs its GPU teardown through a context that no longer exists, and Skia issues that
+ * teardown against whatever context is current instead — deleting names that belong to Skiko's
+ * replacement. Skija frees a Managed object from a cleaner keyed on reachability, so holding the
+ * reference is what keeps that teardown from ever running; closing them is the thing to avoid, and
+ * dropping them only defers it to a garbage collection.
+ *
+ * The GPU memory went with the context the driver tore down. What accumulates here is host-side
+ * bookkeeping, bounded by how often Skiko replaces its context over a run.
+ */
+private val strandedSkiaObjects = mutableListOf<AutoCloseable>()
+
+private fun strandSkiaObject(value: AutoCloseable?) {
+  if (value != null) {
+    strandedSkiaObjects.add(value)
+  }
+}
 
 private fun ensureOpenGlCapabilities() {
   runCatching { GL.getCapabilities() }.getOrNull() ?: GL.createCapabilities()

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/SurfaceApi.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/SurfaceApi.kt
@@ -202,8 +202,16 @@ public sealed interface NativeSurfaceTarget {
   public val generation: Long
 }
 
+/**
+ * A Metal texture and the device it belongs to.
+ *
+ * [device] is the Skiko device the texture was allocated on. A consumer draws from the texture
+ * alone, while a producer that keeps state per device compares this across frames: Skiko allocates
+ * a new texture on every resize, and only a device change means it is a new device's texture.
+ */
 public data class MetalTextureTarget(
   public val texture: NativeHandle,
+  public val device: NativeHandle,
   public val pixelFormat: Long,
   public val origin: TextureOrigin = TextureOrigin.TOP_LEFT,
   override val extent: SurfaceExtent,

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/WindowsOpenGlD3d12Bridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/WindowsOpenGlD3d12Bridge.kt
@@ -96,7 +96,7 @@ internal class WindowsOpenGlD3d12Bridge : NativeSurfaceBridge {
     runOnProducerThread { resizeOnProducerThread(extent, device) }
   }
 
-  private fun resizeOnProducerThread(extent: SurfaceExtent, device: SkikoDirect3DDevice? = null) {
+  private fun resizeOnProducerThread(extent: SurfaceExtent, device: SkikoDirect3DDevice?) {
     if (extent == currentExtent && producerTexture != null) {
       return
     }
@@ -180,13 +180,17 @@ internal class WindowsOpenGlD3d12Bridge : NativeSurfaceBridge {
   private fun target(generation: Long): NativeSurfaceTarget =
     checkNotNull(producerTexture) { "Windows WGL texture is not initialized" }.target(generation)
 
-  private fun recreateTexture(extent: SurfaceExtent, device: SkikoDirect3DDevice? = null) {
+  private fun recreateTexture(extent: SurfaceExtent, device: SkikoDirect3DDevice?) {
     if (extent.isEmpty) {
       disposeTexture()
       return
     }
 
-    val requiredDirect3DDevice = device ?: SkikoHost.requireDirect3DDevice()
+    // Resolved by the caller, on a thread that may ask Skiko for it. Reaching
+    // for it here would ask from the producer thread, and answering that waits
+    // on the event dispatch thread, which is already waiting on this one.
+    val requiredDirect3DDevice =
+      checkNotNull(device) { "The Skiko Direct3D device is resolved before this hop" }
     // Only the device that allocated it can present it, so a Skiko device change
     // leaves nothing worth keeping from the outgoing texture.
     retireTexture(deviceChanged = direct3DDevice.address != requiredDirect3DDevice.ptr)

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/WindowsOpenGlD3d12Bridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/WindowsOpenGlD3d12Bridge.kt
@@ -63,9 +63,21 @@ internal class WindowsOpenGlD3d12Bridge : NativeSurfaceBridge {
   }
   private var wgl: WindowsWglContext? = null
   private var direct3DTexture = NativeHandle(0)
+  private var direct3DDevice = NativeHandle(0)
   private var producerTexture: WindowsWglImportedD3D12Texture? = null
-  private var generation = 0L
   private var currentExtent = SurfaceExtent.Empty
+
+  // Read on the Compose thread while the producer thread writes them.
+  @Volatile private var generation = 0L
+  @Volatile private var renderedGeneration = 0L
+
+  // The Direct3D texture a frame last landed in, kept alive until one lands in
+  // its replacement. Skiko allocates a new texture for every resize and the map
+  // needs a frame or two to fill it, so this is what the consumer draws in
+  // between rather than having nothing to show. The producer import is not
+  // kept: the session already renders through the new texture.
+  private var retiredDirect3DTexture = NativeHandle(0)
+  @Volatile private var retiredGeneration = 0L
 
   override val backend: ProducerBackend = ProducerBackend.OPENGL
 
@@ -110,22 +122,37 @@ internal class WindowsOpenGlD3d12Bridge : NativeSurfaceBridge {
   }
 
   override fun completeProducerAccess(frame: NativeSurfaceFrame) {
+    renderedGeneration = frame.target.generation
     runOnProducerThread { wgl?.waitIdle() }
   }
 
   override fun <T> withProducerAccess(frame: NativeSurfaceFrame, action: () -> T): T =
-    runOnProducerThread(action)
+    runOnProducerThread {
+      releaseRetiredOnceReplaced()
+      action()
+    }
 
   override fun <T> withRendererAccess(action: () -> T): T = runOnProducerThread(action)
 
   override fun draw(scope: DrawScope, target: NativeSurfaceTarget): Boolean {
-    if (target !is OpenGlTextureTarget || direct3DTexture.address == 0L) {
+    if (target !is OpenGlTextureTarget) {
+      return false
+    }
+    // Only a texture this bridge still holds is safe to draw, which is the
+    // current one and the retired one behind it.
+    val texture =
+      when (target.generation) {
+        generation -> direct3DTexture
+        retiredGeneration -> retiredDirect3DTexture
+        else -> NativeHandle(0)
+      }
+    if (texture.address == 0L) {
       return false
     }
     return SkikoHost.drawDirect3DTexture(
       scope,
       Direct3DTextureTarget(
-        texture = direct3DTexture,
+        texture = texture,
         format = WindowsD3D12Interop.DXGI_FORMAT_R8G8B8A8_UNORM,
         colorFormat = SurfaceColorFormat.RGBA_8888,
         origin = TextureOrigin.BOTTOM_LEFT,
@@ -159,11 +186,14 @@ internal class WindowsOpenGlD3d12Bridge : NativeSurfaceBridge {
       return
     }
 
-    val direct3DDevice = device ?: SkikoHost.requireDirect3DDevice()
-    disposeTexture()
+    val requiredDirect3DDevice = device ?: SkikoHost.requireDirect3DDevice()
+    // Only the device that allocated it can present it, so a Skiko device change
+    // leaves nothing worth keeping from the outgoing texture.
+    retireTexture(deviceChanged = direct3DDevice.address != requiredDirect3DDevice.ptr)
+    direct3DDevice = NativeHandle(requiredDirect3DDevice.ptr)
     direct3DTexture =
       WindowsD3D12Interop.createSharedTexture(
-        direct3DDevice,
+        requiredDirect3DDevice,
         extent,
         dxgiFormat = WindowsD3D12Interop.DXGI_FORMAT_R8G8B8A8_UNORM,
       )
@@ -204,17 +234,66 @@ internal class WindowsOpenGlD3d12Bridge : NativeSurfaceBridge {
     return selectedImport.texture
   }
 
-  private fun disposeTexture() {
+  // Holds the outgoing texture for the consumer to draw while the replacement
+  // is still empty. A texture nothing ever rendered into has nothing to show.
+  private fun retireTexture(deviceChanged: Boolean) {
+    if (deviceChanged) {
+      // Both belong to the device Skiko replaced, and neither can be presented
+      // by the new one.
+      disposeTexture()
+      return
+    }
+    if (renderedGeneration != generation || direct3DTexture.address == 0L) {
+      // Keeps whatever is already retired: it is still the last texture a frame
+      // landed in, and this one never held a frame at all.
+      disposeCurrentTexture()
+      return
+    }
     val oldProducerTexture = producerTexture
     producerTexture = null
     if (oldProducerTexture != null) {
       runOnProducerThread { oldProducerTexture.close() }
     }
-    if (direct3DTexture.address != 0L) {
-      SkikoHost.forgetDirect3DTexture(direct3DTexture)
-      WindowsD3D12Interop.release(direct3DTexture)
-      direct3DTexture = NativeHandle(0)
+    releaseDirect3DTexture(retiredDirect3DTexture)
+    retiredDirect3DTexture = direct3DTexture
+    retiredGeneration = generation
+    direct3DTexture = NativeHandle(0)
+  }
+
+  // Runs a frame after the replacement first rendered, so the consumer's last
+  // recorded frame from the retired texture has been flushed by then.
+  private fun releaseRetiredOnceReplaced() {
+    if (retiredDirect3DTexture.address == 0L || renderedGeneration != generation) {
+      return
     }
+    releaseDirect3DTexture(retiredDirect3DTexture)
+    retiredDirect3DTexture = NativeHandle(0)
+    retiredGeneration = 0
+  }
+
+  private fun disposeTexture() {
+    disposeCurrentTexture()
+    releaseDirect3DTexture(retiredDirect3DTexture)
+    retiredDirect3DTexture = NativeHandle(0)
+    retiredGeneration = 0
+  }
+
+  private fun disposeCurrentTexture() {
+    val oldProducerTexture = producerTexture
+    producerTexture = null
+    if (oldProducerTexture != null) {
+      runOnProducerThread { oldProducerTexture.close() }
+    }
+    releaseDirect3DTexture(direct3DTexture)
+    direct3DTexture = NativeHandle(0)
+  }
+
+  private fun releaseDirect3DTexture(texture: NativeHandle) {
+    if (texture.address == 0L) {
+      return
+    }
+    SkikoHost.forgetDirect3DTexture(texture)
+    WindowsD3D12Interop.release(texture)
   }
 
   private fun <T> runOnProducerThread(action: () -> T): T {

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/WindowsVulkanD3d12Bridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/WindowsVulkanD3d12Bridge.kt
@@ -80,9 +80,22 @@ internal class WindowsVulkanD3d12Bridge : NativeSurfaceBridge {
     NativeSurfaceRendererDispatcher("compose-map-windows-vulkan-renderer")
   private var vulkan: WindowsVulkanContext? = null
   private var direct3DTexture = NativeHandle(0)
+  private var direct3DDevice = NativeHandle(0)
   private var importedTexture: WindowsVulkanImportedD3D12Texture? = null
-  private var generation = 0L
   private var currentExtent = SurfaceExtent.Empty
+
+  // Read on the Compose thread while the renderer thread writes them.
+  @Volatile private var generation = 0L
+  @Volatile private var renderedGeneration = 0L
+
+  // The Direct3D texture a frame last landed in, kept alive until one lands in
+  // its replacement. Skiko allocates a new texture for every resize and the map
+  // needs a frame or two to fill it, so this is what the consumer draws in
+  // between rather than having nothing to show. The Vulkan import is not kept:
+  // the session already renders through the new image.
+  private var retiredDirect3DTexture = NativeHandle(0)
+  private var retiredStorageExtent = SurfaceExtent.Empty
+  @Volatile private var retiredGeneration = 0L
 
   override val backend: ProducerBackend = ProducerBackend.VULKAN
 
@@ -127,23 +140,45 @@ internal class WindowsVulkanD3d12Bridge : NativeSurfaceBridge {
   }
 
   override fun completeProducerAccess(frame: NativeSurfaceFrame) {
+    renderedGeneration = frame.target.generation
     rendererDispatcher.run { vulkan?.waitIdle() }
   }
 
   override fun <T> withProducerAccess(frame: NativeSurfaceFrame, action: () -> T): T =
-    rendererDispatcher.run(action)
+    rendererDispatcher.run {
+      releaseRetiredOnceReplaced()
+      action()
+    }
 
   override fun <T> withRendererAccess(action: () -> T): T = rendererDispatcher.run(action)
 
   override fun draw(scope: DrawScope, target: NativeSurfaceTarget): Boolean {
-    if (target !is VulkanImageTarget || direct3DTexture.address == 0L) {
+    if (target !is VulkanImageTarget) {
+      return false
+    }
+    // Only a texture this bridge still holds is safe to draw, which is the
+    // current one and the retired one behind it.
+    val texture: NativeHandle
+    val storageExtent: SurfaceExtent
+    when (target.generation) {
+      generation -> {
+        texture = direct3DTexture
+        storageExtent = importedTexture?.storageExtent ?: target.extent
+      }
+      retiredGeneration -> {
+        texture = retiredDirect3DTexture
+        storageExtent = retiredStorageExtent
+      }
+      else -> return false
+    }
+    if (texture.address == 0L) {
       return false
     }
     return SkikoHost.drawDirect3DTexture(
       scope,
       Direct3DTextureTarget(
-        texture = direct3DTexture,
-        extent = importedTexture?.storageExtent ?: target.extent,
+        texture = texture,
+        extent = storageExtent,
         generation = target.generation,
       ),
     )
@@ -172,10 +207,13 @@ internal class WindowsVulkanD3d12Bridge : NativeSurfaceBridge {
       return
     }
 
-    val direct3DDevice = device ?: SkikoHost.requireDirect3DDevice()
+    val requiredDirect3DDevice = device ?: SkikoHost.requireDirect3DDevice()
     val storageExtent = extent
-    disposeTexture()
-    direct3DTexture = WindowsD3D12Interop.createSharedTexture(direct3DDevice, storageExtent)
+    // Only the device that allocated it can present it, so a Skiko device change
+    // leaves nothing worth keeping from the outgoing texture.
+    retireTexture(deviceChanged = direct3DDevice.address != requiredDirect3DDevice.ptr)
+    direct3DDevice = NativeHandle(requiredDirect3DDevice.ptr)
+    direct3DTexture = WindowsD3D12Interop.createSharedTexture(requiredDirect3DDevice, storageExtent)
     var sharedHandle = NULL
     try {
       sharedHandle = WindowsD3D12Interop.createSharedHandle(direct3DTexture)
@@ -189,14 +227,66 @@ internal class WindowsVulkanD3d12Bridge : NativeSurfaceBridge {
     }
   }
 
-  private fun disposeTexture() {
+  // Holds the outgoing texture for the consumer to draw while the replacement
+  // is still empty. A texture nothing ever rendered into has nothing to show.
+  private fun retireTexture(deviceChanged: Boolean) {
+    val outgoingExtent = importedTexture?.storageExtent
+    if (deviceChanged) {
+      // Both belong to the device Skiko replaced, and neither can be presented
+      // by the new one.
+      disposeTexture()
+      return
+    }
+    if (
+      renderedGeneration != generation || direct3DTexture.address == 0L || outgoingExtent == null
+    ) {
+      // Keeps whatever is already retired: it is still the last texture a frame
+      // landed in, and this one never held a frame at all.
+      disposeCurrentTexture()
+      return
+    }
     importedTexture?.close()
     importedTexture = null
-    if (direct3DTexture.address != 0L) {
-      SkikoHost.forgetDirect3DTexture(direct3DTexture)
-      WindowsD3D12Interop.release(direct3DTexture)
-      direct3DTexture = NativeHandle(0)
+    releaseDirect3DTexture(retiredDirect3DTexture)
+    retiredDirect3DTexture = direct3DTexture
+    retiredStorageExtent = outgoingExtent
+    retiredGeneration = generation
+    direct3DTexture = NativeHandle(0)
+  }
+
+  // Runs a frame after the replacement first rendered, so the consumer's last
+  // recorded frame from the retired texture has been flushed by then.
+  private fun releaseRetiredOnceReplaced() {
+    if (retiredDirect3DTexture.address == 0L || renderedGeneration != generation) {
+      return
     }
+    releaseDirect3DTexture(retiredDirect3DTexture)
+    retiredDirect3DTexture = NativeHandle(0)
+    retiredStorageExtent = SurfaceExtent.Empty
+    retiredGeneration = 0
+  }
+
+  private fun disposeTexture() {
+    disposeCurrentTexture()
+    releaseDirect3DTexture(retiredDirect3DTexture)
+    retiredDirect3DTexture = NativeHandle(0)
+    retiredStorageExtent = SurfaceExtent.Empty
+    retiredGeneration = 0
+  }
+
+  private fun disposeCurrentTexture() {
+    importedTexture?.close()
+    importedTexture = null
+    releaseDirect3DTexture(direct3DTexture)
+    direct3DTexture = NativeHandle(0)
+  }
+
+  private fun releaseDirect3DTexture(texture: NativeHandle) {
+    if (texture.address == 0L) {
+      return
+    }
+    SkikoHost.forgetDirect3DTexture(texture)
+    WindowsD3D12Interop.release(texture)
   }
 }
 

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/WindowsVulkanD3d12Bridge.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/WindowsVulkanD3d12Bridge.kt
@@ -114,7 +114,7 @@ internal class WindowsVulkanD3d12Bridge : NativeSurfaceBridge {
     rendererDispatcher.run { resizeOnRendererThread(extent, device) }
   }
 
-  private fun resizeOnRendererThread(extent: SurfaceExtent, device: SkikoDirect3DDevice? = null) {
+  private fun resizeOnRendererThread(extent: SurfaceExtent, device: SkikoDirect3DDevice?) {
     if (extent == currentExtent && importedTexture != null) {
       return
     }
@@ -201,13 +201,17 @@ internal class WindowsVulkanD3d12Bridge : NativeSurfaceBridge {
   private fun target(generation: Long): NativeSurfaceTarget =
     checkNotNull(importedTexture) { "Windows Vulkan texture is not initialized" }.target(generation)
 
-  private fun recreateTexture(extent: SurfaceExtent, device: SkikoDirect3DDevice? = null) {
+  private fun recreateTexture(extent: SurfaceExtent, device: SkikoDirect3DDevice?) {
     if (extent.isEmpty) {
       disposeTexture()
       return
     }
 
-    val requiredDirect3DDevice = device ?: SkikoHost.requireDirect3DDevice()
+    // Resolved by the caller, on a thread that may ask Skiko for it. Reaching
+    // for it here would ask from the producer thread, and answering that waits
+    // on the event dispatch thread, which is already waiting on this one.
+    val requiredDirect3DDevice =
+      checkNotNull(device) { "The Skiko Direct3D device is resolved before this hop" }
     val storageExtent = extent
     // Only the device that allocated it can present it, so a Skiko device change
     // leaves nothing worth keeping from the outgoing texture.

--- a/examples/dotnet-map/IRenderTarget.cs
+++ b/examples/dotnet-map/IRenderTarget.cs
@@ -5,10 +5,12 @@ namespace Maplibre.Native.Examples.DotnetMap;
 
 internal interface IRenderTarget : IDisposable
 {
-    bool NeedsReattachOnResize { get; }
-
     bool Render();
 
+    /// <summary>
+    /// Follows a resized host without losing the session: a target the session sizes resizes in
+    /// place, and a caller-owned one hands the live session a replacement at the new size.
+    /// </summary>
     void Resize(Viewport viewport);
 }
 
@@ -67,8 +69,6 @@ internal sealed class OwnedTextureRenderTarget : IRenderTarget
         this.compositor = compositor;
         this.session = session;
     }
-
-    public bool NeedsReattachOnResize => false;
 
     public static OwnedTextureRenderTarget Attach(
         IGraphicsContext graphics,
@@ -226,8 +226,8 @@ internal sealed class BorrowedTextureRenderTarget : IRenderTarget
 {
     private readonly IGraphicsContext graphics;
     private readonly ITextureCompositor compositor;
-    private readonly IDisposable texture;
     private readonly RenderSessionHandle session;
+    private IDisposable texture;
 
     private BorrowedTextureRenderTarget(
         IGraphicsContext graphics,
@@ -241,8 +241,6 @@ internal sealed class BorrowedTextureRenderTarget : IRenderTarget
         this.texture = texture;
         this.session = session;
     }
-
-    public bool NeedsReattachOnResize => true;
 
     public static BorrowedTextureRenderTarget Attach(
         IGraphicsContext graphics,
@@ -294,12 +292,81 @@ internal sealed class BorrowedTextureRenderTarget : IRenderTarget
         return presented;
     }
 
+    /// <summary>
+    /// Follows a resized host. A caller-owned texture is sized by this example rather than by the
+    /// session, so following a resize means allocating one at the new size and handing it over. The
+    /// session keeps its renderer across the handover, which is what keeps the map from going cold
+    /// every time the window changes size.
+    /// </summary>
     public void Resize(Viewport viewport)
     {
-        _ = viewport;
-        throw new InvalidOperationException(
-            "Borrowed textures are reattached instead of resized in place."
-        );
+        switch (graphics)
+        {
+            case MetalContext metal:
+                var metalReplacement = new MetalBorrowedTexture(metal, viewport);
+                HandOver(
+                    metalReplacement,
+                    () =>
+                        session.SetMetalBorrowedTextureTarget(Describe(metalReplacement, viewport)),
+                    viewport
+                );
+                break;
+            case VulkanContext vulkan:
+                var vulkanReplacement = new VulkanBorrowedImage(vulkan, viewport);
+                HandOver(
+                    vulkanReplacement,
+                    () =>
+                        session.SetVulkanBorrowedTextureTarget(
+                            Describe(vulkan, vulkanReplacement, viewport)
+                        ),
+                    viewport
+                );
+                break;
+            case OpenGLContext openGl:
+                var openGlReplacement = new OpenGLBorrowedTexture(openGl, viewport);
+                HandOver(
+                    openGlReplacement,
+                    () =>
+                        session.SetOpenGLBorrowedTextureTarget(
+                            Describe(openGl, openGlReplacement, viewport)
+                        ),
+                    viewport
+                );
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Borrowed textures are not implemented for {graphics.Backend}."
+                );
+        }
+    }
+
+    /// <summary>
+    /// Hands the live session a replacement texture, then retires the outgoing one. Order matters:
+    /// a rejected replacement is released rather than leaked and the session keeps the texture it
+    /// already had.
+    /// </summary>
+    private void HandOver(IDisposable replacement, Action setTarget, Viewport viewport)
+    {
+        try
+        {
+            setTarget();
+        }
+        catch
+        {
+            DisposeAfterFailure(replacement);
+            throw;
+        }
+
+        var outgoing = texture;
+        texture = replacement;
+        try
+        {
+            compositor.Resize(viewport);
+        }
+        finally
+        {
+            outgoing.Dispose();
+        }
     }
 
     public void Dispose()
@@ -336,18 +403,7 @@ internal sealed class BorrowedTextureRenderTarget : IRenderTarget
             compositor = new VulkanTextureCompositor(vulkan, viewport);
             session = RenderSessionHandle.AttachVulkanBorrowedTexture(
                 map,
-                new VulkanBorrowedTextureDescriptor
-                {
-                    Extent = viewport.RenderTargetExtent,
-                    PhysicalWidth = viewport.PhysicalWidth,
-                    PhysicalHeight = viewport.PhysicalHeight,
-                    Context = vulkan.Descriptor(),
-                    Image = texture.ImagePointer,
-                    ImageView = texture.ViewPointer,
-                    Format = (uint)VulkanBorrowedImage.ImageFormat,
-                    InitialLayout = (uint)VulkanBorrowedImage.InitialLayout,
-                    FinalLayout = (uint)VulkanBorrowedImage.FinalLayout,
-                }
+                Describe(vulkan, texture, viewport)
             );
             return new BorrowedTextureRenderTarget(vulkan, compositor, texture, session);
         }
@@ -375,13 +431,7 @@ internal sealed class BorrowedTextureRenderTarget : IRenderTarget
             compositor = new MetalTextureCompositor(metal);
             session = RenderSessionHandle.AttachMetalBorrowedTexture(
                 map,
-                new MetalBorrowedTextureDescriptor
-                {
-                    Extent = viewport.RenderTargetExtent,
-                    PhysicalWidth = viewport.PhysicalWidth,
-                    PhysicalHeight = viewport.PhysicalHeight,
-                    Texture = texture.Pointer,
-                }
+                Describe(texture, viewport)
             );
             return new BorrowedTextureRenderTarget(metal, compositor, texture, session);
         }
@@ -409,15 +459,7 @@ internal sealed class BorrowedTextureRenderTarget : IRenderTarget
             compositor = new OpenGLTextureCompositor(openGl, viewport);
             session = RenderSessionHandle.AttachOpenGLBorrowedTexture(
                 map,
-                new OpenGLBorrowedTextureDescriptor
-                {
-                    Extent = viewport.RenderTargetExtent,
-                    PhysicalWidth = viewport.PhysicalWidth,
-                    PhysicalHeight = viewport.PhysicalHeight,
-                    Context = openGl.Descriptor(requirePbufferConfig: true),
-                    Texture = texture.Texture,
-                    Target = texture.Target,
-                }
+                Describe(openGl, texture, viewport)
             );
             return new BorrowedTextureRenderTarget(openGl, compositor, texture, session);
         }
@@ -428,6 +470,59 @@ internal sealed class BorrowedTextureRenderTarget : IRenderTarget
             DisposeAfterFailure(texture);
             throw;
         }
+    }
+
+    // Attach and set-target describe the same texture the same way: the replacement a resize hands
+    // over has to match what the session attached with.
+    private static MetalBorrowedTextureDescriptor Describe(
+        MetalBorrowedTexture texture,
+        Viewport viewport
+    )
+    {
+        return new MetalBorrowedTextureDescriptor
+        {
+            Extent = viewport.RenderTargetExtent,
+            PhysicalWidth = viewport.PhysicalWidth,
+            PhysicalHeight = viewport.PhysicalHeight,
+            Texture = texture.Pointer,
+        };
+    }
+
+    private static VulkanBorrowedTextureDescriptor Describe(
+        VulkanContext vulkan,
+        VulkanBorrowedImage image,
+        Viewport viewport
+    )
+    {
+        return new VulkanBorrowedTextureDescriptor
+        {
+            Extent = viewport.RenderTargetExtent,
+            PhysicalWidth = viewport.PhysicalWidth,
+            PhysicalHeight = viewport.PhysicalHeight,
+            Context = vulkan.Descriptor(),
+            Image = image.ImagePointer,
+            ImageView = image.ViewPointer,
+            Format = (uint)VulkanBorrowedImage.ImageFormat,
+            InitialLayout = (uint)VulkanBorrowedImage.InitialLayout,
+            FinalLayout = (uint)VulkanBorrowedImage.FinalLayout,
+        };
+    }
+
+    private static OpenGLBorrowedTextureDescriptor Describe(
+        OpenGLContext openGl,
+        OpenGLBorrowedTexture texture,
+        Viewport viewport
+    )
+    {
+        return new OpenGLBorrowedTextureDescriptor
+        {
+            Extent = viewport.RenderTargetExtent,
+            PhysicalWidth = viewport.PhysicalWidth,
+            PhysicalHeight = viewport.PhysicalHeight,
+            Context = openGl.Descriptor(requirePbufferConfig: true),
+            Texture = texture.Texture,
+            Target = texture.Target,
+        };
     }
 
     private static void DisposeAfterFailure(IDisposable? disposable)
@@ -456,8 +551,6 @@ internal sealed class NativeSurfaceRenderTarget : IRenderTarget
     {
         this.session = session;
     }
-
-    public bool NeedsReattachOnResize => false;
 
     public static NativeSurfaceRenderTarget Attach(
         IGraphicsContext graphics,

--- a/examples/dotnet-map/IRenderTarget.cs
+++ b/examples/dotnet-map/IRenderTarget.cs
@@ -343,7 +343,9 @@ internal sealed class BorrowedTextureRenderTarget : IRenderTarget
     /// <summary>
     /// Hands the live session a replacement texture, then retires the outgoing one. Order matters:
     /// a rejected replacement is released rather than leaked and the session keeps the texture it
-    /// already had.
+    /// already had. A native error may instead mean the session took the replacement before
+    /// failing, and nothing here can tell that apart, so the session is detached before either
+    /// texture is released.
     /// </summary>
     private void HandOver(IDisposable replacement, Action setTarget, Viewport viewport)
     {
@@ -353,6 +355,14 @@ internal sealed class BorrowedTextureRenderTarget : IRenderTarget
         }
         catch
         {
+            try
+            {
+                session.Detach();
+            }
+            catch
+            {
+                // Preserve the handover failure that triggered cleanup.
+            }
             DisposeAfterFailure(replacement);
             throw;
         }

--- a/examples/dotnet-map/Shell.cs
+++ b/examples/dotnet-map/Shell.cs
@@ -144,20 +144,11 @@ internal static class Shell
                     if (!viewport.IsEmpty)
                     {
                         graphics.Resize(viewport);
-                        if (target.NeedsReattachOnResize)
-                        {
-                            // Reattach is local to this thread now: close the session, rebuild the
-                            // target, attach again.
-                            var previous = target;
-                            target = null;
-                            previous.Dispose();
-                            target = RenderTargetFactory.Attach(graphics, map, mode);
-                        }
-                        else
-                        {
-                            target.Resize(viewport);
-                        }
-
+                        // Every mode follows a resize without losing its session: the ones the
+                        // session sizes resize in place, and a caller-owned texture hands the
+                        // session a replacement. Closing and attaching again is reserved for a
+                        // target the live session cannot take at all.
+                        target.Resize(viewport);
                         renderRequest.Set();
                     }
                 }

--- a/examples/go-map/main.go
+++ b/examples/go-map/main.go
@@ -157,7 +157,7 @@ func run(mode renderTargetMode) (result error) {
 			if view.empty() {
 				return nil
 			}
-			if err := state.resize(view, mode); err != nil {
+			if err := state.resize(view); err != nil {
 				return err
 			}
 			shared.requestRender()

--- a/examples/go-map/map_state.go
+++ b/examples/go-map/map_state.go
@@ -227,12 +227,10 @@ func drainEvents(runtimeHandle *maplibre.RuntimeHandle, mapID maplibre.MapID) (b
 	}
 }
 
-// renderMapState owns the graphics context and render target on the SDL render
-// loop thread. It uses the published map only for attach and reattach.
+// renderMapState owns the render target on the SDL render loop thread. It uses
+// the published map only to attach that target.
 type renderMapState struct {
-	mapRef   *maplibre.MapHandle
-	graphics *openGLContext
-	target   renderTarget
+	target renderTarget
 }
 
 func newRenderMapState(graphics *openGLContext, mapRef *maplibre.MapHandle, v viewport, mode renderTargetMode) (*renderMapState, error) {
@@ -240,7 +238,7 @@ func newRenderMapState(graphics *openGLContext, mapRef *maplibre.MapHandle, v vi
 	if err != nil {
 		return nil, err
 	}
-	return &renderMapState{mapRef: mapRef, graphics: graphics, target: target}, nil
+	return &renderMapState{target: target}, nil
 }
 
 func (state *renderMapState) closeTarget() error {
@@ -252,24 +250,11 @@ func (state *renderMapState) closeTarget() error {
 	return err
 }
 
-func (state *renderMapState) resize(v viewport, mode renderTargetMode) error {
+// resize follows the resized host without losing the session: the render target
+// either resizes in place or hands the live session a replacement of its own.
+func (state *renderMapState) resize(v viewport) error {
 	if state.target == nil {
 		return errors.New("render target is not attached")
-	}
-	reattach, err := state.target.NeedsReattachOnResize()
-	if err != nil {
-		return err
-	}
-	if reattach {
-		if err := state.closeTarget(); err != nil {
-			return err
-		}
-		target, err := newOpenGLRenderTarget(state.graphics, v, mode, state.mapRef)
-		if err != nil {
-			return err
-		}
-		state.target = target
-		return nil
 	}
 	return state.target.Resize(v)
 }

--- a/examples/go-map/opengl.go
+++ b/examples/go-map/opengl.go
@@ -14,8 +14,9 @@ const glTexture2D = 0x0DE1
 
 type renderTarget interface {
 	Close() error
+	// Resize follows a resized host without losing the session: every mode
+	// either resizes in place or hands the live session a replacement target.
 	Resize(viewport) error
-	NeedsReattachOnResize() (bool, error)
 	FinishFrame() error
 	RenderUpdate() (bool, error)
 }
@@ -328,10 +329,6 @@ func (target *openGLOwnedTextureTarget) Resize(v viewport) error {
 	return target.session.Resize(v.extent())
 }
 
-func (*openGLOwnedTextureTarget) NeedsReattachOnResize() (bool, error) {
-	return false, nil
-}
-
 func (target *openGLOwnedTextureTarget) FinishFrame() error { return target.compositor.FinishFrame() }
 
 func (target *openGLOwnedTextureTarget) RenderUpdate() (bool, error) {
@@ -418,12 +415,39 @@ func (target *openGLBorrowedTextureTarget) Close() error {
 	return result
 }
 
-func (*openGLBorrowedTextureTarget) Resize(viewport) error {
-	return errors.New("borrowed texture resize requires reattach")
-}
-
-func (*openGLBorrowedTextureTarget) NeedsReattachOnResize() (bool, error) {
-	return true, nil
+// Resize follows a resized host. A host-owned texture is sized by this example
+// rather than by the session, so following a resize means creating one at the
+// new size and handing it to the live session. The session keeps its renderer
+// across the handover, which is what keeps the map from going cold every time
+// the window changes size.
+func (target *openGLBorrowedTextureTarget) Resize(v viewport) error {
+	descriptor, err := target.compositor.context.descriptor(true)
+	if err != nil {
+		return err
+	}
+	replacement, err := createBorrowedTexture(target.compositor.context, v)
+	if err != nil {
+		return err
+	}
+	if err := target.session.SetOpenGLBorrowedTextureTarget(maplibre.OpenGLBorrowedTextureDescriptor{
+		Extent:         v.extent(),
+		PhysicalWidth:  v.physicalWidth,
+		PhysicalHeight: v.physicalHeight,
+		Context:        descriptor,
+		Texture:        replacement,
+		Target:         glTexture2D,
+	}); err != nil {
+		glDeleteTexture(replacement)
+		return fmt.Errorf("OpenGL borrowed texture set target failed: %w", err)
+	}
+	// Only once the session has taken the replacement, so the outgoing texture
+	// stays alive for the duration of that call.
+	outgoing := target.texture
+	target.texture = replacement
+	if outgoing != 0 {
+		glDeleteTexture(outgoing)
+	}
+	return target.compositor.Resize(v)
 }
 
 func (target *openGLBorrowedTextureTarget) FinishFrame() error {
@@ -492,17 +516,29 @@ func (target *openGLSurfaceTarget) Close() error {
 	return result
 }
 
-func (target *openGLSurfaceTarget) Resize(v viewport) error { return target.session.Resize(v.extent()) }
-
-func (target *openGLSurfaceTarget) NeedsReattachOnResize() (bool, error) {
-	if target.context.platform.egl == nil {
-		return false, nil
-	}
-	surface := target.context.surface()
+// Resize follows a resized host. SDL can hand back a different EGL window
+// surface for the resized window, and the live session takes that replacement
+// rather than being closed and attached again, so the map keeps its renderer.
+func (target *openGLSurfaceTarget) Resize(v viewport) error {
+	outgoing := target.context.surface()
 	if err := target.context.refreshPlatformSurface(); err != nil {
-		return false, err
+		return err
 	}
-	return target.context.surface() != surface, nil
+	if target.context.surface() == outgoing {
+		return target.session.Resize(v.extent())
+	}
+	descriptor, err := target.context.descriptor(false)
+	if err != nil {
+		return err
+	}
+	if err := target.session.SetOpenGLSurfaceTarget(maplibre.OpenGLSurfaceDescriptor{
+		Extent:  v.extent(),
+		Context: descriptor,
+		Surface: target.context.surface(),
+	}); err != nil {
+		return fmt.Errorf("OpenGL surface set target failed: %w", err)
+	}
+	return nil
 }
 
 func (target *openGLSurfaceTarget) FinishFrame() error {

--- a/examples/go-map/opengl.go
+++ b/examples/go-map/opengl.go
@@ -440,8 +440,8 @@ func (target *openGLBorrowedTextureTarget) Resize(v viewport) error {
 		glDeleteTexture(replacement)
 		return fmt.Errorf("OpenGL borrowed texture set target failed: %w", err)
 	}
-	// Only once the session has taken the replacement, so the outgoing texture
-	// stays alive for the duration of that call.
+	// Only once the session has taken the replacement, so a rejected one leaves
+	// this target on the texture it already had.
 	outgoing := target.texture
 	target.texture = replacement
 	if outgoing != 0 {

--- a/examples/go-map/opengl.go
+++ b/examples/go-map/opengl.go
@@ -437,6 +437,10 @@ func (target *openGLBorrowedTextureTarget) Resize(v viewport) error {
 		Texture:        replacement,
 		Target:         glTexture2D,
 	}); err != nil {
+		// A native error may mean the session took the replacement before
+		// failing, and nothing here can tell that apart from a rejection that
+		// came first, so detach before either texture is deleted.
+		_ = target.session.Detach()
 		glDeleteTexture(replacement)
 		return fmt.Errorf("OpenGL borrowed texture set target failed: %w", err)
 	}
@@ -522,6 +526,10 @@ func (target *openGLSurfaceTarget) Close() error {
 func (target *openGLSurfaceTarget) Resize(v viewport) error {
 	outgoing := target.context.surface()
 	if err := target.context.refreshPlatformSurface(); err != nil {
+		// SDL owns the surfaces and may already have dropped the one the
+		// session presents through, so detach rather than leave it naming a
+		// surface that is gone.
+		_ = target.session.Detach()
 		return err
 	}
 	if target.context.surface() == outgoing {
@@ -536,6 +544,10 @@ func (target *openGLSurfaceTarget) Resize(v viewport) error {
 		Context: descriptor,
 		Surface: target.context.surface(),
 	}); err != nil {
+		// SDL owns both surfaces and already dropped the outgoing one, so on a
+		// native error the session may be holding a surface that is gone.
+		// Detaching is the only way to stop it naming either.
+		_ = target.session.Detach()
 		return fmt.Errorf("OpenGL surface set target failed: %w", err)
 	}
 	return nil

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/MetalRenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/MetalRenderTarget.kt
@@ -64,16 +64,9 @@ internal object MetalRenderTarget {
     var compositor: MetalTextureCompositor? = null
     try {
       texture = MetalBorrowedTexture(context, viewport)
-      val descriptor =
-        MetalBorrowedTextureDescriptor(
-          RenderTarget.extent(viewport),
-          viewport.framebufferWidth(),
-          viewport.framebufferHeight(),
-          NativePointer.ofAddress(texture.texture()),
-        )
-      session = map.attachMetalBorrowedTexture(descriptor)
+      session = map.attachMetalBorrowedTexture(borrowedDescriptor(viewport, texture))
       compositor = MetalTextureCompositor(context)
-      return BorrowedTexture(context, map, session, compositor, texture)
+      return BorrowedTexture(context, session, compositor, texture)
     } catch (error: RuntimeException) {
       RenderTarget.closeSuppressed(error, compositor)
       RenderTarget.closeSuppressed(error, session)
@@ -81,6 +74,17 @@ internal object MetalRenderTarget {
       throw error
     }
   }
+
+  private fun borrowedDescriptor(
+    viewport: Viewport,
+    texture: MetalBorrowedTexture,
+  ): MetalBorrowedTextureDescriptor =
+    MetalBorrowedTextureDescriptor(
+      RenderTarget.extent(viewport),
+      viewport.framebufferWidth(),
+      viewport.framebufferHeight(),
+      NativePointer.ofAddress(texture.texture()),
+    )
 
   private fun descriptor(context: MetalContext): MetalContextDescriptor =
     MetalContextDescriptor(NativePointer.ofAddress(context.deviceAddress()))
@@ -134,58 +138,43 @@ internal object MetalRenderTarget {
 
   private class BorrowedTexture(
     private val context: MetalContext,
-    private val map: MapHandle,
-    private var session: RenderSessionHandle?,
-    private var compositor: MetalTextureCompositor?,
-    private var texture: MetalBorrowedTexture?,
+    private val session: RenderSessionHandle,
+    private val compositor: MetalTextureCompositor,
+    private var texture: MetalBorrowedTexture,
   ) : RenderTarget {
     override fun needsMetalAutoreleasePool(): Boolean = true
 
-    override fun needsReattachOnResize(): Boolean = true
-
-    /** Local to the render loop thread: close the session, rebuild the texture, attach again. */
-    override fun reattach(viewport: Viewport) {
-      close()
-      val replacement = attachBorrowedTexture(context, map, viewport)
-      check(replacement is BorrowedTexture) { "unexpected borrowed texture replacement" }
-      session = replacement.session
-      compositor = replacement.compositor
-      texture = replacement.texture
-      replacement.session = null
-      replacement.compositor = null
-      replacement.texture = null
-    }
-
+    /** Local to the render loop thread: allocate a texture at the new size and hand it over. */
     override fun resize(viewport: Viewport) {
-      error("borrowed texture resize requires render target reattachment")
+      val replacement = MetalBorrowedTexture(context, viewport)
+      try {
+        session.setMetalBorrowedTextureTarget(borrowedDescriptor(viewport, replacement))
+      } catch (error: RuntimeException) {
+        RenderTarget.closeSuppressed(error, replacement)
+        throw error
+      }
+      // Only once the session has taken the replacement, so a rejected one leaves this target on
+      // the texture it already had.
+      texture.close()
+      texture = replacement
     }
 
     override fun renderUpdate(): Boolean {
-      val currentSession = checkNotNull(session) { "Metal borrowed texture session is detached" }
-      val currentCompositor =
-        checkNotNull(compositor) { "Metal borrowed texture compositor is detached" }
-      val currentTexture = checkNotNull(texture) { "Metal borrowed texture is detached" }
-      if (!currentSession.renderUpdate()) {
+      if (!session.renderUpdate()) {
         return false
       }
-      currentCompositor.drawTexture(currentTexture.texture())
+      compositor.drawTexture(texture.texture())
       return true
     }
 
     override fun close() {
-      val closingCompositor = compositor
-      val closingSession = session
-      val closingTexture = texture
-      compositor = null
-      session = null
-      texture = null
       try {
-        closingCompositor?.close()
+        compositor.close()
       } finally {
         try {
-          closingSession?.close()
+          session.close()
         } finally {
-          closingTexture?.close()
+          texture.close()
         }
       }
     }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/MetalRenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/MetalRenderTarget.kt
@@ -150,6 +150,10 @@ internal object MetalRenderTarget {
       try {
         session.setMetalBorrowedTextureTarget(borrowedDescriptor(viewport, replacement))
       } catch (error: RuntimeException) {
+        // A native error may mean the session took the replacement before failing, and nothing here
+        // can tell that apart from a rejection that came first, so detach before either texture is
+        // released.
+        RenderTarget.detachSuppressed(error, session)
         RenderTarget.closeSuppressed(error, replacement)
         throw error
       }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/OpenGLRenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/OpenGLRenderTarget.kt
@@ -168,6 +168,10 @@ internal object OpenGLRenderTarget {
       try {
         session.setOpenGLBorrowedTextureTarget(borrowedDescriptor(context, viewport, replacement))
       } catch (error: RuntimeException) {
+        // A native error may mean the session took the replacement before failing, and nothing here
+        // can tell that apart from a rejection that came first, so detach before either target is
+        // released.
+        RenderTarget.detachSuppressed(error, session)
         RenderTarget.closeSuppressed(error, replacement)
         throw error
       }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/OpenGLRenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/OpenGLRenderTarget.kt
@@ -171,8 +171,8 @@ internal object OpenGLRenderTarget {
         RenderTarget.closeSuppressed(error, replacement)
         throw error
       }
-      // Only once the session has taken the replacement: deleting the outgoing texture before that
-      // call returns would pull it out from under the session.
+      // Only once the session has taken the replacement, so a rejected one leaves this target on
+      // the texture it already had.
       texture.close()
       texture = replacement
     }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/OpenGLRenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/OpenGLRenderTarget.kt
@@ -67,18 +67,9 @@ internal object OpenGLRenderTarget {
     var compositor: OpenGLTextureCompositor? = null
     try {
       texture = OpenGLBorrowedTexture(context, viewport)
-      val descriptor =
-        OpenGLBorrowedTextureDescriptor(
-          RenderTarget.extent(viewport),
-          viewport.framebufferWidth(),
-          viewport.framebufferHeight(),
-          descriptor(context),
-          texture.texture(),
-          texture.target(),
-        )
-      session = map.attachOpenGLBorrowedTexture(descriptor)
+      session = map.attachOpenGLBorrowedTexture(borrowedDescriptor(context, viewport, texture))
       compositor = OpenGLTextureCompositor(context, viewport)
-      return BorrowedTexture(context, map, session, compositor, texture)
+      return BorrowedTexture(context, session, compositor, texture)
     } catch (error: RuntimeException) {
       RenderTarget.closeSuppressed(error, compositor)
       RenderTarget.closeSuppressed(error, session)
@@ -86,6 +77,20 @@ internal object OpenGLRenderTarget {
       throw error
     }
   }
+
+  private fun borrowedDescriptor(
+    context: OpenGLContext,
+    viewport: Viewport,
+    texture: OpenGLBorrowedTexture,
+  ): OpenGLBorrowedTextureDescriptor =
+    OpenGLBorrowedTextureDescriptor(
+      RenderTarget.extent(viewport),
+      viewport.framebufferWidth(),
+      viewport.framebufferHeight(),
+      descriptor(context),
+      texture.texture(),
+      texture.target(),
+    )
 
   private fun descriptor(context: OpenGLContext): OpenGLContextDescriptor =
     if (context.isGles) {
@@ -152,56 +157,42 @@ internal object OpenGLRenderTarget {
 
   private class BorrowedTexture(
     private val context: OpenGLContext,
-    private val map: MapHandle,
-    private var session: RenderSessionHandle?,
-    private var compositor: OpenGLTextureCompositor?,
-    private var texture: OpenGLBorrowedTexture?,
+    private val session: RenderSessionHandle,
+    private val compositor: OpenGLTextureCompositor,
+    private var texture: OpenGLBorrowedTexture,
   ) : RenderTarget {
-    override fun needsReattachOnResize(): Boolean = true
-
-    /** Local to the render loop thread: close the session, rebuild the texture, attach again. */
-    override fun reattach(viewport: Viewport) {
-      close()
-      val replacement = attachBorrowedTexture(context, map, viewport)
-      check(replacement is BorrowedTexture) { "unexpected borrowed texture replacement" }
-      session = replacement.session
-      compositor = replacement.compositor
-      texture = replacement.texture
-      replacement.session = null
-      replacement.compositor = null
-      replacement.texture = null
-    }
-
+    /** Local to the render loop thread: allocate a texture at the new size and hand it over. */
     override fun resize(viewport: Viewport) {
-      error("borrowed texture resize requires render target reattachment")
+      compositor.resize(viewport)
+      val replacement = OpenGLBorrowedTexture(context, viewport)
+      try {
+        session.setOpenGLBorrowedTextureTarget(borrowedDescriptor(context, viewport, replacement))
+      } catch (error: RuntimeException) {
+        RenderTarget.closeSuppressed(error, replacement)
+        throw error
+      }
+      // Only once the session has taken the replacement: deleting the outgoing texture before that
+      // call returns would pull it out from under the session.
+      texture.close()
+      texture = replacement
     }
 
     override fun renderUpdate(): Boolean {
-      val currentSession = checkNotNull(session) { "OpenGL borrowed texture session is detached" }
-      val currentCompositor =
-        checkNotNull(compositor) { "OpenGL borrowed texture compositor is detached" }
-      val currentTexture = checkNotNull(texture) { "OpenGL borrowed texture is detached" }
-      if (!currentSession.renderUpdate()) {
+      if (!session.renderUpdate()) {
         return false
       }
-      currentCompositor.drawTexture(currentTexture.texture())
+      compositor.drawTexture(texture.texture())
       return true
     }
 
     override fun close() {
-      val closingCompositor = compositor
-      val closingSession = session
-      val closingTexture = texture
-      compositor = null
-      session = null
-      texture = null
       try {
-        closingCompositor?.close()
+        compositor.close()
       } finally {
         try {
-          closingSession?.close()
+          session.close()
         } finally {
-          closingTexture?.close()
+          texture.close()
         }
       }
     }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/RenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/RenderTarget.kt
@@ -1,6 +1,7 @@
 package org.maplibre.nativeffi.examples.lwjglmap
 
 import org.maplibre.nativeffi.map.MapHandle
+import org.maplibre.nativeffi.render.RenderSessionHandle
 import org.maplibre.nativeffi.render.RenderTargetExtent
 
 /**
@@ -44,6 +45,21 @@ internal interface RenderTarget : AutoCloseable {
 
     fun extent(viewport: Viewport): RenderTargetExtent =
       RenderTargetExtent(viewport.width(), viewport.height(), viewport.scaleFactor())
+
+    /**
+     * Detaches a session whose handover failed, before the targets it may hold are released.
+     *
+     * A native error may mean the session took the replacement before failing, and a caller cannot
+     * tell that apart from a rejection that came first, so neither target is safe to release while
+     * the session is still attached to one of them.
+     */
+    fun detachSuppressed(error: RuntimeException, session: RenderSessionHandle) {
+      try {
+        session.detach()
+      } catch (cleanupError: Exception) {
+        error.addSuppressed(cleanupError)
+      }
+    }
 
     fun closeSuppressed(error: RuntimeException, closeable: AutoCloseable?) {
       if (closeable == null) {

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/RenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/RenderTarget.kt
@@ -10,14 +10,16 @@ import org.maplibre.nativeffi.render.RenderTargetExtent
  * driven, and closed on the render loop thread, where the host graphics context lives.
  */
 internal interface RenderTarget : AutoCloseable {
-  fun needsReattachOnResize(): Boolean = false
-
   fun needsMetalAutoreleasePool(): Boolean = false
 
-  fun reattach(viewport: Viewport) {
-    throw IllegalStateException("render target does not support reattachment")
-  }
-
+  /**
+   * Follows a resized host, keeping the session attached.
+   *
+   * Surface and owned-texture targets are sized by the session, so they resize in place. A
+   * caller-owned texture is sized by this example instead, so it allocates one at the new size and
+   * hands it to the live session. Either way the session keeps its renderer, which is what keeps
+   * the map from going cold on every window resize.
+   */
   fun resize(viewport: Viewport)
 
   /** Renders the latest map update. Returns false when no update is available yet. */

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/Shell.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/Shell.kt
@@ -116,11 +116,9 @@ internal object Shell {
               viewport.value.log("resized viewport")
               if (!viewport.value.empty()) {
                 graphics.resize(viewport.value)
-                if (target.needsReattachOnResize()) {
-                  target.reattach(viewport.value)
-                } else {
-                  target.resize(viewport.value)
-                }
+                // Every mode follows a resize with its session still attached, so the map stays
+                // warm across the change.
+                target.resize(viewport.value)
                 renderRequest.set()
               }
             }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanRenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanRenderTarget.kt
@@ -168,8 +168,8 @@ internal object VulkanRenderTarget {
         RenderTarget.closeSuppressed(error, replacement)
         throw error
       }
-      // Only once the session has taken the replacement: destroying the outgoing image before that
-      // call returns would pull it out from under the session.
+      // Only once the session has taken the replacement, so a rejected one leaves this target on
+      // the image it already had.
       image.close()
       image = replacement
     }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanRenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanRenderTarget.kt
@@ -165,6 +165,10 @@ internal object VulkanRenderTarget {
       try {
         session.setVulkanBorrowedTextureTarget(borrowedDescriptor(context, viewport, replacement))
       } catch (error: RuntimeException) {
+        // A native error may mean the session took the replacement before failing, and nothing here
+        // can tell that apart from a rejection that came first, so detach before either target is
+        // released.
+        RenderTarget.detachSuppressed(error, session)
         RenderTarget.closeSuppressed(error, replacement)
         throw error
       }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanRenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanRenderTarget.kt
@@ -66,21 +66,9 @@ internal object VulkanRenderTarget {
     var compositor: VulkanTextureCompositor? = null
     try {
       image = VulkanBorrowedImage.create(context, viewport)
-      val descriptor =
-        VulkanBorrowedTextureDescriptor(
-            RenderTarget.extent(viewport),
-            viewport.framebufferWidth(),
-            viewport.framebufferHeight(),
-            descriptor(context),
-            NativePointer.ofAddress(image.imageAddress()),
-            NativePointer.ofAddress(image.viewAddress()),
-            VK10.VK_FORMAT_R8G8B8A8_UNORM,
-            VK10.VK_IMAGE_LAYOUT_UNDEFINED,
-          )
-          .apply { finalLayout = VK10.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }
-      session = map.attachVulkanBorrowedTexture(descriptor)
+      session = map.attachVulkanBorrowedTexture(borrowedDescriptor(context, viewport, image))
       compositor = VulkanTextureCompositor(context, viewport)
-      return BorrowedTexture(context, map, session, compositor, image)
+      return BorrowedTexture(context, session, compositor, image)
     } catch (error: RuntimeException) {
       RenderTarget.closeSuppressed(error, compositor)
       RenderTarget.closeSuppressed(error, session)
@@ -88,6 +76,23 @@ internal object VulkanRenderTarget {
       throw error
     }
   }
+
+  private fun borrowedDescriptor(
+    context: VulkanContext,
+    viewport: Viewport,
+    image: VulkanBorrowedImage,
+  ): VulkanBorrowedTextureDescriptor =
+    VulkanBorrowedTextureDescriptor(
+        RenderTarget.extent(viewport),
+        viewport.framebufferWidth(),
+        viewport.framebufferHeight(),
+        descriptor(context),
+        NativePointer.ofAddress(image.imageAddress()),
+        NativePointer.ofAddress(image.viewAddress()),
+        VK10.VK_FORMAT_R8G8B8A8_UNORM,
+        VK10.VK_IMAGE_LAYOUT_UNDEFINED,
+      )
+      .apply { finalLayout = VK10.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }
 
   private fun descriptor(context: VulkanContext): VulkanContextDescriptor =
     VulkanContextDescriptor(
@@ -149,56 +154,42 @@ internal object VulkanRenderTarget {
 
   private class BorrowedTexture(
     private val context: VulkanContext,
-    private val map: MapHandle,
-    private var session: RenderSessionHandle?,
-    private var compositor: VulkanTextureCompositor?,
-    private var image: VulkanBorrowedImage?,
+    private val session: RenderSessionHandle,
+    private val compositor: VulkanTextureCompositor,
+    private var image: VulkanBorrowedImage,
   ) : RenderTarget {
-    override fun needsReattachOnResize(): Boolean = true
-
-    /** Local to the render loop thread: close the session, rebuild the image, attach again. */
-    override fun reattach(viewport: Viewport) {
-      close()
-      val replacement = attachBorrowedTexture(context, map, viewport)
-      check(replacement is BorrowedTexture) { "unexpected borrowed texture replacement" }
-      session = replacement.session
-      compositor = replacement.compositor
-      image = replacement.image
-      replacement.session = null
-      replacement.compositor = null
-      replacement.image = null
-    }
-
+    /** Local to the render loop thread: allocate an image at the new size and hand it over. */
     override fun resize(viewport: Viewport) {
-      error("borrowed texture resize requires render target reattachment")
+      compositor.resize(viewport)
+      val replacement = VulkanBorrowedImage.create(context, viewport)
+      try {
+        session.setVulkanBorrowedTextureTarget(borrowedDescriptor(context, viewport, replacement))
+      } catch (error: RuntimeException) {
+        RenderTarget.closeSuppressed(error, replacement)
+        throw error
+      }
+      // Only once the session has taken the replacement: destroying the outgoing image before that
+      // call returns would pull it out from under the session.
+      image.close()
+      image = replacement
     }
 
     override fun renderUpdate(): Boolean {
-      val currentSession = checkNotNull(session) { "Vulkan borrowed texture session is detached" }
-      val currentCompositor =
-        checkNotNull(compositor) { "Vulkan borrowed texture compositor is detached" }
-      val currentImage = checkNotNull(image) { "Vulkan borrowed image is detached" }
-      if (!currentSession.renderUpdate()) {
+      if (!session.renderUpdate()) {
         return false
       }
-      currentCompositor.drawImageView(currentImage.view())
+      compositor.drawImageView(image.view())
       return true
     }
 
     override fun close() {
-      val closingCompositor = compositor
-      val closingSession = session
-      val closingImage = image
-      compositor = null
-      session = null
-      image = null
       try {
-        closingCompositor?.close()
+        compositor.close()
       } finally {
         try {
-          closingSession?.close()
+          session.close()
         } finally {
-          closingImage?.close()
+          image.close()
         }
       }
     }

--- a/examples/rust-map/src/app.rs
+++ b/examples/rust-map/src/app.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use std::sync::mpsc::{self, Sender};
 use std::thread::{self, JoinHandle};
 
-use maplibre_native::MapAttachRef;
 use winit::event::WindowEvent;
 use winit::window::{Window, WindowId};
 
@@ -23,7 +22,6 @@ use crate::viewport::Viewport;
 
 pub struct App {
     target: Option<RenderTarget>,
-    attach_ref: MapAttachRef,
     /// Releases the runtime loop's parked pump, so a queued camera command is
     /// applied now rather than after its parking bound.
     wake: Arc<maplibre_native::WakeSource>,
@@ -86,7 +84,6 @@ impl App {
 
         Ok(Self {
             target: Some(target),
-            attach_ref: handles.attach_ref,
             wake: handles.wake,
             runtime_thread: Some(runtime_thread),
             commands,
@@ -162,28 +159,14 @@ impl App {
             return Ok(());
         }
         self.graphics.resize(next)?;
-        if self
-            .target
-            .as_ref()
+        // Every mode follows a resize without losing its session: the ones the
+        // session sizes resize in place, and a caller-owned target allocates a
+        // replacement and hands it over. Closing and attaching again is
+        // reserved for a target the live session cannot take at all.
+        self.target
+            .as_mut()
             .expect("render target is open")
-            .needs_reattach_on_resize()
-        {
-            // Reattach is entirely local: close the session, rebuild the
-            // target, attach again, all on this thread.
-            let old_target = self.target.take().expect("render target is open");
-            old_target.close(&self.graphics)?;
-            self.target = Some(RenderTarget::attach(
-                self.mode,
-                &self.attach_ref,
-                &self.graphics,
-                next,
-            )?);
-        } else {
-            self.target
-                .as_mut()
-                .expect("render target is open")
-                .resize(next)?;
-        }
+            .resize(&self.graphics, next)?;
         self.shared.request_render();
         Ok(())
     }

--- a/examples/rust-map/src/render_target/metal_target.rs
+++ b/examples/rust-map/src/render_target/metal_target.rs
@@ -37,15 +37,34 @@ impl RenderTarget {
         }
     }
 
-    pub fn needs_reattach_on_resize(&self) -> bool {
-        matches!(self, Self::BorrowedTexture { .. })
-    }
-
-    pub fn resize(&mut self, viewport: Viewport) -> maplibre_native::Result<()> {
+    /// Follows a resized host.
+    ///
+    /// A caller-owned texture is sized by this example, not by the session, so
+    /// following a resize means allocating one at the new size and handing it
+    /// over. The session stays live either way, which is what keeps the map
+    /// from going cold every time the window changes size.
+    pub fn resize(
+        &mut self,
+        graphics: &GraphicsContext,
+        viewport: Viewport,
+    ) -> maplibre_native::Result<()> {
         match self {
-            Self::BorrowedTexture { .. } => Err(compositor_error(
-                "borrowed texture resize requires render target reattachment",
-            )),
+            Self::BorrowedTexture {
+                session, texture, ..
+            } => {
+                let replacement = MetalBorrowedTexture::new(graphics.metal(), viewport)?;
+                let descriptor = maplibre_native::MetalBorrowedTextureDescriptor::new(
+                    extent(viewport),
+                    viewport.physical_width,
+                    viewport.physical_height,
+                    replacement.pointer(),
+                );
+                session.set_metal_borrowed_texture_target(&descriptor)?;
+                // Only once the session has taken it: the outgoing texture has
+                // to stay alive for the duration of that call.
+                **texture = replacement;
+                Ok(())
+            }
             Self::OwnedTexture { session, .. } | Self::Surface { session } => session.resize(
                 viewport.logical_width,
                 viewport.logical_height,

--- a/examples/rust-map/src/render_target/metal_target.rs
+++ b/examples/rust-map/src/render_target/metal_target.rs
@@ -60,8 +60,8 @@ impl RenderTarget {
                     replacement.pointer(),
                 );
                 session.set_metal_borrowed_texture_target(&descriptor)?;
-                // Only once the session has taken it: the outgoing texture has
-                // to stay alive for the duration of that call.
+                // Only once the session has taken it, so a rejected replacement
+                // leaves this target on the texture it already had.
                 **texture = replacement;
                 Ok(())
             }

--- a/examples/rust-map/src/render_target/metal_target.rs
+++ b/examples/rust-map/src/render_target/metal_target.rs
@@ -59,7 +59,16 @@ impl RenderTarget {
                     viewport.physical_height,
                     replacement.pointer(),
                 );
-                session.set_metal_borrowed_texture_target(&descriptor)?;
+                if let Err(error) = session.set_metal_borrowed_texture_target(&descriptor) {
+                    // A native error may mean the session took the replacement
+                    // before failing, and nothing here can tell that apart from
+                    // a rejection that came first. Rust's detach consumes the
+                    // handle, which this borrow cannot do, so keep the
+                    // replacement alive instead: releasing it is the only way
+                    // to hand the session a dangling texture.
+                    std::mem::forget(replacement);
+                    return Err(error);
+                }
                 // Only once the session has taken it, so a rejected replacement
                 // leaves this target on the texture it already had.
                 **texture = replacement;

--- a/examples/rust-map/src/render_target/opengl_target.rs
+++ b/examples/rust-map/src/render_target/opengl_target.rs
@@ -174,7 +174,12 @@ impl RenderTarget {
                     replacement.target(),
                 );
                 if let Err(error) = session.set_opengl_borrowed_texture_target(&descriptor) {
-                    replacement.close(Some(opengl));
+                    // A native error may mean the session took the replacement
+                    // before failing, and nothing here can tell that apart from
+                    // a rejection that came first. Rust's detach consumes the
+                    // handle, which this borrow cannot do, so leave the
+                    // replacement alone: deleting it is the only way to hand
+                    // the session a dangling texture.
                     return Err(error);
                 }
                 compositor.resize(viewport);

--- a/examples/rust-map/src/render_target/opengl_target.rs
+++ b/examples/rust-map/src/render_target/opengl_target.rs
@@ -173,15 +173,12 @@ impl RenderTarget {
                     replacement.texture(),
                     replacement.target(),
                 );
-                if let Err(error) = session.set_opengl_borrowed_texture_target(&descriptor) {
-                    // A native error may mean the session took the replacement
-                    // before failing, and nothing here can tell that apart from
-                    // a rejection that came first. Rust's detach consumes the
-                    // handle, which this borrow cannot do, so leave the
-                    // replacement alone: deleting it is the only way to hand
-                    // the session a dangling texture.
-                    return Err(error);
-                }
+                // A native error may mean the session took the replacement before
+                // failing, and nothing here can tell that apart from a rejection
+                // that came first. Rust's detach consumes the handle, which this
+                // borrow cannot do, so leave the replacement alone: deleting it is
+                // the only way to hand the session a dangling texture.
+                session.set_opengl_borrowed_texture_target(&descriptor)?;
                 compositor.resize(viewport);
                 // Only once the session has taken the replacement, so a rejected
                 // one leaves this target on the texture it already had.

--- a/examples/rust-map/src/render_target/opengl_target.rs
+++ b/examples/rust-map/src/render_target/opengl_target.rs
@@ -178,8 +178,8 @@ impl RenderTarget {
                     return Err(error);
                 }
                 compositor.resize(viewport);
-                // Only once the session has taken the replacement, so the
-                // outgoing texture stays alive for the duration of that call.
+                // Only once the session has taken the replacement, so a rejected
+                // one leaves this target on the texture it already had.
                 let outgoing = std::mem::replace(&mut **texture, replacement);
                 outgoing.close(Some(opengl));
                 Ok(())

--- a/examples/rust-map/src/render_target/opengl_target.rs
+++ b/examples/rust-map/src/render_target/opengl_target.rs
@@ -127,11 +127,17 @@ impl RenderTarget {
         })
     }
 
-    pub fn needs_reattach_on_resize(&self) -> bool {
-        matches!(self, Self::BorrowedTexture { .. })
-    }
-
-    pub fn resize(&mut self, viewport: Viewport) -> maplibre_native::Result<()> {
+    /// Follows a resized host.
+    ///
+    /// A caller-owned texture is sized by this example, not by the session, so
+    /// following a resize means allocating one at the new size and handing it
+    /// over. The session stays live either way, which is what keeps the map
+    /// from going cold every time the window changes size.
+    pub fn resize(
+        &mut self,
+        graphics: &GraphicsContext,
+        viewport: Viewport,
+    ) -> maplibre_native::Result<()> {
         match self {
             Self::OwnedTexture {
                 session,
@@ -144,9 +150,40 @@ impl RenderTarget {
                     viewport.scale_factor,
                 )
             }
-            Self::BorrowedTexture { .. } => Err(compositor_error(
-                "borrowed texture resize requires render target reattachment",
-            )),
+            Self::BorrowedTexture {
+                session,
+                compositor,
+                texture,
+            } => {
+                let opengl = graphics.opengl();
+                let replacement =
+                    OpenGLBorrowedTexture::new(opengl, viewport).map_err(|error| {
+                        compositor_error(format!(
+                            "OpenGL borrowed texture creation failed: {error}"
+                        ))
+                    })?;
+                let context = opengl.descriptor().map_err(|error| {
+                    compositor_error(format!("OpenGL context descriptor failed: {error}"))
+                })?;
+                let descriptor = OpenGLBorrowedTextureDescriptor::new(
+                    extent(viewport),
+                    viewport.physical_width,
+                    viewport.physical_height,
+                    context,
+                    replacement.texture(),
+                    replacement.target(),
+                );
+                if let Err(error) = session.set_opengl_borrowed_texture_target(&descriptor) {
+                    replacement.close(Some(opengl));
+                    return Err(error);
+                }
+                compositor.resize(viewport);
+                // Only once the session has taken the replacement, so the
+                // outgoing texture stays alive for the duration of that call.
+                let outgoing = std::mem::replace(&mut **texture, replacement);
+                outgoing.close(Some(opengl));
+                Ok(())
+            }
             Self::Surface { session } => session.resize(
                 viewport.logical_width,
                 viewport.logical_height,

--- a/examples/rust-map/src/render_target/vulkan_target.rs
+++ b/examples/rust-map/src/render_target/vulkan_target.rs
@@ -41,11 +41,17 @@ impl RenderTarget {
         }
     }
 
-    pub fn needs_reattach_on_resize(&self) -> bool {
-        matches!(self, Self::BorrowedTexture { .. })
-    }
-
-    pub fn resize(&mut self, viewport: Viewport) -> maplibre_native::Result<()> {
+    /// Follows a resized host.
+    ///
+    /// A caller-owned image is sized by this example, not by the session, so
+    /// following a resize means allocating one at the new size and handing it
+    /// over. The session stays live either way, which is what keeps the map
+    /// from going cold every time the window changes size.
+    pub fn resize(
+        &mut self,
+        graphics: &GraphicsContext,
+        viewport: Viewport,
+    ) -> maplibre_native::Result<()> {
         match self {
             Self::OwnedTexture {
                 session,
@@ -62,9 +68,37 @@ impl RenderTarget {
                     viewport.scale_factor,
                 )
             }
-            Self::BorrowedTexture { .. } => Err(compositor_error(
-                "borrowed texture resize requires render target reattachment",
-            )),
+            Self::BorrowedTexture {
+                session,
+                compositor,
+                image,
+            } => {
+                let vulkan = graphics.vulkan();
+                let replacement = BorrowedImage::new(vulkan, viewport).map_err(|error| {
+                    compositor_error(format!("Vulkan borrowed image creation failed: {error:?}"))
+                })?;
+                let descriptor = VulkanBorrowedTextureDescriptor::new(
+                    extent(viewport),
+                    viewport.physical_width,
+                    viewport.physical_height,
+                    context_descriptor(vulkan),
+                    replacement.image_pointer(),
+                    replacement.view_pointer(),
+                    ash::vk::Format::R8G8B8A8_UNORM.as_raw() as u32,
+                    ash::vk::ImageLayout::UNDEFINED.as_raw() as u32,
+                    ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL.as_raw() as u32,
+                );
+                session.set_vulkan_borrowed_texture_target(&descriptor)?;
+                compositor.resize(viewport).map_err(|error| {
+                    compositor_error(format!(
+                        "Vulkan texture compositor resize failed: {error:?}"
+                    ))
+                })?;
+                // Only once the session has taken the replacement: dropping the
+                // outgoing image destroys it, and it has to outlive that call.
+                **image = replacement;
+                Ok(())
+            }
             Self::Surface { session } => session.resize(
                 viewport.logical_width,
                 viewport.logical_height,

--- a/examples/rust-map/src/render_target/vulkan_target.rs
+++ b/examples/rust-map/src/render_target/vulkan_target.rs
@@ -88,7 +88,16 @@ impl RenderTarget {
                     ash::vk::ImageLayout::UNDEFINED.as_raw() as u32,
                     ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL.as_raw() as u32,
                 );
-                session.set_vulkan_borrowed_texture_target(&descriptor)?;
+                if let Err(error) = session.set_vulkan_borrowed_texture_target(&descriptor) {
+                    // A native error may mean the session took the replacement
+                    // before failing, and nothing here can tell that apart from
+                    // a rejection that came first. Rust's detach consumes the
+                    // handle, which this borrow cannot do, so keep the
+                    // replacement alive instead: dropping it destroys the image
+                    // and would hand the session a dangling one.
+                    std::mem::forget(replacement);
+                    return Err(error);
+                }
                 // Adopted the moment the session takes it, and before anything
                 // else that can fail: the session renders into this image now,
                 // so dropping the local would pull it out from under it. A

--- a/examples/rust-map/src/render_target/vulkan_target.rs
+++ b/examples/rust-map/src/render_target/vulkan_target.rs
@@ -89,14 +89,17 @@ impl RenderTarget {
                     ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL.as_raw() as u32,
                 );
                 session.set_vulkan_borrowed_texture_target(&descriptor)?;
+                // Adopted the moment the session takes it, and before anything
+                // else that can fail: the session renders into this image now,
+                // so dropping the local would pull it out from under it. A
+                // rejected replacement never gets here, leaving this target on
+                // the image it already had.
+                **image = replacement;
                 compositor.resize(viewport).map_err(|error| {
                     compositor_error(format!(
                         "Vulkan texture compositor resize failed: {error:?}"
                     ))
                 })?;
-                // Only once the session has taken the replacement, so a rejected
-                // one leaves this target on the image it already had.
-                **image = replacement;
                 Ok(())
             }
             Self::Surface { session } => session.resize(

--- a/examples/rust-map/src/render_target/vulkan_target.rs
+++ b/examples/rust-map/src/render_target/vulkan_target.rs
@@ -94,8 +94,8 @@ impl RenderTarget {
                         "Vulkan texture compositor resize failed: {error:?}"
                     ))
                 })?;
-                // Only once the session has taken the replacement: dropping the
-                // outgoing image destroys it, and it has to outlive that call.
+                // Only once the session has taken the replacement, so a rejected
+                // one leaves this target on the image it already had.
                 **image = replacement;
                 Ok(())
             }

--- a/examples/swift-map/Sources/SwiftMap/MetalMapView.swift
+++ b/examples/swift-map/Sources/SwiftMap/MetalMapView.swift
@@ -193,18 +193,10 @@ final class MetalMapView: NSView {
 
     do {
       graphics.resize(viewport)
-      if let renderTarget {
-        if renderTarget.needsReattachOnResize {
-          // The host texture is fixed to the viewport size, so close the
-          // session and let the next tick attach a replacement against a fresh
-          // texture. Both halves run here, on the thread that owns the session
-          // either way.
-          try renderTarget.close()
-          self.renderTarget = nil
-        } else {
-          try renderTarget.resize(viewport)
-        }
-      }
+      // Every mode follows a resize without losing its session: the ones the
+      // session sizes resize in place, and the caller-owned texture allocates a
+      // replacement and hands it over.
+      try renderTarget?.resize(graphics: graphics, viewport: viewport)
       currentViewport = viewport
       channels.setRenderRequest()
       startRuntimeLoopIfNeeded(viewport: viewport)

--- a/examples/swift-map/Sources/SwiftMap/MetalMapView.swift
+++ b/examples/swift-map/Sources/SwiftMap/MetalMapView.swift
@@ -201,7 +201,12 @@ final class MetalMapView: NSView {
       channels.setRenderRequest()
       startRuntimeLoopIfNeeded(viewport: viewport)
     } catch {
+      // A failed resize leaves the render target detached, so stop driving it
+      // rather than letting the next tick render through a session that is no
+      // longer attached to anything.
       print(error)
+      timer?.invalidate()
+      timer = nil
       showError(String(describing: error))
     }
   }

--- a/examples/swift-map/Sources/SwiftMap/MetalRenderTarget.swift
+++ b/examples/swift-map/Sources/SwiftMap/MetalRenderTarget.swift
@@ -115,13 +115,23 @@ enum MetalRenderTarget {
         graphics: graphics,
         viewport: viewport
       )
-      try session
-        .setMetalBorrowedTextureTarget(MetalBorrowedTextureDescriptor(
-          extent: viewport.extent,
-          physicalWidth: viewport.physicalWidth,
-          physicalHeight: viewport.physicalHeight,
-          texture: replacement.pointer
-        ))
+      do {
+        try session
+          .setMetalBorrowedTextureTarget(MetalBorrowedTextureDescriptor(
+            extent: viewport.extent,
+            physicalWidth: viewport.physicalWidth,
+            physicalHeight: viewport.physicalHeight,
+            texture: replacement.pointer
+          ))
+      } catch {
+        // A native error may mean the session took the replacement before
+        // failing, and nothing here can tell that apart from a rejection that
+        // came first, so the session may be holding either texture. Detach
+        // before either one is released, which is what happens next as this
+        // scope unwinds.
+        try? session.detach()
+        throw error
+      }
       compositor.resize(viewport)
       // Only once the session has taken the replacement: a throw above leaves
       // the session on the texture this case still holds, and releases the

--- a/examples/swift-map/Sources/SwiftMap/MetalRenderTarget.swift
+++ b/examples/swift-map/Sources/SwiftMap/MetalRenderTarget.swift
@@ -92,16 +92,16 @@ enum MetalRenderTarget {
     }
   }
 
-  var needsReattachOnResize: Bool {
-    switch self {
-    case .borrowedTexture:
-      true
-    case .nativeSurface, .ownedTexture:
-      false
-    }
-  }
-
-  func resize(_ viewport: Viewport) throws {
+  /// Follows a resized host.
+  ///
+  /// A caller-owned texture is sized by this example rather than by the
+  /// session, so following a resize means allocating one at the new size and
+  /// handing it over. The session stays live either way, which is what keeps
+  /// the map from going cold every time the window changes size.
+  mutating func resize(
+    graphics: MetalGraphicsContext,
+    viewport: Viewport
+  ) throws {
     switch self {
     case let .ownedTexture(session, compositor):
       compositor.resize(viewport)
@@ -110,9 +110,26 @@ enum MetalRenderTarget {
         height: viewport.logicalHeight,
         scaleFactor: viewport.scaleFactor
       )
-    case .borrowedTexture:
-      throw metalError(
-        "borrowed texture resize requires render target reattachment"
+    case let .borrowedTexture(session, compositor, _):
+      let replacement = try MetalBorrowedTexture(
+        graphics: graphics,
+        viewport: viewport
+      )
+      try session
+        .setMetalBorrowedTextureTarget(MetalBorrowedTextureDescriptor(
+          extent: viewport.extent,
+          physicalWidth: viewport.physicalWidth,
+          physicalHeight: viewport.physicalHeight,
+          texture: replacement.pointer
+        ))
+      compositor.resize(viewport)
+      // Only once the session has taken the replacement: a throw above leaves
+      // the session on the texture this case still holds, and releases the
+      // replacement instead.
+      self = .borrowedTexture(
+        session: session,
+        compositor: compositor,
+        texture: replacement
       )
     case let .nativeSurface(session):
       try session.resize(

--- a/examples/zig-map/main.zig
+++ b/examples/zig-map/main.zig
@@ -141,14 +141,11 @@ pub fn main(init_args: std.process.Init) !void {
         .map_channel = &map_channel,
     }});
 
-    var target_live = true;
     const result = renderLoop(
         init_args.io,
-        allocator,
         window_handle,
         target_mode,
         &target,
-        &target_live,
         &current_viewport,
         &commands,
         &render_request,
@@ -156,9 +153,8 @@ pub fn main(init_args: std.process.Init) !void {
     );
 
     // Destroy the session before the runtime loop destroys the map: a map with
-    // an attached session cannot be destroyed. A reattach that failed partway
-    // already destroyed it and left the slot dead.
-    if (target_live) target.deinit();
+    // an attached session cannot be destroyed.
+    target.deinit();
     map_channel.requestShutdown();
     runtime_thread.join();
 
@@ -170,11 +166,9 @@ pub fn main(init_args: std.process.Init) !void {
 /// session once it adopts it.
 fn renderLoop(
     io: std.Io,
-    allocator: std.mem.Allocator,
     window_handle: *c.SDL_Window,
     target_mode: types.RenderTargetMode,
     target: *RenderTarget,
-    target_live: *bool,
     current_viewport: *types.Viewport,
     commands: *channel.CommandQueue,
     render_request: *channel.RenderRequest,
@@ -211,25 +205,11 @@ fn renderLoop(
                 => {
                     current_viewport.* = viewport.get(window_handle);
                     viewport.log("resized viewport", current_viewport.*);
-                    if (target.needsReattachOnResize()) {
-                        // Reattach is entirely local now: close the session,
-                        // rebuild the target, attach again, all on this thread.
-                        // The slot holds a destroyed target between the two, so
-                        // mark it dead: a failure here returns and the caller
-                        // must not deinit it a second time.
-                        target.deinit();
-                        target_live.* = false;
-                        target.* = try RenderTarget.init(
-                            allocator,
-                            window_handle,
-                            current_viewport.*,
-                            target_mode,
-                        );
-                        target_live.* = true;
-                        try target.attach(&map, current_viewport.*);
-                    } else {
-                        try target.resize(current_viewport.*);
-                    }
+                    // Every mode follows a resize without losing its session:
+                    // the ones the session sizes resize in place, and a
+                    // caller-owned target allocates a replacement and hands it
+                    // over.
+                    try target.resize(current_viewport.*);
                     render_request.set();
                 },
                 else => {

--- a/examples/zig-map/render/metal/mod.zig
+++ b/examples/zig-map/render/metal/mod.zig
@@ -71,13 +71,6 @@ pub const MetalRenderTarget = union(enum) {
         }
     }
 
-    pub fn needsReattachOnResize(self: *const MetalRenderTarget) bool {
-        return switch (self.*) {
-            .owned_texture, .native_surface => false,
-            .borrowed_texture => true,
-        };
-    }
-
     pub fn finishFrame(_: *MetalRenderTarget) !void {}
 
     pub fn renderUpdate(
@@ -306,8 +299,31 @@ const MetalBorrowedTextureBackend = struct {
         self.compositor.deinit();
     }
 
-    fn resize(_: *MetalBorrowedTextureBackend, _: types.Viewport) !void {
-        return types.AppError.TextureResizeFailed;
+    /// Follows a resized window.
+    ///
+    /// This example sizes the borrowed texture, not the session, so following a
+    /// resize means allocating one at the new size and handing it to the live
+    /// session. The session stays live, which is what keeps the map from going
+    /// cold on every resize.
+    fn resize(self: *MetalBorrowedTextureBackend, viewport: types.Viewport) !void {
+        const session = try self.session.textureHandle();
+        self.compositor.resize(viewport);
+
+        const replacement = try createBorrowedTexture(self.compositor.view.device, viewport);
+        errdefer replacement.release();
+        session.setMetalBorrowedTextureTarget(.{
+            .extent = render_target.extent(viewport),
+            .physical_width = viewport.physical_width,
+            .physical_height = viewport.physical_height,
+            .texture = maplibre.NativePointer.fromPtr(replacement.value.?),
+        }) catch |err| {
+            diagnostics.logError("Metal borrowed texture set target failed", err, null);
+            return types.AppError.TextureResizeFailed;
+        };
+        // Only once the session has taken the replacement, so a rejected one
+        // leaves this target on the texture it already had.
+        self.borrowed_texture.release();
+        self.borrowed_texture = replacement;
     }
 
     fn attachRenderTarget(

--- a/examples/zig-map/render/metal/mod.zig
+++ b/examples/zig-map/render/metal/mod.zig
@@ -317,6 +317,11 @@ const MetalBorrowedTextureBackend = struct {
             .physical_height = viewport.physical_height,
             .texture = maplibre.NativePointer.fromPtr(replacement.value.?),
         }) catch |err| {
+            // A native error may mean the session took the replacement
+            // before failing, and nothing here can tell that apart from a
+            // rejection that came first, so detach before either target is
+            // released; errdefer releases the replacement next.
+            session.detach() catch {};
             diagnostics.logError("Metal borrowed texture set target failed", err, null);
             return types.AppError.TextureResizeFailed;
         };

--- a/examples/zig-map/render/opengl/mod.zig
+++ b/examples/zig-map/render/opengl/mod.zig
@@ -353,6 +353,17 @@ const OpenGLContext = struct {
         };
     }
 
+    /// Re-reads the platform surface for this window.
+    ///
+    /// SDL can hand back a different EGL window surface once the window has
+    /// been resized, and a session still presenting through the old one draws
+    /// nowhere. Returns whether the handle changed.
+    fn refreshPlatformSurface(self: *OpenGLContext) !bool {
+        const previous = self.surface();
+        self.platform = try platformContext(self.window);
+        return !std.meta.eql(self.surface(), previous);
+    }
+
     fn surface(self: *const OpenGLContext) maplibre.NativePointer {
         return switch (self.platform) {
             .wgl => |wgl| maplibre.NativePointer.fromPtr(@ptrCast(wgl.device_context)),
@@ -653,8 +664,8 @@ const OpenGLBorrowedTextureBackend = struct {
             diagnostics.logError("OpenGL borrowed texture set target failed", err, null);
             return types.AppError.TextureResizeFailed;
         };
-        // Only once the session has taken the replacement: it renders into the
-        // outgoing texture until that call returns, so delete it after.
+        // Only once the session has taken the replacement, so a rejected one
+        // leaves this target on the texture it already had.
         self.borrowed_texture.deinit(&self.compositor.context, self.compositor.procs);
         self.borrowed_texture = replacement;
     }
@@ -724,8 +735,29 @@ const OpenGLSurfaceBackend = struct {
         self.context.deinit();
     }
 
+    /// Follows a resized window.
+    ///
+    /// SDL can hand back a different EGL window surface for the resized window.
+    /// The live session takes that replacement rather than being closed and
+    /// attached again, so it keeps its renderer either way.
     fn resize(self: *OpenGLSurfaceBackend, viewport: types.Viewport) !void {
-        try self.session.resize(viewport, null);
+        const replaced = self.context.refreshPlatformSurface() catch |err| {
+            diagnostics.logError("OpenGL surface refresh failed", err, null);
+            return types.AppError.SurfaceAttachFailed;
+        };
+        if (!replaced) {
+            try self.session.resize(viewport, null);
+            return;
+        }
+        const handle = try self.session.surfaceHandle();
+        handle.setOpenGLSurfaceTarget(.{
+            .extent = render_target.extent(viewport),
+            .context = self.context.descriptor(),
+            .surface = self.context.surface(),
+        }) catch |err| {
+            diagnostics.logError("OpenGL surface set target failed", err, null);
+            return types.AppError.SurfaceAttachFailed;
+        };
     }
 
     fn finishFrame(self: *OpenGLSurfaceBackend) !void {

--- a/examples/zig-map/render/opengl/mod.zig
+++ b/examples/zig-map/render/opengl/mod.zig
@@ -661,6 +661,11 @@ const OpenGLBorrowedTextureBackend = struct {
             .texture = replacement.texture,
             .target = gl_texture_target,
         }) catch |err| {
+            // A native error may mean the session took the replacement
+            // before failing, and nothing here can tell that apart from a
+            // rejection that came first, so detach before either target is
+            // released; errdefer releases the replacement next.
+            session.detach() catch {};
             diagnostics.logError("OpenGL borrowed texture set target failed", err, null);
             return types.AppError.TextureResizeFailed;
         };
@@ -742,6 +747,10 @@ const OpenGLSurfaceBackend = struct {
     /// attached again, so it keeps its renderer either way.
     fn resize(self: *OpenGLSurfaceBackend, viewport: types.Viewport) !void {
         const replaced = self.context.refreshPlatformSurface() catch |err| {
+            // SDL owns the surfaces and may already have dropped the one the
+            // session presents through, so detach rather than leave it naming
+            // a surface that is gone.
+            self.detachSuppressed();
             diagnostics.logError("OpenGL surface refresh failed", err, null);
             return types.AppError.SurfaceAttachFailed;
         };
@@ -755,9 +764,22 @@ const OpenGLSurfaceBackend = struct {
             .context = self.context.descriptor(),
             .surface = self.context.surface(),
         }) catch |err| {
+            // A native error may mean the session took the replacement before
+            // failing, and nothing here can tell that apart from a rejection
+            // that came first. SDL owns both surfaces and already dropped the
+            // outgoing one, so detaching is the only way to stop the session
+            // naming either.
+            handle.detach() catch {};
             diagnostics.logError("OpenGL surface set target failed", err, null);
             return types.AppError.SurfaceAttachFailed;
         };
+    }
+
+    /// Detaches the session, for a failure path that has nothing better to
+    /// report than the failure it is already returning.
+    fn detachSuppressed(self: *OpenGLSurfaceBackend) void {
+        const handle = self.session.surfaceHandle() catch return;
+        handle.detach() catch {};
     }
 
     fn finishFrame(self: *OpenGLSurfaceBackend) !void {

--- a/examples/zig-map/render/opengl/mod.zig
+++ b/examples/zig-map/render/opengl/mod.zig
@@ -262,13 +262,6 @@ const PlatformOpenGLRenderTarget = union(enum) {
         }
     }
 
-    pub fn needsReattachOnResize(self: *const PlatformOpenGLRenderTarget) bool {
-        return switch (self.*) {
-            .owned_texture, .native_surface => false,
-            .borrowed_texture => true,
-        };
-    }
-
     pub fn finishFrame(self: *PlatformOpenGLRenderTarget) !void {
         switch (self.*) {
             .owned_texture => |*backend| try backend.finishFrame(),
@@ -633,8 +626,37 @@ const OpenGLBorrowedTextureBackend = struct {
         self.compositor.deinit();
     }
 
-    fn resize(_: *OpenGLBorrowedTextureBackend, _: types.Viewport) !void {
-        return types.AppError.TextureResizeFailed;
+    /// Follows a resized window.
+    ///
+    /// This example sizes the borrowed texture, not the session, so following a
+    /// resize means allocating one at the new size and handing it to the live
+    /// session. The session stays live, which is what keeps the map from going
+    /// cold on every resize.
+    fn resize(self: *OpenGLBorrowedTextureBackend, viewport: types.Viewport) !void {
+        const session = try self.session.textureHandle();
+        try self.compositor.resize(viewport);
+
+        var replacement = try BorrowedTexture.init(
+            &self.compositor.context,
+            self.compositor.procs,
+            viewport,
+        );
+        errdefer replacement.deinit(&self.compositor.context, self.compositor.procs);
+        session.setOpenGLBorrowedTextureTarget(.{
+            .extent = render_target.extent(viewport),
+            .physical_width = viewport.physical_width,
+            .physical_height = viewport.physical_height,
+            .context = self.compositor.context.descriptor(),
+            .texture = replacement.texture,
+            .target = gl_texture_target,
+        }) catch |err| {
+            diagnostics.logError("OpenGL borrowed texture set target failed", err, null);
+            return types.AppError.TextureResizeFailed;
+        };
+        // Only once the session has taken the replacement: it renders into the
+        // outgoing texture until that call returns, so delete it after.
+        self.borrowed_texture.deinit(&self.compositor.context, self.compositor.procs);
+        self.borrowed_texture = replacement;
     }
 
     fn finishFrame(self: *OpenGLBorrowedTextureBackend) !void {

--- a/examples/zig-map/render/vulkan/mod.zig
+++ b/examples/zig-map/render/vulkan/mod.zig
@@ -438,8 +438,8 @@ const VulkanBorrowedTextureBackend = struct {
             diagnostics.logError("Vulkan borrowed texture set target failed", err, null);
             return types.AppError.TextureResizeFailed;
         };
-        // Only once the session has taken the replacement: it renders into the
-        // outgoing image until that call returns, so destroy it after.
+        // Only once the session has taken the replacement, so a rejected one
+        // leaves this target on the image it already had.
         self.borrowed_image.deinit(self.compositor.context.device);
         self.borrowed_image = replacement;
     }

--- a/examples/zig-map/render/vulkan/mod.zig
+++ b/examples/zig-map/render/vulkan/mod.zig
@@ -56,13 +56,6 @@ pub const VulkanRenderTarget = union(enum) {
         }
     }
 
-    pub fn needsReattachOnResize(self: *const VulkanRenderTarget) bool {
-        return switch (self.*) {
-            .owned_texture, .native_surface => false,
-            .borrowed_texture => true,
-        };
-    }
-
     pub fn finishFrame(self: *VulkanRenderTarget) !void {
         switch (self.*) {
             .owned_texture => |*backend| try backend.finishFrame(),
@@ -418,8 +411,37 @@ const VulkanBorrowedTextureBackend = struct {
         self.compositor.deinit();
     }
 
-    fn resize(_: *VulkanBorrowedTextureBackend, _: types.Viewport) !void {
-        return types.AppError.TextureResizeFailed;
+    /// Follows a resized window.
+    ///
+    /// This example sizes the borrowed image, not the session, so following a
+    /// resize means allocating one at the new size and handing it to the live
+    /// session. The session stays live, which is what keeps the map from going
+    /// cold on every resize.
+    fn resize(self: *VulkanBorrowedTextureBackend, viewport: types.Viewport) !void {
+        const session = try self.session.textureHandle();
+        self.compositor.waitIdle();
+        try self.compositor.resize(viewport);
+
+        var replacement = try BorrowedImage.init(&self.compositor.context, viewport);
+        errdefer replacement.deinit(self.compositor.context.device);
+        session.setVulkanBorrowedTextureTarget(.{
+            .extent = render_target.extent(viewport),
+            .physical_width = viewport.physical_width,
+            .physical_height = viewport.physical_height,
+            .context = vulkanContextDescriptor(&self.compositor.context),
+            .image = maplibre.NativePointer.fromPtr(@ptrCast(replacement.image.?)),
+            .image_view = maplibre.NativePointer.fromPtr(@ptrCast(replacement.view.?)),
+            .format = c.VK_FORMAT_R8G8B8A8_UNORM,
+            .initial_layout = c.VK_IMAGE_LAYOUT_UNDEFINED,
+            .final_layout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+        }) catch |err| {
+            diagnostics.logError("Vulkan borrowed texture set target failed", err, null);
+            return types.AppError.TextureResizeFailed;
+        };
+        // Only once the session has taken the replacement: it renders into the
+        // outgoing image until that call returns, so destroy it after.
+        self.borrowed_image.deinit(self.compositor.context.device);
+        self.borrowed_image = replacement;
     }
 
     fn finishFrame(self: *VulkanBorrowedTextureBackend) !void {

--- a/examples/zig-map/render/vulkan/mod.zig
+++ b/examples/zig-map/render/vulkan/mod.zig
@@ -435,6 +435,11 @@ const VulkanBorrowedTextureBackend = struct {
             .initial_layout = c.VK_IMAGE_LAYOUT_UNDEFINED,
             .final_layout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
         }) catch |err| {
+            // A native error may mean the session took the replacement
+            // before failing, and nothing here can tell that apart from a
+            // rejection that came first, so detach before either target is
+            // released; errdefer releases the replacement next.
+            session.detach() catch {};
             diagnostics.logError("Vulkan borrowed texture set target failed", err, null);
             return types.AppError.TextureResizeFailed;
         };

--- a/examples/zig-map/render_target.zig
+++ b/examples/zig-map/render_target.zig
@@ -34,6 +34,15 @@ pub const Session = union(enum) {
         }
     }
 
+    /// The handle behind an attached texture session, which a caller-owned
+    /// target needs so it can hand a replacement texture to the live session.
+    pub fn textureHandle(self: *Session) !*maplibre.RenderSessionHandle {
+        return switch (self.*) {
+            .texture => |*texture| texture,
+            .none, .surface => types.AppError.TextureResizeFailed,
+        };
+    }
+
     pub fn renderUpdate(
         self: *Session,
         diagnostic_store: ?*const maplibre.DiagnosticStore,

--- a/examples/zig-map/render_target.zig
+++ b/examples/zig-map/render_target.zig
@@ -43,6 +43,13 @@ pub const Session = union(enum) {
         };
     }
 
+    pub fn surfaceHandle(self: *Session) !*maplibre.RenderSessionHandle {
+        return switch (self.*) {
+            .surface => |*surface| surface,
+            .none, .texture => types.AppError.SurfaceAttachFailed,
+        };
+    }
+
     pub fn renderUpdate(
         self: *Session,
         diagnostic_store: ?*const maplibre.DiagnosticStore,

--- a/include/maplibre_native_c/render_session.h
+++ b/include/maplibre_native_c/render_session.h
@@ -27,7 +27,8 @@ extern "C" {
  * borrowed texture targets return MLN_STATUS_UNSUPPORTED because the texture is
  * sized by its owner; a host that reallocates one hands the replacement over
  * with the mln_*_borrowed_texture_set_target() function for its backend, which
- * keeps the session and its renderer. See texture.h.
+ * keeps the session alive and, under the conditions stated there, its renderer.
+ * See texture.h.
  *
  * The session renderer survives a resize, carrying the tile pyramid, glyph and
  * image atlases, symbol placement, and feature state set through

--- a/include/maplibre_native_c/render_session.h
+++ b/include/maplibre_native_c/render_session.h
@@ -25,17 +25,18 @@ extern "C" {
  *
  * Surface and session-owned texture sessions resize in place. Caller-owned
  * borrowed texture targets return MLN_STATUS_UNSUPPORTED because the texture is
- * sized by its owner; follow a host whose target changed by destroying the
- * session with mln_render_session_destroy() (or releasing the map slot with
- * mln_render_session_detach()), recreating the texture, and attaching a new
- * session. A map holds at most one attached session, so detach or destroy the
- * old session before attaching the replacement.
+ * sized by its owner; a host that reallocates one hands the replacement over
+ * with the mln_*_borrowed_texture_set_target() function for its backend, which
+ * keeps the session and its renderer. See texture.h.
  *
- * Resizing discards the session renderer, which is rebuilt on the next
- * mln_render_session_render_update(). Renderer-held state, including feature
- * state set through mln_render_session_set_feature_state(), does not survive.
- * Map state such as camera, style, and sources lives on the map and survives
- * both resize and reattach.
+ * The session renderer survives a resize, carrying the tile pyramid, glyph and
+ * image atlases, symbol placement, and feature state set through
+ * mln_render_session_set_feature_state() across to the new size. A scale_factor
+ * that differs from the session's current value is the exception: a renderer
+ * compiles its shaders for a fixed pixel ratio, so that resize retires the
+ * renderer, the next mln_render_session_render_update() builds a replacement,
+ * and renderer-held state starts empty. Map state such as camera, style, and
+ * sources lives on the map and survives either way.
  *
  * Passing a scale_factor that differs from the map's mln_map_options
  * scale_factor logs a warning; see mln_map_options.

--- a/include/maplibre_native_c/surface.h
+++ b/include/maplibre_native_c/surface.h
@@ -183,6 +183,11 @@ MLN_API mln_status mln_opengl_surface_attach(
  * value rebuilds the renderer, whose shaders are compiled for a fixed pixel
  * ratio; the surface is replaced either way.
  *
+ *
+ * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
+ * failed, which cannot be unwound. Destroy the session with
+ * mln_render_session_destroy() and attach again; every other status leaves the
+ * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
@@ -221,6 +226,11 @@ MLN_API mln_status mln_metal_surface_set_target(
  * again is what changes either. Both are read from the replacement before
  * anything is torn down.
  *
+ *
+ * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
+ * failed, which cannot be unwound. Destroy the session with
+ * mln_render_session_destroy() and attach again; every other status leaves the
+ * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
@@ -259,6 +269,11 @@ MLN_API mln_status mln_vulkan_surface_set_target(
  * A lost OpenGL context is a different matter: nothing in it survives, and the
  * session is destroyed and attached again.
  *
+ *
+ * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
+ * failed, which cannot be unwound. Destroy the session with
+ * mln_render_session_destroy() and attach again; every other status leaves the
+ * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is

--- a/include/maplibre_native_c/surface.h
+++ b/include/maplibre_native_c/surface.h
@@ -183,8 +183,8 @@ MLN_API mln_status mln_opengl_surface_attach(
  * value rebuilds the renderer, whose shaders are compiled for a fixed pixel
  * ratio; the surface is replaced either way.
  *
- * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
- * touched and leaves the session rendering into the one it already had.
+ * Every failure status but MLN_STATUS_NATIVE_ERROR is reported before the
+ * target is touched and leaves the session rendering into the one it had.
  * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
  * already under way, which cannot be unwound; it can also come from a check
  * made before anything was touched, and the two do not read differently here.
@@ -228,8 +228,8 @@ MLN_API mln_status mln_metal_surface_set_target(
  * again is what changes either. Both are read from the replacement before
  * anything is torn down.
  *
- * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
- * touched and leaves the session rendering into the one it already had.
+ * Every failure status but MLN_STATUS_NATIVE_ERROR is reported before the
+ * target is touched and leaves the session rendering into the one it had.
  * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
  * already under way, which cannot be unwound; it can also come from a check
  * made before anything was touched, and the two do not read differently here.
@@ -273,8 +273,8 @@ MLN_API mln_status mln_vulkan_surface_set_target(
  * A lost OpenGL context is a different matter: nothing in it survives, and the
  * session is destroyed and attached again.
  *
- * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
- * touched and leaves the session rendering into the one it already had.
+ * Every failure status but MLN_STATUS_NATIVE_ERROR is reported before the
+ * target is touched and leaves the session rendering into the one it had.
  * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
  * already under way, which cannot be unwound; it can also come from a check
  * made before anything was touched, and the two do not read differently here.

--- a/include/maplibre_native_c/surface.h
+++ b/include/maplibre_native_c/surface.h
@@ -214,9 +214,12 @@ MLN_API mln_status mln_metal_surface_set_target(
  * mln_render_session_destroy() instead and attaches again afterward. Metal and
  * OpenGL carry no such requirement; see mln_opengl_surface_set_target().
  *
- * A replacement surface whose swapchain reports a different color format needs
- * a new render pass, which mbgl keys its pipeline cache on, so the renderer is
- * rebuilt in that case. Matching formats keep it.
+ * The replacement must report the color format and the surface-transform
+ * support this session already compiled a render pass and shaders for.
+ * MLN_STATUS_UNSUPPORTED reports one that does not, with the session still
+ * rendering into the surface it has, and destroying the session and attaching
+ * again is what changes either. Both are read from the replacement before
+ * anything is torn down.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -227,8 +230,11 @@ MLN_API mln_status mln_metal_surface_set_target(
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
  * - MLN_STATUS_UNSUPPORTED when the session does not render through a Vulkan
- *   surface, or when Vulkan surface sessions are not supported by this build.
- * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ *   surface, when the replacement's color format or surface-transform support
+ *   differs from the session's, or when Vulkan surface sessions are not
+ *   supported by this build.
+ * - MLN_STATUS_NATIVE_ERROR when a Vulkan query about the replacement fails, or
+ *   when an internal exception is converted to status.
  */
 MLN_API mln_status mln_vulkan_surface_set_target(
   mln_render_session session, const mln_vulkan_surface_descriptor* descriptor
@@ -248,7 +254,7 @@ MLN_API mln_status mln_vulkan_surface_set_target(
  * turn out to be unusable. An HDC whose pixel format does not match the
  * session's context, or an EGLSurface from another display, is reported by the
  * next mln_render_session_render_update() as MLN_STATUS_NATIVE_ERROR rather
- * than by this function.
+ * than by this function. The session stays destroyable in that state.
  *
  * A lost OpenGL context is a different matter: nothing in it survives, and the
  * session is destroyed and attached again.

--- a/include/maplibre_native_c/surface.h
+++ b/include/maplibre_native_c/surface.h
@@ -207,6 +207,13 @@ MLN_API mln_status mln_metal_surface_set_target(
  * physical device, device, and graphics queue the session attached with, and
  * the new descriptor->surface must be presentable from that queue family.
  *
+ * The outgoing VkSurfaceKHR must still be valid when this is called. The
+ * session holds a swapchain built from it, and Vulkan requires every swapchain
+ * to be destroyed before its surface, which this does. A host that has to
+ * release its surface first destroys the session with
+ * mln_render_session_destroy() instead and attaches again afterward. Metal and
+ * OpenGL carry no such requirement; see mln_opengl_surface_set_target().
+ *
  * A replacement surface whose swapchain reports a different color format needs
  * a new render pass, which mbgl keys its pipeline cache on, so the renderer is
  * rebuilt in that case. Matching formats keep it.
@@ -232,10 +239,16 @@ MLN_API mln_status mln_vulkan_surface_set_target(
  *
  * See mln_metal_surface_set_target() for what replacing a surface preserves and
  * when a host reaches for it. descriptor->context must name the context
- * provider data the session attached with, so the session's own context — and
- * every object the renderer holds in it — stays current across the change. The
+ * provider data the session attached with, so the session's own context, and
+ * every object the renderer holds in it, stays current across the change. The
  * new surface is made current on the next render, which lets a host replace a
  * surface it has already destroyed.
+ *
+ * Because nothing is made current here, a surface this call accepts can still
+ * turn out to be unusable. An HDC whose pixel format does not match the
+ * session's context, or an EGLSurface from another display, is reported by the
+ * next mln_render_session_render_update() as MLN_STATUS_NATIVE_ERROR rather
+ * than by this function.
  *
  * A lost OpenGL context is a different matter: nothing in it survives, and the
  * session is destroyed and attached again.

--- a/include/maplibre_native_c/surface.h
+++ b/include/maplibre_native_c/surface.h
@@ -183,11 +183,13 @@ MLN_API mln_status mln_opengl_surface_attach(
  * value rebuilds the renderer, whose shaders are compiled for a fixed pixel
  * ratio; the surface is replaced either way.
  *
+ * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
+ * touched and leaves the session rendering into the one it already had.
+ * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
+ * already under way, which cannot be unwound; it can also come from a check
+ * made before anything was touched, and the two do not read differently here.
+ * Treat it as a session to destroy with mln_render_session_destroy().
  *
- * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
- * failed, which cannot be unwound. Destroy the session with
- * mln_render_session_destroy() and attach again; every other status leaves the
- * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
@@ -226,11 +228,13 @@ MLN_API mln_status mln_metal_surface_set_target(
  * again is what changes either. Both are read from the replacement before
  * anything is torn down.
  *
+ * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
+ * touched and leaves the session rendering into the one it already had.
+ * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
+ * already under way, which cannot be unwound; it can also come from a check
+ * made before anything was touched, and the two do not read differently here.
+ * Treat it as a session to destroy with mln_render_session_destroy().
  *
- * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
- * failed, which cannot be unwound. Destroy the session with
- * mln_render_session_destroy() and attach again; every other status leaves the
- * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
@@ -269,11 +273,13 @@ MLN_API mln_status mln_vulkan_surface_set_target(
  * A lost OpenGL context is a different matter: nothing in it survives, and the
  * session is destroyed and attached again.
  *
+ * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
+ * touched and leaves the session rendering into the one it already had.
+ * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
+ * already under way, which cannot be unwound; it can also come from a check
+ * made before anything was touched, and the two do not read differently here.
+ * Treat it as a session to destroy with mln_render_session_destroy().
  *
- * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
- * failed, which cannot be unwound. Destroy the session with
- * mln_render_session_destroy() and attach again; every other status leaves the
- * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is

--- a/include/maplibre_native_c/surface.h
+++ b/include/maplibre_native_c/surface.h
@@ -161,6 +161,101 @@ MLN_API mln_status mln_opengl_surface_attach(
   mln_render_session* out_session
 ) MLN_NOEXCEPT;
 
+/**
+ * Presents an attached Metal surface session through a new surface.
+ *
+ * A host surface can be destroyed and recreated while the map goes on living,
+ * which is what Android rotation, a Flutter SurfaceProducer lifecycle change,
+ * and a window resize that reallocates all look like from here. This replaces
+ * the presentation surface in place, so the session keeps its renderer along
+ * with the tile pyramid, glyph and image atlases, symbol placement, and feature
+ * state set through mln_render_session_set_feature_state().
+ *
+ * descriptor->context must name the graphics context or device the session
+ * attached with; a null Metal device names none and is accepted. A target on a
+ * different context is a different session: destroy this one with
+ * mln_render_session_destroy() and attach again, accepting a cold renderer.
+ * That is also the path to take when a graphics context is genuinely lost.
+ *
+ * The new extent applies exactly as mln_render_session_resize() applies one,
+ * including how the next mln_render_session_render_update() waits for the map
+ * to catch up to it. A scale_factor that differs from the session's current
+ * value rebuilds the renderer, whose shaders are compiled for a fixed pixel
+ * ratio; the surface is replaced either way.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
+ *   null or invalid, or descriptor->context names a device other than the
+ *   session's.
+ * - MLN_STATUS_INVALID_STATE when the session is detached.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_UNSUPPORTED when the session does not render through a Metal
+ *   surface, or when Metal surface sessions are not supported by this build.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_metal_surface_set_target(
+  mln_render_session session, const mln_metal_surface_descriptor* descriptor
+) MLN_NOEXCEPT;
+
+/**
+ * Presents an attached Vulkan surface session through a new surface.
+ *
+ * See mln_metal_surface_set_target() for what replacing a surface preserves and
+ * when a host reaches for it. descriptor->context must name the same instance,
+ * physical device, device, and graphics queue the session attached with, and
+ * the new descriptor->surface must be presentable from that queue family.
+ *
+ * A replacement surface whose swapchain reports a different color format needs
+ * a new render pass, which mbgl keys its pipeline cache on, so the renderer is
+ * rebuilt in that case. Matching formats keep it.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
+ *   null or invalid, descriptor->context names handles other than the
+ *   session's, or the surface is not usable by this session.
+ * - MLN_STATUS_INVALID_STATE when the session is detached.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_UNSUPPORTED when the session does not render through a Vulkan
+ *   surface, or when Vulkan surface sessions are not supported by this build.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_vulkan_surface_set_target(
+  mln_render_session session, const mln_vulkan_surface_descriptor* descriptor
+) MLN_NOEXCEPT;
+
+/**
+ * Presents an attached OpenGL surface session through a new surface.
+ *
+ * See mln_metal_surface_set_target() for what replacing a surface preserves and
+ * when a host reaches for it. descriptor->context must name the context
+ * provider data the session attached with, so the session's own context — and
+ * every object the renderer holds in it — stays current across the change. The
+ * new surface is made current on the next render, which lets a host replace a
+ * surface it has already destroyed.
+ *
+ * A lost OpenGL context is a different matter: nothing in it survives, and the
+ * session is destroyed and attached again.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
+ *   null or invalid, or descriptor->context names context provider data other
+ *   than the session's.
+ * - MLN_STATUS_INVALID_STATE when the session is detached.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_UNSUPPORTED when the session does not render through an OpenGL
+ *   surface, or when OpenGL surface sessions are not supported by this build.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_opengl_surface_set_target(
+  mln_render_session session, const mln_opengl_surface_descriptor* descriptor
+) MLN_NOEXCEPT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/maplibre_native_c/texture.h
+++ b/include/maplibre_native_c/texture.h
@@ -477,6 +477,111 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
 ) MLN_NOEXCEPT;
 
 /**
+ * Renders an attached Metal texture session into a new caller-owned texture.
+ *
+ * A caller-owned texture is sized by its owner, so a host that follows a resize
+ * reallocates rather than resizing, and
+ * mln_render_session_resize() reports MLN_STATUS_UNSUPPORTED for these targets.
+ * This replaces the texture in place instead, so the session keeps its renderer
+ * along with the tile pyramid, glyph and image atlases, symbol placement, and
+ * feature state set through mln_render_session_set_feature_state().
+ *
+ * descriptor->texture must belong to the device the session attached with. A
+ * texture on a different device is a different session: destroy this one with
+ * mln_render_session_destroy() and attach again, accepting a cold renderer.
+ *
+ * The caller owns the replacement, keeps it valid until the next replacement,
+ * detach, or destroy, and synchronizes any use outside this session, exactly as
+ * for mln_metal_borrowed_texture_attach(). The texture handed over is released
+ * by this session on return and is the caller's to free.
+ *
+ * The new extent applies exactly as mln_render_session_resize() applies one,
+ * including how the next mln_render_session_render_update() waits for the map
+ * to catch up to it. A scale_factor that differs from the session's current
+ * value rebuilds the renderer, whose shaders are compiled for a fixed pixel
+ * ratio, as does a texture whose pixel format differs from the outgoing one,
+ * which mbgl builds render pipeline states against. The texture is replaced
+ * either way.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
+ *   null or invalid, or descriptor->texture belongs to another device.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or a texture frame is
+ *   currently acquired.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_UNSUPPORTED when the session does not render into a caller-owned
+ *   Metal texture, or when Metal borrowed texture sessions are not supported by
+ *   this build.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_metal_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_metal_borrowed_texture_descriptor* descriptor
+) MLN_NOEXCEPT;
+
+/**
+ * Renders an attached Vulkan texture session into a new caller-owned image.
+ *
+ * See mln_metal_borrowed_texture_set_target() for what replacing a target
+ * preserves and when a host reaches for it. descriptor->context must name the
+ * same instance, physical device, device, and graphics queue the session
+ * attached with.
+ *
+ * A replacement whose format or layouts differ from the outgoing image needs a
+ * new render pass, which mbgl keys its pipeline cache on, so the renderer is
+ * rebuilt in that case. Matching values keep it.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
+ *   null or invalid, or descriptor->context names handles other than the
+ *   session's.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or a texture frame is
+ *   currently acquired.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_UNSUPPORTED when the session does not render into a caller-owned
+ *   Vulkan image, or when Vulkan borrowed texture sessions are not supported by
+ *   this build.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_vulkan_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_vulkan_borrowed_texture_descriptor* descriptor
+) MLN_NOEXCEPT;
+
+/**
+ * Renders an attached OpenGL texture session into a new caller-owned texture.
+ *
+ * See mln_metal_borrowed_texture_set_target() for what replacing a target
+ * preserves and when a host reaches for it. descriptor->context must name the
+ * context provider data the session attached with, so the session's own context
+ * — and every object the renderer holds in it — stays current across the
+ * change. The replacement belongs to that context or one in the same share
+ * group, and the host context must be current on the calling thread.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
+ *   null or invalid, or descriptor->context names context provider data other
+ *   than the session's.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or a texture frame is
+ *   currently acquired.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_UNSUPPORTED when the session does not render into a caller-owned
+ *   OpenGL texture, or when OpenGL borrowed texture sessions are not supported
+ *   by this build.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_opengl_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_opengl_borrowed_texture_descriptor* descriptor
+) MLN_NOEXCEPT;
+
+/**
  * Reads the most recently rendered session-owned texture frame into
  * caller-owned storage.
  *

--- a/include/maplibre_native_c/texture.h
+++ b/include/maplibre_native_c/texture.h
@@ -509,6 +509,11 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
  * the session still rendering into the texture it has. Destroying the session
  * and attaching again is what changes the format.
  *
+ *
+ * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
+ * failed, which cannot be unwound. Destroy the session with
+ * mln_render_session_destroy() and attach again; every other status leaves the
+ * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
@@ -541,6 +546,11 @@ MLN_API mln_status mln_metal_borrowed_texture_set_target(
  * with the session still rendering into the image it has, and destroying the
  * session and attaching again is what changes them.
  *
+ *
+ * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
+ * failed, which cannot be unwound. Destroy the session with
+ * mln_render_session_destroy() and attach again; every other status leaves the
+ * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
@@ -571,6 +581,11 @@ MLN_API mln_status mln_vulkan_borrowed_texture_set_target(
  * change. The replacement belongs to that context or one in the same share
  * group, and the host context must be current on the calling thread.
  *
+ *
+ * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
+ * failed, which cannot be unwound. Destroy the session with
+ * mln_render_session_destroy() and attach again; every other status leaves the
+ * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is

--- a/include/maplibre_native_c/texture.h
+++ b/include/maplibre_native_c/texture.h
@@ -42,9 +42,11 @@ typedef struct mln_metal_borrowed_texture_descriptor {
    * Borrowed id<MTLTexture> / MTL::Texture*. Required.
    *
    * The texture's pixel dimensions must equal physical_width and
-   * physical_height, and the texture must allow render-target usage. The
-   * session reads the texture's dimensions and rejects a mismatch. The caller
-   * owns the texture and must keep it valid until detach or destroy.
+   * physical_height, the texture must allow render-target usage, and it must be
+   * single-sample: the session builds the matching depth and stencil
+   * attachments itself and builds them single-sample. The session reads all
+   * three from the texture and rejects a mismatch. The caller owns the texture
+   * and must keep it valid until detach or destroy.
    */
   void* texture;
 } mln_metal_borrowed_texture_descriptor;
@@ -503,11 +505,13 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
  * including how the next mln_render_session_render_update() waits for the map
  * to catch up to it. A scale_factor that differs from the session's current
  * value rebuilds the renderer, whose shaders are compiled for a fixed pixel
- * ratio. The replacement's pixel format and sample count are a different
- * matter: mbgl builds its render pipeline states against both, so a texture
- * differing in either from the one this session attached with is reported as
- * MLN_STATUS_UNSUPPORTED, with the session still rendering into the texture it
- * has. Destroying the session and attaching again is what changes them.
+ * ratio. The replacement's pixel format is a different matter: mbgl reads the
+ * color format off the target when it builds a render pipeline state but does
+ * not key its cache on it, so a texture in another format would be drawn with
+ * pipelines built for the old one. One that differs from the format this
+ * session attached with is reported as MLN_STATUS_UNSUPPORTED, with the session
+ * still rendering into the texture it has. Destroying the session and attaching
+ * again is what changes the format.
  *
  * Every failure status but MLN_STATUS_NATIVE_ERROR is reported before the
  * target is touched and leaves the session rendering into the one it had.
@@ -525,9 +529,9 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
  * - MLN_STATUS_UNSUPPORTED when the session does not render into a caller-owned
- *   Metal texture, when descriptor->texture has a different pixel format or
- *   sample count from the session's, or when Metal borrowed texture sessions
- *   are not supported by this build.
+ *   Metal texture, when descriptor->texture has a different pixel format from
+ *   the session's, or when Metal borrowed texture sessions are not supported by
+ *   this build.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_metal_borrowed_texture_set_target(

--- a/include/maplibre_native_c/texture.h
+++ b/include/maplibre_native_c/texture.h
@@ -497,9 +497,10 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
  * The caller owns the replacement, keeps it valid until the next replacement,
  * detach, or destroy, and synchronizes any use outside this session, exactly as
  * for mln_metal_borrowed_texture_attach(). The session never retained the
- * outgoing texture and never releases it. Keep that texture valid for the
- * duration of this call, after which the session holds no reference to it and
- * the caller is free to release it.
+ * outgoing texture, never releases it, and never reads it here: the pixel
+ * format it checks was recorded when it took that texture. A caller that
+ * already released the outgoing texture, which a host reallocating on resize
+ * often has, hands over the replacement all the same.
  *
  * The new extent applies exactly as mln_render_session_resize() applies one,
  * including how the next mln_render_session_render_update() waits for the map

--- a/include/maplibre_native_c/texture.h
+++ b/include/maplibre_native_c/texture.h
@@ -492,8 +492,10 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
  *
  * The caller owns the replacement, keeps it valid until the next replacement,
  * detach, or destroy, and synchronizes any use outside this session, exactly as
- * for mln_metal_borrowed_texture_attach(). The texture handed over is released
- * by this session on return and is the caller's to free.
+ * for mln_metal_borrowed_texture_attach(). The session never retained the
+ * outgoing texture and never releases it. Keep that texture valid for the
+ * duration of this call, after which the session holds no reference to it and
+ * the caller is free to release it.
  *
  * The new extent applies exactly as mln_render_session_resize() applies one,
  * including how the next mln_render_session_render_update() waits for the map
@@ -558,7 +560,7 @@ MLN_API mln_status mln_vulkan_borrowed_texture_set_target(
  * See mln_metal_borrowed_texture_set_target() for what replacing a target
  * preserves and when a host reaches for it. descriptor->context must name the
  * context provider data the session attached with, so the session's own context
- * — and every object the renderer holds in it — stays current across the
+ * and every object the renderer holds in it, stays current across the
  * change. The replacement belongs to that context or one in the same share
  * group, and the host context must be current on the calling thread.
  *

--- a/include/maplibre_native_c/texture.h
+++ b/include/maplibre_native_c/texture.h
@@ -503,17 +503,19 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
  * including how the next mln_render_session_render_update() waits for the map
  * to catch up to it. A scale_factor that differs from the session's current
  * value rebuilds the renderer, whose shaders are compiled for a fixed pixel
- * ratio. The replacement's pixel format is a different matter: mbgl builds its
- * render pipeline states against it, so a texture whose format differs from the
- * one this session attached with is reported as MLN_STATUS_UNSUPPORTED, with
- * the session still rendering into the texture it has. Destroying the session
- * and attaching again is what changes the format.
+ * ratio. The replacement's pixel format and sample count are a different
+ * matter: mbgl builds its render pipeline states against both, so a texture
+ * differing in either from the one this session attached with is reported as
+ * MLN_STATUS_UNSUPPORTED, with the session still rendering into the texture it
+ * has. Destroying the session and attaching again is what changes them.
  *
+ * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
+ * touched and leaves the session rendering into the one it already had.
+ * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
+ * already under way, which cannot be unwound; it can also come from a check
+ * made before anything was touched, and the two do not read differently here.
+ * Treat it as a session to destroy with mln_render_session_destroy().
  *
- * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
- * failed, which cannot be unwound. Destroy the session with
- * mln_render_session_destroy() and attach again; every other status leaves the
- * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
@@ -523,9 +525,9 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
  * - MLN_STATUS_UNSUPPORTED when the session does not render into a caller-owned
- *   Metal texture, when descriptor->texture has a different pixel format from
- *   the session's, or when Metal borrowed texture sessions are not supported by
- *   this build.
+ *   Metal texture, when descriptor->texture has a different pixel format or
+ *   sample count from the session's, or when Metal borrowed texture sessions
+ *   are not supported by this build.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_metal_borrowed_texture_set_target(
@@ -546,11 +548,13 @@ MLN_API mln_status mln_metal_borrowed_texture_set_target(
  * with the session still rendering into the image it has, and destroying the
  * session and attaching again is what changes them.
  *
+ * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
+ * touched and leaves the session rendering into the one it already had.
+ * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
+ * already under way, which cannot be unwound; it can also come from a check
+ * made before anything was touched, and the two do not read differently here.
+ * Treat it as a session to destroy with mln_render_session_destroy().
  *
- * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
- * failed, which cannot be unwound. Destroy the session with
- * mln_render_session_destroy() and attach again; every other status leaves the
- * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is
@@ -581,11 +585,13 @@ MLN_API mln_status mln_vulkan_borrowed_texture_set_target(
  * change. The replacement belongs to that context or one in the same share
  * group, and the host context must be current on the calling thread.
  *
+ * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
+ * touched and leaves the session rendering into the one it already had.
+ * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
+ * already under way, which cannot be unwound; it can also come from a check
+ * made before anything was touched, and the two do not read differently here.
+ * Treat it as a session to destroy with mln_render_session_destroy().
  *
- * MLN_STATUS_NATIVE_ERROR means a replacement was already under way when it
- * failed, which cannot be unwound. Destroy the session with
- * mln_render_session_destroy() and attach again; every other status leaves the
- * session rendering into the target it already had.
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, descriptor is

--- a/include/maplibre_native_c/texture.h
+++ b/include/maplibre_native_c/texture.h
@@ -324,9 +324,10 @@ MLN_API mln_status mln_metal_owned_texture_attach(
  * *out_session receives a handle the caller destroys with
  * mln_render_session_destroy().
  *
- * mln_render_session_resize() returns MLN_STATUS_UNSUPPORTED for this target.
- * Follow a resized host by destroying the session, recreating the texture at
- * the new extent, and attaching again; see mln_render_session_resize().
+ * mln_render_session_resize() returns MLN_STATUS_UNSUPPORTED for this target,
+ * which the host owns and sizes. Follow a resized host by allocating a texture
+ * at the new size and handing it over with
+ * mln_metal_borrowed_texture_set_target(), which keeps the session.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -392,10 +393,10 @@ MLN_API mln_status mln_vulkan_owned_texture_attach(
  * the submitted work to finish, and leaves the image in
  * descriptor->final_layout before mln_render_session_render_update() returns.
  *
- * mln_render_session_resize() returns MLN_STATUS_UNSUPPORTED for this target.
- * Follow a resized host by destroying the session, recreating the image and
- * view at the new extent, and attaching again; see
- * mln_render_session_resize().
+ * mln_render_session_resize() returns MLN_STATUS_UNSUPPORTED for this target,
+ * which the host owns and sizes. Follow a resized host by allocating an image
+ * and view at the new size and handing them over with
+ * mln_vulkan_borrowed_texture_set_target(), which keeps the session.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -458,9 +459,10 @@ MLN_API mln_status mln_opengl_owned_texture_attach(
  * *out_session receives a handle the caller destroys with
  * mln_render_session_destroy().
  *
- * mln_render_session_resize() returns MLN_STATUS_UNSUPPORTED for this target.
- * Follow a resized host by destroying the session, recreating the texture at
- * the new extent, and attaching again; see mln_render_session_resize().
+ * mln_render_session_resize() returns MLN_STATUS_UNSUPPORTED for this target,
+ * which the host owns and sizes. Follow a resized host by allocating a texture
+ * at the new size and handing it over with
+ * mln_opengl_borrowed_texture_set_target(), which keeps the session.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -501,9 +503,11 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
  * including how the next mln_render_session_render_update() waits for the map
  * to catch up to it. A scale_factor that differs from the session's current
  * value rebuilds the renderer, whose shaders are compiled for a fixed pixel
- * ratio, as does a texture whose pixel format differs from the outgoing one,
- * which mbgl builds render pipeline states against. The texture is replaced
- * either way.
+ * ratio. The replacement's pixel format is a different matter: mbgl builds its
+ * render pipeline states against it, so a texture whose format differs from the
+ * one this session attached with is reported as MLN_STATUS_UNSUPPORTED, with
+ * the session still rendering into the texture it has. Destroying the session
+ * and attaching again is what changes the format.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -514,7 +518,8 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
  * - MLN_STATUS_UNSUPPORTED when the session does not render into a caller-owned
- *   Metal texture, or when Metal borrowed texture sessions are not supported by
+ *   Metal texture, when descriptor->texture has a different pixel format from
+ *   the session's, or when Metal borrowed texture sessions are not supported by
  *   this build.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
@@ -531,9 +536,10 @@ MLN_API mln_status mln_metal_borrowed_texture_set_target(
  * same instance, physical device, device, and graphics queue the session
  * attached with.
  *
- * A replacement whose format or layouts differ from the outgoing image needs a
- * new render pass, which mbgl keys its pipeline cache on, so the renderer is
- * rebuilt in that case. Matching values keep it.
+ * The replacement must carry the format and both layouts this session built
+ * its render pass around. MLN_STATUS_UNSUPPORTED reports one that does not,
+ * with the session still rendering into the image it has, and destroying the
+ * session and attaching again is what changes them.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -545,8 +551,9 @@ MLN_API mln_status mln_metal_borrowed_texture_set_target(
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
  * - MLN_STATUS_UNSUPPORTED when the session does not render into a caller-owned
- *   Vulkan image, or when Vulkan borrowed texture sessions are not supported by
- *   this build.
+ *   Vulkan image, when descriptor->format, descriptor->initial_layout, or
+ *   descriptor->final_layout differs from the session's, or when Vulkan
+ *   borrowed texture sessions are not supported by this build.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_vulkan_borrowed_texture_set_target(

--- a/include/maplibre_native_c/texture.h
+++ b/include/maplibre_native_c/texture.h
@@ -509,8 +509,8 @@ MLN_API mln_status mln_opengl_borrowed_texture_attach(
  * MLN_STATUS_UNSUPPORTED, with the session still rendering into the texture it
  * has. Destroying the session and attaching again is what changes them.
  *
- * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
- * touched and leaves the session rendering into the one it already had.
+ * Every failure status but MLN_STATUS_NATIVE_ERROR is reported before the
+ * target is touched and leaves the session rendering into the one it had.
  * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
  * already under way, which cannot be unwound; it can also come from a check
  * made before anything was touched, and the two do not read differently here.
@@ -548,8 +548,8 @@ MLN_API mln_status mln_metal_borrowed_texture_set_target(
  * with the session still rendering into the image it has, and destroying the
  * session and attaching again is what changes them.
  *
- * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
- * touched and leaves the session rendering into the one it already had.
+ * Every failure status but MLN_STATUS_NATIVE_ERROR is reported before the
+ * target is touched and leaves the session rendering into the one it had.
  * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
  * already under way, which cannot be unwound; it can also come from a check
  * made before anything was touched, and the two do not read differently here.
@@ -585,8 +585,8 @@ MLN_API mln_status mln_vulkan_borrowed_texture_set_target(
  * change. The replacement belongs to that context or one in the same share
  * group, and the host context must be current on the calling thread.
  *
- * Every status but MLN_STATUS_NATIVE_ERROR is reported before the target is
- * touched and leaves the session rendering into the one it already had.
+ * Every failure status but MLN_STATUS_NATIVE_ERROR is reported before the
+ * target is touched and leaves the session rendering into the one it had.
  * MLN_STATUS_NATIVE_ERROR is the only one that can mean a replacement was
  * already under way, which cannot be unwound; it can also come from a check
  * made before anything was touched, and the two do not read differently here.

--- a/src/c_api/surface.cpp
+++ b/src/c_api/surface.cpp
@@ -45,3 +45,27 @@ auto mln_opengl_surface_attach(
     return mln::core::opengl_surface_attach(map, descriptor, out_session);
   });
 }
+
+auto mln_metal_surface_set_target(
+  mln_render_session session, const mln_metal_surface_descriptor* descriptor
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::metal_surface_set_target(session, descriptor);
+  });
+}
+
+auto mln_vulkan_surface_set_target(
+  mln_render_session session, const mln_vulkan_surface_descriptor* descriptor
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::vulkan_surface_set_target(session, descriptor);
+  });
+}
+
+auto mln_opengl_surface_set_target(
+  mln_render_session session, const mln_opengl_surface_descriptor* descriptor
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::opengl_surface_set_target(session, descriptor);
+  });
+}

--- a/src/c_api/tests/abi_tests.h
+++ b/src/c_api/tests/abi_tests.h
@@ -24,6 +24,7 @@ void run_handles_abi_tests(void);
 void run_map_options_abi_tests(void);
 void run_render_backend_abi_tests(void);
 void run_owned_texture_abi_tests(void);
+void run_render_target_lifecycle_abi_tests(void);
 void run_render_thread_abi_tests(void);
 void run_query_abi_tests(void);
 void run_mlt_decode_abi_tests(void);

--- a/src/c_api/tests/main.c
+++ b/src/c_api/tests/main.c
@@ -28,6 +28,7 @@ int main(void) {
   run_map_options_abi_tests();
   run_render_backend_abi_tests();
   run_owned_texture_abi_tests();
+  run_render_target_lifecycle_abi_tests();
   run_render_thread_abi_tests();
   run_query_abi_tests();
   run_mlt_decode_abi_tests();

--- a/src/c_api/tests/render_target_lifecycle_abi.c
+++ b/src/c_api/tests/render_target_lifecycle_abi.c
@@ -1,0 +1,188 @@
+// Raw C ABI coverage: what a render session keeps when its target changes.
+//
+// The session renderer is not reachable through the C API, so these tests probe
+// it through mln_render_session_clear_data(), which reports
+// MLN_STATUS_INVALID_STATE while no renderer exists and MLN_STATUS_OK once one
+// does. That makes "the renderer survived" and "the renderer was rebuilt"
+// directly observable, which is the whole contract under test: a surviving
+// renderer is what carries the tile pyramid, atlases, symbol placement, and
+// feature state across a resize instead of rebuilding them cold.
+
+#include <stdbool.h>
+
+#include "abi_tests.h"
+#include "test_support.h"
+#include "unity.h"
+
+// Renders until the session reports a frame, which is when it builds its
+// renderer. Returns whether one was rendered before the attempts ran out.
+static bool render_until_frame(
+  mln_runtime runtime, mln_render_session session
+) {
+  for (unsigned int attempt = 0; attempt < 200; attempt += 1) {
+    bool rendered = false;
+    if (mln_render_session_render_update(session, &rendered) != MLN_STATUS_OK) {
+      return false;
+    }
+    if (rendered) {
+      return true;
+    }
+    if (mln_runtime_pump(runtime, 0) != MLN_STATUS_OK) {
+      return false;
+    }
+    mln_test_sleep_millisecond();
+  }
+  return false;
+}
+
+// Whether the session currently holds a renderer.
+static bool has_renderer(mln_render_session session) {
+  return mln_render_session_clear_data(session) == MLN_STATUS_OK;
+}
+
+// A resize changes the size of the target and nothing the renderer caches
+// against, so the renderer carries over.
+static void resize_keeps_the_session_renderer(void) {
+  mln_runtime runtime = mln_test_create_runtime();
+  mln_map map = mln_test_create_map(runtime);
+  mln_test_render_fixture fixture = {0};
+  TEST_ASSERT_TRUE(mln_test_render_fixture_create(map, &fixture));
+
+  TEST_ASSERT_TRUE(render_until_frame(runtime, fixture.session));
+  TEST_ASSERT_TRUE_MESSAGE(
+    has_renderer(fixture.session), "a rendered frame should leave a renderer"
+  );
+
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_render_session_resize(fixture.session, 96, 48, 1.0)
+  );
+  TEST_ASSERT_TRUE_MESSAGE(
+    has_renderer(fixture.session),
+    "resizing at the same scale factor should keep the renderer"
+  );
+
+  mln_test_render_fixture_destroy(&fixture);
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
+// The pixel ratio is fixed when a renderer is built and baked into its shaders,
+// so a scale factor change is the one resize that starts over. The replacement
+// is built lazily on the next render.
+static void scale_factor_change_rebuilds_the_session_renderer(void) {
+  mln_runtime runtime = mln_test_create_runtime();
+  mln_map map = mln_test_create_map(runtime);
+  mln_test_render_fixture fixture = {0};
+  TEST_ASSERT_TRUE(mln_test_render_fixture_create(map, &fixture));
+
+  TEST_ASSERT_TRUE(render_until_frame(runtime, fixture.session));
+  TEST_ASSERT_TRUE(has_renderer(fixture.session));
+
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_render_session_resize(fixture.session, 64, 64, 2.0)
+  );
+  TEST_ASSERT_FALSE_MESSAGE(
+    has_renderer(fixture.session),
+    "changing the scale factor should retire the renderer"
+  );
+
+  TEST_ASSERT_TRUE(render_until_frame(runtime, fixture.session));
+  TEST_ASSERT_TRUE_MESSAGE(
+    has_renderer(fixture.session),
+    "the next render should build a renderer for the new scale factor"
+  );
+
+  mln_test_render_fixture_destroy(&fixture);
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
+// A session-owned texture is allocated and sized by its session, so following a
+// host resize means resizing rather than handing over a new target. The
+// caller-owned entry points say so instead of quietly doing nothing.
+static void set_target_rejects_a_session_owned_texture(void) {
+  mln_runtime runtime = mln_test_create_runtime();
+  mln_map map = mln_test_create_map(runtime);
+  mln_test_render_fixture fixture = {0};
+  TEST_ASSERT_TRUE(mln_test_render_fixture_create(map, &fixture));
+
+  mln_metal_borrowed_texture_descriptor metal =
+    mln_metal_borrowed_texture_descriptor_default();
+  metal.extent.width = 64;
+  metal.extent.height = 64;
+  metal.physical_width = 64;
+  metal.physical_height = 64;
+  TEST_ASSERT_NOT_EQUAL_INT(
+    MLN_STATUS_OK,
+    mln_metal_borrowed_texture_set_target(fixture.session, &metal)
+  );
+
+  mln_vulkan_borrowed_texture_descriptor vulkan =
+    mln_vulkan_borrowed_texture_descriptor_default();
+  vulkan.extent.width = 64;
+  vulkan.extent.height = 64;
+  vulkan.physical_width = 64;
+  vulkan.physical_height = 64;
+  TEST_ASSERT_NOT_EQUAL_INT(
+    MLN_STATUS_OK,
+    mln_vulkan_borrowed_texture_set_target(fixture.session, &vulkan)
+  );
+
+  mln_opengl_borrowed_texture_descriptor opengl =
+    mln_opengl_borrowed_texture_descriptor_default();
+  opengl.extent.width = 64;
+  opengl.extent.height = 64;
+  opengl.physical_width = 64;
+  opengl.physical_height = 64;
+  TEST_ASSERT_NOT_EQUAL_INT(
+    MLN_STATUS_OK,
+    mln_opengl_borrowed_texture_set_target(fixture.session, &opengl)
+  );
+
+  mln_test_render_fixture_destroy(&fixture);
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
+// Null handles and descriptors are rejected before any of this reaches a
+// backend, so a host that loses track of a session gets a status rather than a
+// crash.
+static void set_target_rejects_null_raw_arguments(void) {
+  mln_metal_surface_descriptor metal_surface =
+    mln_metal_surface_descriptor_default();
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_metal_surface_set_target(MLN_HANDLE_NULL, NULL)
+  );
+  TEST_ASSERT_NOT_EQUAL_INT(
+    MLN_STATUS_OK, mln_metal_surface_set_target(MLN_HANDLE_NULL, &metal_surface)
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_vulkan_surface_set_target(MLN_HANDLE_NULL, NULL)
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_opengl_surface_set_target(MLN_HANDLE_NULL, NULL)
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_metal_borrowed_texture_set_target(MLN_HANDLE_NULL, NULL)
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_vulkan_borrowed_texture_set_target(MLN_HANDLE_NULL, NULL)
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_opengl_borrowed_texture_set_target(MLN_HANDLE_NULL, NULL)
+  );
+}
+
+void run_render_target_lifecycle_abi_tests(void) {
+  UnitySetTestFile(__FILE__);
+  RUN_TEST(resize_keeps_the_session_renderer);
+  RUN_TEST(scale_factor_change_rebuilds_the_session_renderer);
+  RUN_TEST(set_target_rejects_a_session_owned_texture);
+  RUN_TEST(set_target_rejects_null_raw_arguments);
+}

--- a/src/c_api/tests/render_target_lifecycle_abi.c
+++ b/src/c_api/tests/render_target_lifecycle_abi.c
@@ -1,12 +1,14 @@
 // Raw C ABI coverage: what a render session keeps when its target changes.
 //
 // The session renderer is not reachable through the C API, so these tests probe
-// it through mln_render_session_clear_data(), which reports
+// for its existence through mln_render_session_dump_debug_logs(), which reports
 // MLN_STATUS_INVALID_STATE while no renderer exists and MLN_STATUS_OK once one
-// does. That makes "the renderer survived" and "the renderer was rebuilt"
-// directly observable, which is the whole contract under test: a surviving
-// renderer is what carries the tile pyramid, atlases, symbol placement, and
-// feature state across a resize instead of rebuilding them cold.
+// does. That is a probe for the renderer's identity only, not for its contents:
+// it says whether a resize kept the renderer, which is the precondition for the
+// tile pyramid, atlases, symbol placement, and feature state surviving with it.
+// It is chosen over the other renderer-requiring entry points because it leaves
+// the renderer alone, where clear_data() would empty the very state a later
+// assertion might want to look at.
 
 #include <stdbool.h>
 
@@ -35,9 +37,16 @@ static bool render_until_frame(
   return false;
 }
 
-// Whether the session currently holds a renderer.
+// Whether the session currently holds a renderer. Distinguishes the missing
+// renderer from a backend failure, which reports NATIVE_ERROR, so a broken
+// backend cannot read as a retired renderer.
 static bool has_renderer(mln_render_session session) {
-  return mln_render_session_clear_data(session) == MLN_STATUS_OK;
+  const mln_status status = mln_render_session_dump_debug_logs(session);
+  if (status == MLN_STATUS_INVALID_STATE) {
+    return false;
+  }
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, status);
+  return true;
 }
 
 // A resize changes the size of the target and nothing the renderer caches
@@ -98,45 +107,60 @@ static void scale_factor_change_rebuilds_the_session_renderer(void) {
 }
 
 // A session-owned texture is allocated and sized by its session, so following a
-// host resize means resizing rather than handing over a new target. The
-// caller-owned entry points say so instead of quietly doing nothing.
+// host resize means resizing rather than handing over a new target.
+//
+// The session is checked before the descriptor, which is what makes this
+// reachable: the descriptors here are defaults that no backend would accept, so
+// a validation order that looked at them first would report a malformed
+// descriptor and never reach the question being asked.
 static void set_target_rejects_a_session_owned_texture(void) {
   mln_runtime runtime = mln_test_create_runtime();
   mln_map map = mln_test_create_map(runtime);
   mln_test_render_fixture fixture = {0};
   TEST_ASSERT_TRUE(mln_test_render_fixture_create(map, &fixture));
 
-  mln_metal_borrowed_texture_descriptor metal =
+  const mln_metal_borrowed_texture_descriptor metal =
     mln_metal_borrowed_texture_descriptor_default();
-  metal.extent.width = 64;
-  metal.extent.height = 64;
-  metal.physical_width = 64;
-  metal.physical_height = 64;
-  TEST_ASSERT_NOT_EQUAL_INT(
-    MLN_STATUS_OK,
+  const mln_vulkan_borrowed_texture_descriptor vulkan =
+    mln_vulkan_borrowed_texture_descriptor_default();
+  const mln_opengl_borrowed_texture_descriptor opengl =
+    mln_opengl_borrowed_texture_descriptor_default();
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_UNSUPPORTED,
     mln_metal_borrowed_texture_set_target(fixture.session, &metal)
   );
-
-  mln_vulkan_borrowed_texture_descriptor vulkan =
-    mln_vulkan_borrowed_texture_descriptor_default();
-  vulkan.extent.width = 64;
-  vulkan.extent.height = 64;
-  vulkan.physical_width = 64;
-  vulkan.physical_height = 64;
-  TEST_ASSERT_NOT_EQUAL_INT(
-    MLN_STATUS_OK,
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_UNSUPPORTED,
     mln_vulkan_borrowed_texture_set_target(fixture.session, &vulkan)
   );
-
-  mln_opengl_borrowed_texture_descriptor opengl =
-    mln_opengl_borrowed_texture_descriptor_default();
-  opengl.extent.width = 64;
-  opengl.extent.height = 64;
-  opengl.physical_width = 64;
-  opengl.physical_height = 64;
-  TEST_ASSERT_NOT_EQUAL_INT(
-    MLN_STATUS_OK,
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_UNSUPPORTED,
     mln_opengl_borrowed_texture_set_target(fixture.session, &opengl)
+  );
+
+  // A surface descriptor names a target this session does not have at all.
+  const mln_metal_surface_descriptor metal_surface =
+    mln_metal_surface_descriptor_default();
+  const mln_vulkan_surface_descriptor vulkan_surface =
+    mln_vulkan_surface_descriptor_default();
+  const mln_opengl_surface_descriptor opengl_surface =
+    mln_opengl_surface_descriptor_default();
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_UNSUPPORTED,
+    mln_metal_surface_set_target(fixture.session, &metal_surface)
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_UNSUPPORTED,
+    mln_vulkan_surface_set_target(fixture.session, &vulkan_surface)
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_UNSUPPORTED,
+    mln_opengl_surface_set_target(fixture.session, &opengl_surface)
+  );
+
+  // Every rejection left the session usable.
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_render_session_resize(fixture.session, 32, 32, 1.0)
   );
 
   mln_test_render_fixture_destroy(&fixture);
@@ -144,39 +168,36 @@ static void set_target_rejects_a_session_owned_texture(void) {
   mln_test_destroy_runtime(runtime);
 }
 
-// Null handles and descriptors are rejected before any of this reaches a
-// backend, so a host that loses track of a session gets a status rather than a
-// crash.
-static void set_target_rejects_null_raw_arguments(void) {
-  mln_metal_surface_descriptor metal_surface =
+// A retired session handle is reported as such whatever the descriptor says,
+// which is what lets a host tell a lost session apart from a build that lacks
+// the backend it asked for.
+static void set_target_rejects_a_stale_session(void) {
+  mln_runtime runtime = mln_test_create_runtime();
+  mln_map map = mln_test_create_map(runtime);
+  mln_test_render_fixture fixture = {0};
+  TEST_ASSERT_TRUE(mln_test_render_fixture_create(map, &fixture));
+  const mln_render_session stale_session = fixture.session;
+  mln_test_render_fixture_destroy(&fixture);
+
+  const mln_metal_surface_descriptor metal_surface =
     mln_metal_surface_descriptor_default();
+  const mln_opengl_borrowed_texture_descriptor opengl_texture =
+    mln_opengl_borrowed_texture_descriptor_default();
   TEST_ASSERT_EQUAL_INT(
     MLN_STATUS_INVALID_ARGUMENT,
-    mln_metal_surface_set_target(MLN_HANDLE_NULL, NULL)
-  );
-  TEST_ASSERT_NOT_EQUAL_INT(
-    MLN_STATUS_OK, mln_metal_surface_set_target(MLN_HANDLE_NULL, &metal_surface)
-  );
-  TEST_ASSERT_EQUAL_INT(
-    MLN_STATUS_INVALID_ARGUMENT,
-    mln_vulkan_surface_set_target(MLN_HANDLE_NULL, NULL)
+    mln_metal_surface_set_target(stale_session, &metal_surface)
   );
   TEST_ASSERT_EQUAL_INT(
     MLN_STATUS_INVALID_ARGUMENT,
-    mln_opengl_surface_set_target(MLN_HANDLE_NULL, NULL)
+    mln_opengl_borrowed_texture_set_target(stale_session, &opengl_texture)
   );
   TEST_ASSERT_EQUAL_INT(
     MLN_STATUS_INVALID_ARGUMENT,
-    mln_metal_borrowed_texture_set_target(MLN_HANDLE_NULL, NULL)
+    mln_metal_surface_set_target(MLN_HANDLE_NULL, &metal_surface)
   );
-  TEST_ASSERT_EQUAL_INT(
-    MLN_STATUS_INVALID_ARGUMENT,
-    mln_vulkan_borrowed_texture_set_target(MLN_HANDLE_NULL, NULL)
-  );
-  TEST_ASSERT_EQUAL_INT(
-    MLN_STATUS_INVALID_ARGUMENT,
-    mln_opengl_borrowed_texture_set_target(MLN_HANDLE_NULL, NULL)
-  );
+
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
 }
 
 void run_render_target_lifecycle_abi_tests(void) {
@@ -184,5 +205,5 @@ void run_render_target_lifecycle_abi_tests(void) {
   RUN_TEST(resize_keeps_the_session_renderer);
   RUN_TEST(scale_factor_change_rebuilds_the_session_renderer);
   RUN_TEST(set_target_rejects_a_session_owned_texture);
-  RUN_TEST(set_target_rejects_null_raw_arguments);
+  RUN_TEST(set_target_rejects_a_stale_session);
 }

--- a/src/c_api/tests/render_thread_abi.c
+++ b/src/c_api/tests/render_thread_abi.c
@@ -6,6 +6,7 @@
 // it, which is not a shape a single-threaded binding test can build.
 
 #include <stdatomic.h>
+#include <stddef.h>
 
 #include "abi_tests.h"
 #include "test_support.h"
@@ -122,6 +123,8 @@ typedef struct foreign_call_probe {
   mln_status reduce_memory_status;
   mln_status clear_data_status;
   mln_status readback_status;
+  mln_status surface_set_target_status[3];
+  mln_status texture_set_target_status[3];
 } foreign_call_probe;
 
 static void call_session_from_a_foreign_thread(void* argument) {
@@ -138,6 +141,34 @@ static void call_session_from_a_foreign_thread(void* argument) {
   mln_texture_image_info info = {.size = sizeof(mln_texture_image_info)};
   probe->readback_status =
     mln_texture_read_premultiplied_rgba8(probe->session, NULL, 0, &info);
+
+  // Thread affinity is checked before the target kind, so these report the
+  // foreign thread rather than that this session owns its texture.
+  const mln_metal_surface_descriptor metal_surface =
+    mln_metal_surface_descriptor_default();
+  const mln_vulkan_surface_descriptor vulkan_surface =
+    mln_vulkan_surface_descriptor_default();
+  const mln_opengl_surface_descriptor opengl_surface =
+    mln_opengl_surface_descriptor_default();
+  probe->surface_set_target_status[0] =
+    mln_metal_surface_set_target(probe->session, &metal_surface);
+  probe->surface_set_target_status[1] =
+    mln_vulkan_surface_set_target(probe->session, &vulkan_surface);
+  probe->surface_set_target_status[2] =
+    mln_opengl_surface_set_target(probe->session, &opengl_surface);
+
+  const mln_metal_borrowed_texture_descriptor metal_texture =
+    mln_metal_borrowed_texture_descriptor_default();
+  const mln_vulkan_borrowed_texture_descriptor vulkan_texture =
+    mln_vulkan_borrowed_texture_descriptor_default();
+  const mln_opengl_borrowed_texture_descriptor opengl_texture =
+    mln_opengl_borrowed_texture_descriptor_default();
+  probe->texture_set_target_status[0] =
+    mln_metal_borrowed_texture_set_target(probe->session, &metal_texture);
+  probe->texture_set_target_status[1] =
+    mln_vulkan_borrowed_texture_set_target(probe->session, &vulkan_texture);
+  probe->texture_set_target_status[2] =
+    mln_opengl_borrowed_texture_set_target(probe->session, &opengl_texture);
   atomic_store(&probe->finished, true);
 }
 
@@ -165,6 +196,14 @@ static void session_entry_points_reject_a_foreign_thread(void) {
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_WRONG_THREAD, probe.reduce_memory_status);
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_WRONG_THREAD, probe.clear_data_status);
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_WRONG_THREAD, probe.readback_status);
+  for (size_t index = 0; index < 3; index += 1) {
+    TEST_ASSERT_EQUAL_INT(
+      MLN_STATUS_WRONG_THREAD, probe.surface_set_target_status[index]
+    );
+    TEST_ASSERT_EQUAL_INT(
+      MLN_STATUS_WRONG_THREAD, probe.texture_set_target_status[index]
+    );
+  }
 
   // The session survived every rejected call and is still usable here.
   mln_test_render_fixture_destroy(&fixture);

--- a/src/c_api/tests/runtime_wake_abi.c
+++ b/src/c_api/tests/runtime_wake_abi.c
@@ -238,6 +238,90 @@ static void a_style_response_wakes_a_parked_owner_thread(void) {
   mln_test_destroy_runtime(runtime);
 }
 
+typedef struct session_resize_probe {
+  mln_map map;
+  atomic_bool attached;
+  atomic_bool start_resize;
+  atomic_int resize_status;
+  atomic_bool resize_done;
+  bool attach_succeeded;
+} session_resize_probe;
+
+// Attaches on its own thread, so the resize below reaches the map the way a
+// host's render loop reaches it: queued from a thread that owns no runtime.
+static void resize_session_entry(void* argument) {
+  session_resize_probe* probe = argument;
+  mln_test_render_fixture fixture = {0};
+  probe->attach_succeeded =
+    mln_test_render_fixture_create(probe->map, &fixture);
+  atomic_store(&probe->attached, true);
+  if (!probe->attach_succeeded) {
+    atomic_store(&probe->resize_done, true);
+    return;
+  }
+
+  while (!atomic_load(&probe->start_resize)) {
+    mln_test_sleep_millisecond();
+  }
+  // Long enough for the owner thread to reach its park, so the wake under test
+  // is the queued resize rather than a flag already set when the pump began.
+  mln_test_sleep_milliseconds(signal_delay_milliseconds);
+  atomic_store(
+    &probe->resize_status,
+    mln_render_session_resize(fixture.session, 96, 48, 1.0)
+  );
+  atomic_store(&probe->resize_done, true);
+
+  mln_test_render_fixture_destroy(&fixture);
+}
+
+// A render thread's resize queues the new size for the map's owner thread. The
+// owner thread takes it from a park without a host wake source, which is what
+// lets a host resize without also arranging to release its own pump.
+static void a_session_resize_releases_a_parked_owner_thread(void) {
+  mln_runtime runtime = mln_test_create_runtime();
+  mln_map map = mln_test_create_map(runtime);
+
+  session_resize_probe probe = {.map = map};
+  atomic_init(&probe.attached, false);
+  atomic_init(&probe.start_resize, false);
+  atomic_init(&probe.resize_status, MLN_STATUS_OK);
+  atomic_init(&probe.resize_done, false);
+
+  mln_test_thread* thread = mln_test_thread_start(resize_session_entry, &probe);
+  TEST_ASSERT_TRUE(mln_test_pump_until(runtime, &probe.attached));
+  TEST_ASSERT_TRUE(probe.attach_succeeded);
+  quiesce(runtime);
+  atomic_store(&probe.start_resize, true);
+
+  const uint64_t started = mln_test_monotonic_milliseconds();
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_runtime_pump(runtime, park_timeout_milliseconds)
+  );
+  const uint64_t elapsed = mln_test_monotonic_milliseconds() - started;
+  TEST_ASSERT_TRUE_MESSAGE(
+    elapsed < prompt_return_milliseconds,
+    "The parked owner thread timed out instead of taking the queued resize."
+  );
+
+  TEST_ASSERT_TRUE(mln_test_pump_until(runtime, &probe.resize_done));
+  mln_test_thread_join(thread);
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, atomic_load(&probe.resize_status));
+
+  // The pump that took the wake is the one that applied the size.
+  uint32_t width = 0;
+  uint32_t height = 0;
+  double scale_factor = 0.0;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_map_get_size(map, &width, &height, &scale_factor)
+  );
+  TEST_ASSERT_EQUAL_UINT32(96, width);
+  TEST_ASSERT_EQUAL_UINT32(48, height);
+
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
 // Queued unread events return a blocking pump without parking.
 static void queued_events_return_from_the_pump_immediately(void) {
   mln_runtime runtime = mln_test_create_runtime();
@@ -402,6 +486,7 @@ void run_runtime_wake_abi_tests(void) {
   RUN_TEST(a_wake_source_releases_a_parked_owner_thread);
   RUN_TEST(a_signal_before_the_pump_sets_the_wake_flag);
   RUN_TEST(a_style_response_wakes_a_parked_owner_thread);
+  RUN_TEST(a_session_resize_releases_a_parked_owner_thread);
   RUN_TEST(queued_events_return_from_the_pump_immediately);
   RUN_TEST(render_updates_coalesce_at_the_queue_tail);
   RUN_TEST(a_wake_source_outlives_its_runtime);

--- a/src/c_api/texture.cpp
+++ b/src/c_api/texture.cpp
@@ -121,6 +121,33 @@ auto mln_opengl_borrowed_texture_attach(
   });
 }
 
+auto mln_metal_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_metal_borrowed_texture_descriptor* descriptor
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::metal_borrowed_texture_set_target(session, descriptor);
+  });
+}
+
+auto mln_vulkan_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_vulkan_borrowed_texture_descriptor* descriptor
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::vulkan_borrowed_texture_set_target(session, descriptor);
+  });
+}
+
+auto mln_opengl_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_opengl_borrowed_texture_descriptor* descriptor
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::opengl_borrowed_texture_set_target(session, descriptor);
+  });
+}
+
 auto mln_texture_read_premultiplied_rgba8(
   mln_render_session session, uint8_t* out_data, size_t out_data_capacity,
   mln_texture_image_info* out_info

--- a/src/render/metal/metal_surface_session.mm
+++ b/src/render/metal/metal_surface_session.mm
@@ -57,6 +57,24 @@ class MetalSurfaceBackend final : public mbgl::mtl::RendererBackend,
       depthStencilDirty = true;
     }
 
+    // Presents through a different layer from here on. Every layer this session
+    // takes is configured for the same device and pixel format, so the render
+    // pipeline states mbgl caches against that format stay usable and the
+    // renderer keeps its resources.
+    void set_layer(CA::MetalLayer* layer_, mbgl::Size size_) {
+      // Release what is still bound to the outgoing layer. A drawable outlives
+      // its layer badly, and bind() acquires one from the new layer anyway.
+      commandBuffer.reset();
+      renderPassDescriptor.reset();
+      drawable.reset();
+
+      layer = NS::RetainPtr(layer_);
+      layer->setDevice(backend.getDevice().get());
+      layer->setPixelFormat(MTL::PixelFormatRGBA8Unorm);
+      layer->setFramebufferOnly(false);
+      setSize(size_);
+    }
+
     void bind() override {
       if (drawable && commandBuffer && renderPassDescriptor) {
         return;
@@ -213,6 +231,17 @@ class MetalSurfaceBackend final : public mbgl::mtl::RendererBackend,
     getResource<MetalSurfaceRenderableResource>().setSize(size_);
   }
 
+  void set_layer(CA::MetalLayer* layer_, mbgl::Size size_) {
+    size = size_;
+    getResource<MetalSurfaceRenderableResource>().set_layer(layer_, size_);
+  }
+
+  // A null device in a descriptor names no device at all, which every session
+  // satisfies; the session keeps the one it attached with either way.
+  [[nodiscard]] auto has_device(MTL::Device* other) const -> bool {
+    return other == nullptr || other == device.get();
+  }
+
   void activate() override {}
   void deactivate() override {}
   void updateAssumedState() override {}
@@ -232,6 +261,33 @@ class MetalSurfaceSessionBackend final
 
   void resize(uint32_t physical_width, uint32_t physical_height) override {
     backend_.setSize(mbgl::Size{physical_width, physical_height});
+  }
+
+  auto set_metal_target(
+    const mln_metal_surface_descriptor& descriptor,
+    mln::core::RetargetOutcome& out_outcome
+  ) -> mln_status override {
+    if (!backend_.has_device(
+          static_cast<MTL::Device*>(descriptor.context.device)
+        )) {
+      mln::core::set_thread_error(
+        "Metal surface target must name the device this session attached with"
+      );
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+    backend_.set_layer(
+      static_cast<CA::MetalLayer*>(descriptor.layer),
+      mbgl::Size{
+        mln::core::physical_dimension(
+          descriptor.extent.width, descriptor.extent.scale_factor
+        ),
+        mln::core::physical_dimension(
+          descriptor.extent.height, descriptor.extent.scale_factor
+        )
+      }
+    );
+    out_outcome = mln::core::RetargetOutcome::RendererPreserved;
+    return MLN_STATUS_OK;
   }
 
  private:
@@ -284,6 +340,23 @@ auto metal_surface_attach(
       .null_session = "surface session must not be null",
       .null_output = "out_session must not be null",
       .non_null_output = "out_session must point to a null handle"
+    }
+  );
+}
+
+auto metal_surface_set_target(
+  mln_render_session session, const mln_metal_surface_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status = validate_metal_surface_descriptor(descriptor);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  return surface_session_set_target(
+    session, descriptor->extent,
+    [descriptor](
+      mln_render_session_object& live, RetargetOutcome& outcome
+    ) -> mln_status {
+      return live.surface.backend->set_metal_target(*descriptor, outcome);
     }
   );
 }

--- a/src/render/metal/metal_surface_session.mm
+++ b/src/render/metal/metal_surface_session.mm
@@ -347,6 +347,13 @@ auto metal_surface_attach(
 auto metal_surface_set_target(
   mln_render_session session, const mln_metal_surface_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::Surface, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status = validate_metal_surface_descriptor(descriptor);
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
@@ -354,9 +361,11 @@ auto metal_surface_set_target(
   return surface_session_set_target(
     session, descriptor->extent,
     [descriptor](
-      mln_render_session_object& live, RetargetOutcome& outcome
+      mln_render_session_object& target_session, RetargetOutcome& outcome
     ) -> mln_status {
-      return live.surface.backend->set_metal_target(*descriptor, outcome);
+      return target_session.surface.backend->set_metal_target(
+        *descriptor, outcome
+      );
     }
   );
 }

--- a/src/render/metal/metal_surface_session.mm
+++ b/src/render/metal/metal_surface_session.mm
@@ -263,10 +263,8 @@ class MetalSurfaceSessionBackend final
     backend_.setSize(mbgl::Size{physical_width, physical_height});
   }
 
-  auto set_metal_target(
-    const mln_metal_surface_descriptor& descriptor,
-    mln::core::RetargetOutcome& out_outcome
-  ) -> mln_status override {
+  auto set_metal_target(const mln_metal_surface_descriptor& descriptor)
+    -> mln_status override {
     if (!backend_.has_device(
           static_cast<MTL::Device*>(descriptor.context.device)
         )) {
@@ -286,7 +284,6 @@ class MetalSurfaceSessionBackend final
         )
       }
     );
-    out_outcome = mln::core::RetargetOutcome::RendererPreserved;
     return MLN_STATUS_OK;
   }
 
@@ -360,12 +357,8 @@ auto metal_surface_set_target(
   }
   return surface_session_set_target(
     session, descriptor->extent,
-    [descriptor](
-      mln_render_session_object& target_session, RetargetOutcome& outcome
-    ) -> mln_status {
-      return target_session.surface.backend->set_metal_target(
-        *descriptor, outcome
-      );
+    [descriptor](mln_render_session_object& target_session) -> mln_status {
+      return target_session.surface.backend->set_metal_target(*descriptor);
     }
   );
 }

--- a/src/render/metal/metal_texture_backend.inc
+++ b/src/render/metal/metal_texture_backend.inc
@@ -32,9 +32,10 @@ class MetalTextureBackend final : public mbgl::mtl::RendererBackend,
   auto metal_texture() -> MTL::Texture*;
 
   [[nodiscard]] auto has_device(const MTL::Device* other) const -> bool;
-  // Whether a replacement texture matches the format this session's cached
-  // render pipeline states were built against.
-  [[nodiscard]] auto has_borrowed_pixel_format(MTL::PixelFormat format) const
+  // Whether a replacement texture matches what this session's cached render
+  // pipeline states were built against, which is its pixel format and its
+  // sample count.
+  [[nodiscard]] auto matches_borrowed_texture(const MTL::Texture* texture) const
     -> bool;
   // Renders into a different caller-owned texture from here on. The caller has
   // already established that the format matches.
@@ -42,10 +43,11 @@ class MetalTextureBackend final : public mbgl::mtl::RendererBackend,
 
  private:
   MTL::Texture* borrowed_texture_ = nullptr;
-  // The format of borrowed_texture_, recorded when this session took it, so a
-  // replacement is measured against a value rather than against a texture the
-  // host may already have released.
+  // Recorded when this session took borrowed_texture_, so a replacement is
+  // measured against values rather than against a texture the host may already
+  // have released.
   MTL::PixelFormat borrowed_pixel_format_ = MTL::PixelFormatInvalid;
+  NS::UInteger borrowed_sample_count_ = 1;
 };
 
 }  // namespace mln::core

--- a/src/render/metal/metal_texture_backend.inc
+++ b/src/render/metal/metal_texture_backend.inc
@@ -31,6 +31,12 @@ class MetalTextureBackend final : public mbgl::mtl::RendererBackend,
 
   auto metal_texture() -> MTL::Texture*;
 
+  [[nodiscard]] auto has_device(const MTL::Device* other) const -> bool;
+  // Renders into a different caller-owned texture from here on. Returns whether
+  // the renderer's cached state survives, which turns on the pixel format mbgl
+  // builds its render pipeline states against.
+  auto set_borrowed_texture(MTL::Texture* texture, mbgl::Size new_size) -> bool;
+
  private:
   MTL::Texture* borrowed_texture_ = nullptr;
 };

--- a/src/render/metal/metal_texture_backend.inc
+++ b/src/render/metal/metal_texture_backend.inc
@@ -32,10 +32,13 @@ class MetalTextureBackend final : public mbgl::mtl::RendererBackend,
   auto metal_texture() -> MTL::Texture*;
 
   [[nodiscard]] auto has_device(const MTL::Device* other) const -> bool;
-  // Renders into a different caller-owned texture from here on. Returns whether
-  // the renderer's cached state survives, which turns on the pixel format mbgl
-  // builds its render pipeline states against.
-  auto set_borrowed_texture(MTL::Texture* texture, mbgl::Size new_size) -> bool;
+  // Whether a replacement texture matches the format this session's cached
+  // render pipeline states were built against.
+  [[nodiscard]] auto has_borrowed_pixel_format(MTL::PixelFormat format) const
+    -> bool;
+  // Renders into a different caller-owned texture from here on. The caller has
+  // already established that the format matches.
+  void set_borrowed_texture(MTL::Texture* texture, mbgl::Size new_size);
 
  private:
   MTL::Texture* borrowed_texture_ = nullptr;

--- a/src/render/metal/metal_texture_backend.inc
+++ b/src/render/metal/metal_texture_backend.inc
@@ -32,10 +32,9 @@ class MetalTextureBackend final : public mbgl::mtl::RendererBackend,
   auto metal_texture() -> MTL::Texture*;
 
   [[nodiscard]] auto has_device(const MTL::Device* other) const -> bool;
-  // Whether a replacement texture matches what this session's cached render
-  // pipeline states were built against, which is its pixel format and its
-  // sample count.
-  [[nodiscard]] auto matches_borrowed_texture(const MTL::Texture* texture) const
+  // Whether a replacement texture has the pixel format this session's cached
+  // render pipeline states were built against.
+  [[nodiscard]] auto has_borrowed_pixel_format(MTL::PixelFormat format) const
     -> bool;
   // Renders into a different caller-owned texture from here on. The caller has
   // already established that the format matches.
@@ -44,10 +43,9 @@ class MetalTextureBackend final : public mbgl::mtl::RendererBackend,
  private:
   MTL::Texture* borrowed_texture_ = nullptr;
   // Recorded when this session took borrowed_texture_, so a replacement is
-  // measured against values rather than against a texture the host may already
+  // measured against a value rather than against a texture the host may already
   // have released.
   MTL::PixelFormat borrowed_pixel_format_ = MTL::PixelFormatInvalid;
-  NS::UInteger borrowed_sample_count_ = 1;
 };
 
 }  // namespace mln::core

--- a/src/render/metal/metal_texture_backend.inc
+++ b/src/render/metal/metal_texture_backend.inc
@@ -39,6 +39,10 @@ class MetalTextureBackend final : public mbgl::mtl::RendererBackend,
 
  private:
   MTL::Texture* borrowed_texture_ = nullptr;
+  // The format of borrowed_texture_, recorded when this session took it, so a
+  // replacement is measured against a value rather than against a texture the
+  // host may already have released.
+  MTL::PixelFormat borrowed_pixel_format_ = MTL::PixelFormatInvalid;
 };
 
 }  // namespace mln::core

--- a/src/render/metal/metal_texture_backend.mm
+++ b/src/render/metal/metal_texture_backend.mm
@@ -262,4 +262,27 @@ auto MetalTextureBackend::metal_texture() -> MTL::Texture* {
   return getResource<MetalTextureRenderableResource>().metal_texture();
 }
 
+auto MetalTextureBackend::has_device(const MTL::Device* other) const -> bool {
+  return other == device.get();
+}
+
+auto MetalTextureBackend::set_borrowed_texture(
+  MTL::Texture* texture, mbgl::Size new_size
+) -> bool {
+  const auto previous_format = borrowed_texture_ != nullptr
+                                 ? borrowed_texture_->pixelFormat()
+                                 : texture->pixelFormat();
+  borrowed_texture_ = texture;
+  size = new_size;
+  // Drop the renderable rather than patch it: its depth and stencil textures
+  // are sized with the color attachment, and any command buffer in hand was
+  // opened against the texture being replaced. bind() builds a matching set
+  // from the new one on the next frame.
+  {
+    auto guard = mbgl::gfx::BackendScope{*this};
+    resource.reset();
+  }
+  return texture->pixelFormat() == previous_format;
+}
+
 }  // namespace mln::core

--- a/src/render/metal/metal_texture_backend.mm
+++ b/src/render/metal/metal_texture_backend.mm
@@ -267,15 +267,19 @@ auto MetalTextureBackend::has_device(const MTL::Device* other) const -> bool {
   return other == device.get();
 }
 
-auto MetalTextureBackend::set_borrowed_texture(
+auto MetalTextureBackend::has_borrowed_pixel_format(
+  MTL::PixelFormat format
+) const -> bool {
+  // Against the format recorded when this session took its texture, not against
+  // the outgoing texture itself: the session never retained that, and a host
+  // replacing a texture it just released would otherwise be answered from freed
+  // memory.
+  return format == borrowed_pixel_format_;
+}
+
+void MetalTextureBackend::set_borrowed_texture(
   MTL::Texture* texture, mbgl::Size new_size
-) -> bool {
-  // Against the format recorded when this session took the outgoing texture,
-  // not against the outgoing texture itself. The session never retained it, and
-  // a host replacing a texture it just released would otherwise have its
-  // renderer verdict decided by freed memory.
-  const auto previous_format = borrowed_pixel_format_;
-  borrowed_pixel_format_ = texture->pixelFormat();
+) {
   borrowed_texture_ = texture;
   size = new_size;
   // Drop the renderable rather than patch it: its depth and stencil textures
@@ -286,7 +290,6 @@ auto MetalTextureBackend::set_borrowed_texture(
     auto guard = mbgl::gfx::BackendScope{*this};
     resource.reset();
   }
-  return borrowed_pixel_format_ == previous_format;
 }
 
 }  // namespace mln::core

--- a/src/render/metal/metal_texture_backend.mm
+++ b/src/render/metal/metal_texture_backend.mm
@@ -221,8 +221,7 @@ MetalTextureBackend::MetalTextureBackend(
     : mbgl::mtl::RendererBackend(mbgl::gfx::ContextMode::Unique),
       mbgl::gfx::HeadlessBackend(size),
       borrowed_texture_(borrowed_texture),
-      borrowed_pixel_format_(borrowed_texture->pixelFormat()),
-      borrowed_sample_count_(borrowed_texture->sampleCount()) {
+      borrowed_pixel_format_(borrowed_texture->pixelFormat()) {
   device = NS::RetainPtr(borrowed_texture->device());
   commandQueue = NS::TransferPtr(device->newCommandQueue());
 }
@@ -268,15 +267,20 @@ auto MetalTextureBackend::has_device(const MTL::Device* other) const -> bool {
   return other == device.get();
 }
 
-auto MetalTextureBackend::matches_borrowed_texture(
-  const MTL::Texture* texture
+auto MetalTextureBackend::has_borrowed_pixel_format(
+  MTL::PixelFormat format
 ) const -> bool {
-  // Against the values recorded when this session took its texture, not against
+  // Against the format recorded when this session took its texture, not against
   // the outgoing texture itself: the session never retained that, and a host
   // replacing a texture it just released would otherwise be answered from freed
   // memory.
-  return texture->pixelFormat() == borrowed_pixel_format_ &&
-         texture->sampleCount() == borrowed_sample_count_;
+  //
+  // mbgl reads the color format off the renderable when it builds a render
+  // pipeline state, but keys its cache on the shader and color mode alone, so a
+  // replacement in another format would be drawn with a pipeline built for the
+  // old one. Sample count needs no comparison here: attach admits only
+  // single-sample textures, so both sides are always one.
+  return format == borrowed_pixel_format_;
 }
 
 void MetalTextureBackend::set_borrowed_texture(

--- a/src/render/metal/metal_texture_backend.mm
+++ b/src/render/metal/metal_texture_backend.mm
@@ -221,7 +221,8 @@ MetalTextureBackend::MetalTextureBackend(
     : mbgl::mtl::RendererBackend(mbgl::gfx::ContextMode::Unique),
       mbgl::gfx::HeadlessBackend(size),
       borrowed_texture_(borrowed_texture),
-      borrowed_pixel_format_(borrowed_texture->pixelFormat()) {
+      borrowed_pixel_format_(borrowed_texture->pixelFormat()),
+      borrowed_sample_count_(borrowed_texture->sampleCount()) {
   device = NS::RetainPtr(borrowed_texture->device());
   commandQueue = NS::TransferPtr(device->newCommandQueue());
 }
@@ -267,14 +268,15 @@ auto MetalTextureBackend::has_device(const MTL::Device* other) const -> bool {
   return other == device.get();
 }
 
-auto MetalTextureBackend::has_borrowed_pixel_format(
-  MTL::PixelFormat format
+auto MetalTextureBackend::matches_borrowed_texture(
+  const MTL::Texture* texture
 ) const -> bool {
-  // Against the format recorded when this session took its texture, not against
+  // Against the values recorded when this session took its texture, not against
   // the outgoing texture itself: the session never retained that, and a host
   // replacing a texture it just released would otherwise be answered from freed
   // memory.
-  return format == borrowed_pixel_format_;
+  return texture->pixelFormat() == borrowed_pixel_format_ &&
+         texture->sampleCount() == borrowed_sample_count_;
 }
 
 void MetalTextureBackend::set_borrowed_texture(

--- a/src/render/metal/metal_texture_backend.mm
+++ b/src/render/metal/metal_texture_backend.mm
@@ -220,7 +220,8 @@ MetalTextureBackend::MetalTextureBackend(
 )
     : mbgl::mtl::RendererBackend(mbgl::gfx::ContextMode::Unique),
       mbgl::gfx::HeadlessBackend(size),
-      borrowed_texture_(borrowed_texture) {
+      borrowed_texture_(borrowed_texture),
+      borrowed_pixel_format_(borrowed_texture->pixelFormat()) {
   device = NS::RetainPtr(borrowed_texture->device());
   commandQueue = NS::TransferPtr(device->newCommandQueue());
 }
@@ -269,9 +270,12 @@ auto MetalTextureBackend::has_device(const MTL::Device* other) const -> bool {
 auto MetalTextureBackend::set_borrowed_texture(
   MTL::Texture* texture, mbgl::Size new_size
 ) -> bool {
-  const auto previous_format = borrowed_texture_ != nullptr
-                                 ? borrowed_texture_->pixelFormat()
-                                 : texture->pixelFormat();
+  // Against the format recorded when this session took the outgoing texture,
+  // not against the outgoing texture itself. The session never retained it, and
+  // a host replacing a texture it just released would otherwise have its
+  // renderer verdict decided by freed memory.
+  const auto previous_format = borrowed_pixel_format_;
+  borrowed_pixel_format_ = texture->pixelFormat();
   borrowed_texture_ = texture;
   size = new_size;
   // Drop the renderable rather than patch it: its depth and stencil textures
@@ -282,7 +286,7 @@ auto MetalTextureBackend::set_borrowed_texture(
     auto guard = mbgl::gfx::BackendScope{*this};
     resource.reset();
   }
-  return texture->pixelFormat() == previous_format;
+  return borrowed_pixel_format_ == previous_format;
 }
 
 }  // namespace mln::core

--- a/src/render/metal/metal_texture_backend.mm
+++ b/src/render/metal/metal_texture_backend.mm
@@ -276,7 +276,8 @@ auto MetalTextureBackend::has_borrowed_pixel_format(
   // memory.
   //
   // mbgl reads the color format off the renderable when it builds a render
-  // pipeline state, but keys its cache on the shader and color mode alone, so a
+  // pipeline state, then caches that state per shader program under a key of
+  // color mode and vertex layout, with the format itself absent from it. A
   // replacement in another format would be drawn with a pipeline built for the
   // old one. Sample count needs no comparison here: attach admits only
   // single-sample textures, so both sides are always one.

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -61,8 +61,7 @@ class MetalTextureSessionBackend final
   }
 
   auto set_metal_borrowed_target(
-    const mln_metal_borrowed_texture_descriptor& descriptor,
-    mln::core::RetargetOutcome& out_outcome
+    const mln_metal_borrowed_texture_descriptor& descriptor
   ) -> mln_status override {
     auto* texture = static_cast<MTL::Texture*>(descriptor.texture);
     if (!backend_.has_device(texture->device())) {
@@ -72,11 +71,16 @@ class MetalTextureSessionBackend final
       );
       return MLN_STATUS_INVALID_ARGUMENT;
     }
-    const auto preserved = backend_.set_borrowed_texture(
+    if (!backend_.has_borrowed_pixel_format(texture->pixelFormat())) {
+      return mln::core::unsupported_retarget(
+        "Metal texture target must have the pixel format this session's render "
+        "pipeline states were built for; destroy the session and attach again "
+        "to change it"
+      );
+    }
+    backend_.set_borrowed_texture(
       texture, mbgl::Size{descriptor.physical_width, descriptor.physical_height}
     );
-    out_outcome = preserved ? mln::core::RetargetOutcome::RendererPreserved
-                            : mln::core::RetargetOutcome::RendererInvalidated;
     return MLN_STATUS_OK;
   }
 
@@ -316,11 +320,9 @@ auto metal_borrowed_texture_set_target(
   return render_session_set_target(
     session, RetargetTargetKind::BorrowedTexture, descriptor->extent,
     descriptor->physical_width, descriptor->physical_height,
-    [descriptor](
-      mln_render_session_object& target_session, RetargetOutcome& outcome
-    ) -> mln_status {
+    [descriptor](mln_render_session_object& target_session) -> mln_status {
       return target_session.texture.backend->set_metal_borrowed_target(
-        *descriptor, outcome
+        *descriptor
       );
     }
   );

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -71,11 +71,11 @@ class MetalTextureSessionBackend final
       );
       return MLN_STATUS_INVALID_ARGUMENT;
     }
-    if (!backend_.has_borrowed_pixel_format(texture->pixelFormat())) {
+    if (!backend_.matches_borrowed_texture(texture)) {
       return mln::core::unsupported_retarget(
-        "Metal texture target must have the pixel format this session's render "
-        "pipeline states were built for; destroy the session and attach again "
-        "to change it"
+        "Metal texture target must have the pixel format and sample count this "
+        "session's render pipeline states were built for; destroy the session "
+        "and attach again to change either"
       );
     }
     backend_.set_borrowed_texture(

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -44,6 +44,15 @@ auto validate_borrowed_texture(
     mln::core::set_thread_error("Metal texture must allow render target usage");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
+  // The session builds the depth and stencil attachments that go alongside this
+  // texture, and builds them single-sample. Metal wants one sample count across
+  // a render pass, and mbgl leaves rasterSampleCount at its default of one for
+  // every pipeline it creates, so a multisample texture has no way to work
+  // here. Rejecting it now beats reporting it as a render failure later.
+  if (metal_texture->sampleCount() != 1) {
+    mln::core::set_thread_error("Metal texture must be single-sample");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
   return MLN_STATUS_OK;
 }
 
@@ -71,11 +80,11 @@ class MetalTextureSessionBackend final
       );
       return MLN_STATUS_INVALID_ARGUMENT;
     }
-    if (!backend_.matches_borrowed_texture(texture)) {
+    if (!backend_.has_borrowed_pixel_format(texture->pixelFormat())) {
       return mln::core::unsupported_retarget(
-        "Metal texture target must have the pixel format and sample count this "
-        "session's render pipeline states were built for; destroy the session "
-        "and attach again to change either"
+        "Metal texture target must have the pixel format this session's render "
+        "pipeline states were built for; destroy the session and attach again "
+        "to change it"
       );
     }
     backend_.set_borrowed_texture(

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -60,6 +60,26 @@ class MetalTextureSessionBackend final
     return backend_;
   }
 
+  auto set_metal_borrowed_target(
+    const mln_metal_borrowed_texture_descriptor& descriptor,
+    mln::core::RetargetOutcome& out_outcome
+  ) -> mln_status override {
+    auto* texture = static_cast<MTL::Texture*>(descriptor.texture);
+    if (!backend_.has_device(texture->device())) {
+      mln::core::set_thread_error(
+        "Metal texture target must belong to the device this session attached "
+        "with"
+      );
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+    const auto preserved = backend_.set_borrowed_texture(
+      texture, mbgl::Size{descriptor.physical_width, descriptor.physical_height}
+    );
+    out_outcome = preserved ? mln::core::RetargetOutcome::RendererPreserved
+                            : mln::core::RetargetOutcome::RendererInvalidated;
+    return MLN_STATUS_OK;
+  }
+
   auto after_render(mln_render_session_object& texture, bool& out_rendered)
     -> mln_status override {
     auto* rendered_texture = backend_.metal_texture();
@@ -275,6 +295,28 @@ auto metal_owned_texture_release_frame(
   live->texture.acquired_frame_kind = TextureSessionFrameKind::None;
   live->texture.acquired_native_texture = nullptr;
   return MLN_STATUS_OK;
+}
+
+auto metal_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_metal_borrowed_texture_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status =
+    validate_metal_borrowed_texture_descriptor(descriptor);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  return render_session_set_target(
+    session, RetargetTargetKind::BorrowedTexture, descriptor->extent,
+    descriptor->physical_width, descriptor->physical_height,
+    [descriptor](
+      mln_render_session_object& live, RetargetOutcome& outcome
+    ) -> mln_status {
+      return live.texture.backend->set_metal_borrowed_target(
+        *descriptor, outcome
+      );
+    }
+  );
 }
 
 }  // namespace mln::core

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -301,6 +301,13 @@ auto metal_borrowed_texture_set_target(
   mln_render_session session,
   const mln_metal_borrowed_texture_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::BorrowedTexture, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status =
     validate_metal_borrowed_texture_descriptor(descriptor);
   if (descriptor_status != MLN_STATUS_OK) {
@@ -310,9 +317,9 @@ auto metal_borrowed_texture_set_target(
     session, RetargetTargetKind::BorrowedTexture, descriptor->extent,
     descriptor->physical_width, descriptor->physical_height,
     [descriptor](
-      mln_render_session_object& live, RetargetOutcome& outcome
+      mln_render_session_object& target_session, RetargetOutcome& outcome
     ) -> mln_status {
-      return live.texture.backend->set_metal_borrowed_target(
+      return target_session.texture.backend->set_metal_borrowed_target(
         *descriptor, outcome
       );
     }

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -321,8 +321,11 @@ auto metal_borrowed_texture_set_target(
   if (session_status != MLN_STATUS_OK) {
     return session_status;
   }
-  const auto descriptor_status =
-    validate_metal_borrowed_texture_descriptor(descriptor);
+  // The same validator attach uses. The shape-only shared one would let a
+  // texture through that attachment rejects — mismatched dimensions, no render
+  // target usage, multisampled — and the old target is discarded by then, so
+  // the next render is where it would surface.
+  const auto descriptor_status = validate_borrowed_texture(descriptor);
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }

--- a/src/render/opengl/opengl_surface_session.cpp
+++ b/src/render/opengl/opengl_surface_session.cpp
@@ -78,28 +78,15 @@ class OpenGLSurfaceBackend final : public mbgl::gl::RendererBackend,
   }
 
   void destroy_backend() {
-    auto cleanup = [this] {
-      resource.reset();
-      context.reset();
-    };
     if (has_native_context()) {
       // Making the surface current can fail, and set_target lets a host install
       // a surface that only turns out to be unusable later, so this is
-      // reachable. Release the GL objects only when the context is current, but
-      // release the context itself either way: skipping it would leak the HGLRC
-      // or EGLContext for a session the host has already destroyed.
+      // reachable. Run the GL teardown against whatever can be made current,
+      // but release the context itself either way: skipping it would leak the
+      // HGLRC or EGLContext for a session the host has already destroyed.
       try {
-        auto guard = mbgl::gfx::BackendScope{*this};
-        cleanup();
+        cleanup_while_current();
       } catch (...) {
-        // Nothing can be made current, so no GL call is safe from here. Give up
-        // the renderable resource and the mbgl context without running their
-        // teardown: destroying either issues the deletes it has queued, and
-        // after destroy_native_context() those land on whatever context is
-        // current instead. The objects they name go when the driver tears the
-        // native context down, so this leaks bookkeeping, not GPU memory.
-        static_cast<void>(resource.release());
-        static_cast<void>(context.release());
         getThreadPool().runRenderJobs(true);
         destroy_native_context();
         throw;
@@ -109,6 +96,41 @@ class OpenGLSurfaceBackend final : public mbgl::gl::RendererBackend,
     }
     getThreadPool().runRenderJobs(true);
     destroy_native_context();
+  }
+
+  void cleanup() {
+    resource.reset();
+    context.reset();
+  }
+
+  // Runs GL teardown with this session's context current, through the surface
+  // it presents to or, when that cannot be made current, through the drawable
+  // the context itself was created from. The second try is what keeps the
+  // deletes reachable: this context is created in the host's share group, so
+  // the textures, buffers, and programs the renderer built there outlive it and
+  // stay allocated until something in the group deletes them.
+  void cleanup_while_current() {
+    try {
+      auto guard = mbgl::gfx::BackendScope{*this};
+      cleanup();
+      return;
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
+      // Fall through to the drawable the context was created from.
+    }
+    fallback_drawable_ = true;
+    try {
+      auto guard = mbgl::gfx::BackendScope{*this};
+      cleanup();
+    } catch (...) {
+      // Nothing can be made current, so no GL call is safe from here. Give up
+      // the renderable resource and the mbgl context without running their
+      // teardown: destroying either issues the deletes it has queued, and after
+      // destroy_native_context() those land on whatever context is current
+      // instead. What they name is left to the host's share group.
+      static_cast<void>(resource.release());
+      static_cast<void>(context.release());
+      throw;
+    }
   }
 
   auto getDefaultRenderable() -> mbgl::gfx::Renderable& override {
@@ -220,11 +242,12 @@ class OpenGLSurfaceBackend final : public mbgl::gl::RendererBackend,
       if (render_context_ == nullptr) {
         create_wgl_context();
       }
+      auto* const draw_surface =
+        fallback_drawable_
+          ? static_cast<HDC>(descriptor_.context.data.wgl.device_context)
+          : static_cast<HDC>(descriptor_.surface);
       if (
-        wglMakeCurrent(
-          static_cast<HDC>(descriptor_.surface),
-          static_cast<HGLRC>(render_context_)
-        ) == 0
+        wglMakeCurrent(draw_surface, static_cast<HGLRC>(render_context_)) == 0
       ) {
         throw std::runtime_error("Switching OpenGL WGL context failed");
       }
@@ -242,9 +265,13 @@ class OpenGLSurfaceBackend final : public mbgl::gl::RendererBackend,
     if (!egl_context_) {
       egl_context_.emplace(descriptor_.context.data.egl);
     }
-    egl_context_->activate_surface(
-      static_cast<EGLSurface>(descriptor_.surface)
-    );
+    if (fallback_drawable_) {
+      egl_context_->activate_pbuffer();
+    } else {
+      egl_context_->activate_surface(
+        static_cast<EGLSurface>(descriptor_.surface)
+      );
+    }
 #else
     throw std::runtime_error("OpenGL context provider is unsupported");
 #endif
@@ -298,6 +325,9 @@ class OpenGLSurfaceBackend final : public mbgl::gl::RendererBackend,
 #endif
 
   mln_opengl_surface_descriptor descriptor_{};
+  // Set once teardown has found the session's surface unusable, so activate()
+  // reaches for the drawable the context was created from instead.
+  bool fallback_drawable_ = false;
 
 #if defined(MLN_FFI_OPENGL_PROVIDER_WGL)
   void* render_context_ = nullptr;

--- a/src/render/opengl/opengl_surface_session.cpp
+++ b/src/render/opengl/opengl_surface_session.cpp
@@ -104,7 +104,11 @@ class OpenGLSurfaceBackend final : public mbgl::gl::RendererBackend,
   // next render. That deliberately never reaches for the outgoing surface,
   // which a host may already have destroyed — the case this exists for.
   void set_surface(const mln_opengl_surface_descriptor& descriptor) {
-    descriptor_ = descriptor;
+    // The surface alone. The context descriptor stays as it was at attach: this
+    // session's own GL context was created from it, WGL context creation still
+    // reads its device_context, and context identity is what the caller was
+    // told cannot change here.
+    descriptor_.surface = descriptor.surface;
     size = mbgl::Size{
       mln::core::physical_dimension(
         descriptor.extent.width, descriptor.extent.scale_factor
@@ -374,6 +378,13 @@ auto opengl_surface_attach(
 auto opengl_surface_set_target(
   mln_render_session session, const mln_opengl_surface_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::Surface, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status =
     validate_opengl_surface_descriptor(descriptor, true);
   if (descriptor_status != MLN_STATUS_OK) {
@@ -382,9 +393,11 @@ auto opengl_surface_set_target(
   return surface_session_set_target(
     session, descriptor->extent,
     [descriptor](
-      mln_render_session_object& live, RetargetOutcome& outcome
+      mln_render_session_object& target_session, RetargetOutcome& outcome
     ) -> mln_status {
-      return live.surface.backend->set_opengl_target(*descriptor, outcome);
+      return target_session.surface.backend->set_opengl_target(
+        *descriptor, outcome
+      );
     }
   );
 }

--- a/src/render/opengl/opengl_surface_session.cpp
+++ b/src/render/opengl/opengl_surface_session.cpp
@@ -98,6 +98,28 @@ class OpenGLSurfaceBackend final : public mbgl::gl::RendererBackend,
 
   void resize(mbgl::Size size_) { size = size_; }
 
+  // Presents through a different host surface from here on. Nothing is touched
+  // now: the session's own context stays as it is, holding every object the
+  // renderer built in it, and activate() makes the new surface current on the
+  // next render. That deliberately never reaches for the outgoing surface,
+  // which a host may already have destroyed — the case this exists for.
+  void set_surface(const mln_opengl_surface_descriptor& descriptor) {
+    descriptor_ = descriptor;
+    size = mbgl::Size{
+      mln::core::physical_dimension(
+        descriptor.extent.width, descriptor.extent.scale_factor
+      ),
+      mln::core::physical_dimension(
+        descriptor.extent.height, descriptor.extent.scale_factor
+      )
+    };
+  }
+
+  [[nodiscard]] auto context_descriptor() const
+    -> const mln_opengl_context_descriptor& {
+    return descriptor_.context;
+  }
+
   void updateAssumedState() override {
     assumeFramebufferBinding(0);
     setViewport(0, 0, size);
@@ -279,6 +301,23 @@ class OpenGLSurfaceSessionBackend final
     backend_.resize(mbgl::Size{physical_width, physical_height});
   }
 
+  auto set_opengl_target(
+    const mln_opengl_surface_descriptor& descriptor,
+    mln::core::RetargetOutcome& out_outcome
+  ) -> mln_status override {
+    if (!mln::core::opengl_context_matches(
+          backend_.context_descriptor(), descriptor.context
+        )) {
+      mln::core::set_thread_error(
+        "OpenGL surface target must name the context this session attached with"
+      );
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+    backend_.set_surface(descriptor);
+    out_outcome = mln::core::RetargetOutcome::RendererPreserved;
+    return MLN_STATUS_OK;
+  }
+
  private:
   OpenGLSurfaceBackend backend_;
 };
@@ -328,6 +367,24 @@ auto opengl_surface_attach(
       .null_session = "surface session must not be null",
       .null_output = "out_session must not be null",
       .non_null_output = "out_session must point to a null handle"
+    }
+  );
+}
+
+auto opengl_surface_set_target(
+  mln_render_session session, const mln_opengl_surface_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status =
+    validate_opengl_surface_descriptor(descriptor, true);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  return surface_session_set_target(
+    session, descriptor->extent,
+    [descriptor](
+      mln_render_session_object& live, RetargetOutcome& outcome
+    ) -> mln_status {
+      return live.surface.backend->set_opengl_target(*descriptor, outcome);
     }
   );
 }

--- a/src/render/opengl/opengl_surface_session.cpp
+++ b/src/render/opengl/opengl_surface_session.cpp
@@ -83,8 +83,19 @@ class OpenGLSurfaceBackend final : public mbgl::gl::RendererBackend,
       context.reset();
     };
     if (has_native_context()) {
-      auto guard = mbgl::gfx::BackendScope{*this};
-      cleanup();
+      // Making the surface current can fail, and set_target lets a host install
+      // a surface that only turns out to be unusable later, so this is
+      // reachable. Release the GL objects only when the context is current, but
+      // release the context itself either way: skipping it would leak the HGLRC
+      // or EGLContext for a session the host has already destroyed.
+      try {
+        auto guard = mbgl::gfx::BackendScope{*this};
+        cleanup();
+      } catch (...) {
+        getThreadPool().runRenderJobs(true);
+        destroy_native_context();
+        throw;
+      }
     } else {
       cleanup();
     }
@@ -305,12 +316,11 @@ class OpenGLSurfaceSessionBackend final
     backend_.resize(mbgl::Size{physical_width, physical_height});
   }
 
-  auto set_opengl_target(
-    const mln_opengl_surface_descriptor& descriptor,
-    mln::core::RetargetOutcome& out_outcome
-  ) -> mln_status override {
+  auto set_opengl_target(const mln_opengl_surface_descriptor& descriptor)
+    -> mln_status override {
     if (!mln::core::opengl_context_matches(
-          backend_.context_descriptor(), descriptor.context
+          backend_.context_descriptor(), descriptor.context,
+          mln::core::OpenGLContextMatch::ShareGroup
         )) {
       mln::core::set_thread_error(
         "OpenGL surface target must name the context this session attached with"
@@ -318,7 +328,6 @@ class OpenGLSurfaceSessionBackend final
       return MLN_STATUS_INVALID_ARGUMENT;
     }
     backend_.set_surface(descriptor);
-    out_outcome = mln::core::RetargetOutcome::RendererPreserved;
     return MLN_STATUS_OK;
   }
 
@@ -392,12 +401,8 @@ auto opengl_surface_set_target(
   }
   return surface_session_set_target(
     session, descriptor->extent,
-    [descriptor](
-      mln_render_session_object& target_session, RetargetOutcome& outcome
-    ) -> mln_status {
-      return target_session.surface.backend->set_opengl_target(
-        *descriptor, outcome
-      );
+    [descriptor](mln_render_session_object& target_session) -> mln_status {
+      return target_session.surface.backend->set_opengl_target(*descriptor);
     }
   );
 }

--- a/src/render/opengl/opengl_surface_session.cpp
+++ b/src/render/opengl/opengl_surface_session.cpp
@@ -92,6 +92,14 @@ class OpenGLSurfaceBackend final : public mbgl::gl::RendererBackend,
         auto guard = mbgl::gfx::BackendScope{*this};
         cleanup();
       } catch (...) {
+        // Nothing can be made current, so no GL call is safe from here. Give up
+        // the renderable resource and the mbgl context without running their
+        // teardown: destroying either issues the deletes it has queued, and
+        // after destroy_native_context() those land on whatever context is
+        // current instead. The objects they name go when the driver tears the
+        // native context down, so this leaks bookkeeping, not GPU memory.
+        static_cast<void>(resource.release());
+        static_cast<void>(context.release());
         getThreadPool().runRenderJobs(true);
         destroy_native_context();
         throw;

--- a/src/render/opengl/opengl_texture_session.cpp
+++ b/src/render/opengl/opengl_texture_session.cpp
@@ -637,6 +637,14 @@ auto opengl_borrowed_texture_set_target(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
+  // The same check attach makes: the shared validator accepts any nonzero
+  // target, and the backend attaches whatever name it is given as
+  // GL_TEXTURE_2D. Without this a cube-map target is taken here and only fails
+  // on the next render, with the old target already discarded.
+  if (descriptor->target != opengl_texture_target) {
+    set_thread_error("OpenGL texture target must be GL_TEXTURE_2D");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
   const auto physical_status = validate_borrowed_physical_size(
     descriptor->physical_width, descriptor->physical_height
   );

--- a/src/render/opengl/opengl_texture_session.cpp
+++ b/src/render/opengl/opengl_texture_session.cpp
@@ -449,11 +449,11 @@ class OpenGLTextureSessionBackend final
   }
 
   auto set_opengl_borrowed_target(
-    const mln_opengl_borrowed_texture_descriptor& descriptor,
-    mln::core::RetargetOutcome& out_outcome
+    const mln_opengl_borrowed_texture_descriptor& descriptor
   ) -> mln_status override {
     if (!mln::core::opengl_context_matches(
-          backend_.context_descriptor(), descriptor.context
+          backend_.context_descriptor(), descriptor.context,
+          mln::core::OpenGLContextMatch::Exact
         )) {
       mln::core::set_thread_error(
         "OpenGL texture target must name the context this session attached with"
@@ -464,7 +464,6 @@ class OpenGLTextureSessionBackend final
       descriptor.texture,
       mbgl::Size{descriptor.physical_width, descriptor.physical_height}
     );
-    out_outcome = mln::core::RetargetOutcome::RendererPreserved;
     return MLN_STATUS_OK;
   }
 
@@ -647,11 +646,9 @@ auto opengl_borrowed_texture_set_target(
   return render_session_set_target(
     session, RetargetTargetKind::BorrowedTexture, descriptor->extent,
     descriptor->physical_width, descriptor->physical_height,
-    [descriptor](
-      mln_render_session_object& target_session, RetargetOutcome& outcome
-    ) -> mln_status {
+    [descriptor](mln_render_session_object& target_session) -> mln_status {
       return target_session.texture.backend->set_opengl_borrowed_target(
-        *descriptor, outcome
+        *descriptor
       );
     }
   );

--- a/src/render/opengl/opengl_texture_session.cpp
+++ b/src/render/opengl/opengl_texture_session.cpp
@@ -272,6 +272,22 @@ class OpenGLTextureBackend final : public mbgl::gl::RendererBackend,
 
   void finish_rendering() { getContext<mbgl::gl::Context>().finish(); }
 
+  // Renders into a different caller-owned texture from here on. The session's
+  // context is untouched, so every object the renderer built in it survives;
+  // only the framebuffer that named the outgoing texture is rebuilt, which
+  // getDefaultRenderable() does once the resource is gone.
+  void set_borrowed_texture(uint32_t texture, mbgl::Size new_size) {
+    borrowed_texture_ = texture;
+    // Deleting the framebuffer is a GL call like any other.
+    auto guard = mbgl::gfx::BackendScope{*this};
+    setSize(new_size);
+  }
+
+  [[nodiscard]] auto context_descriptor() const
+    -> const mln_opengl_context_descriptor& {
+    return context_;
+  }
+
  private:
   [[nodiscard]] auto has_native_context() const -> bool {
 #if defined(MLN_FFI_OPENGL_PROVIDER_WGL)
@@ -429,6 +445,26 @@ class OpenGLTextureSessionBackend final
     return backend_;
   }
 
+  auto set_opengl_borrowed_target(
+    const mln_opengl_borrowed_texture_descriptor& descriptor,
+    mln::core::RetargetOutcome& out_outcome
+  ) -> mln_status override {
+    if (!mln::core::opengl_context_matches(
+          backend_.context_descriptor(), descriptor.context
+        )) {
+      mln::core::set_thread_error(
+        "OpenGL texture target must name the context this session attached with"
+      );
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+    backend_.set_borrowed_texture(
+      descriptor.texture,
+      mbgl::Size{descriptor.physical_width, descriptor.physical_height}
+    );
+    out_outcome = mln::core::RetargetOutcome::RendererPreserved;
+    return MLN_STATUS_OK;
+  }
+
   auto after_render(mln_render_session_object& texture, bool& out_rendered)
     -> mln_status override {
     texture.texture.rendered_native_texture =
@@ -579,6 +615,34 @@ auto opengl_borrowed_texture_attach(
       .null_session = "texture session must not be null",
       .null_output = "out_session must not be null",
       .non_null_output = "out_session must point to a null handle"
+    }
+  );
+}
+
+auto opengl_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_opengl_borrowed_texture_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status =
+    validate_opengl_borrowed_texture_descriptor(descriptor, true);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  const auto physical_status = validate_borrowed_physical_size(
+    descriptor->physical_width, descriptor->physical_height
+  );
+  if (physical_status != MLN_STATUS_OK) {
+    return physical_status;
+  }
+  return render_session_set_target(
+    session, RetargetTargetKind::BorrowedTexture, descriptor->extent,
+    descriptor->physical_width, descriptor->physical_height,
+    [descriptor](
+      mln_render_session_object& live, RetargetOutcome& outcome
+    ) -> mln_status {
+      return live.texture.backend->set_opengl_borrowed_target(
+        *descriptor, outcome
+      );
     }
   );
 }

--- a/src/render/opengl/opengl_texture_session.cpp
+++ b/src/render/opengl/opengl_texture_session.cpp
@@ -278,8 +278,11 @@ class OpenGLTextureBackend final : public mbgl::gl::RendererBackend,
   // getDefaultRenderable() does once the resource is gone.
   void set_borrowed_texture(uint32_t texture, mbgl::Size new_size) {
     borrowed_texture_ = texture;
-    // Deleting the framebuffer is a GL call like any other.
-    auto guard = mbgl::gfx::BackendScope{*this};
+    // setSize() drops the renderable unconditionally, which is what rebuilds
+    // the framebuffer against the new texture even when the size is unchanged.
+    // No context is made current for it: the framebuffer and renderbuffer names
+    // it owns go to the context's abandoned lists and are deleted on the next
+    // render, the same way an owned-texture resize releases them.
     setSize(new_size);
   }
 
@@ -623,6 +626,13 @@ auto opengl_borrowed_texture_set_target(
   mln_render_session session,
   const mln_opengl_borrowed_texture_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::BorrowedTexture, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status =
     validate_opengl_borrowed_texture_descriptor(descriptor, true);
   if (descriptor_status != MLN_STATUS_OK) {
@@ -638,9 +648,9 @@ auto opengl_borrowed_texture_set_target(
     session, RetargetTargetKind::BorrowedTexture, descriptor->extent,
     descriptor->physical_width, descriptor->physical_height,
     [descriptor](
-      mln_render_session_object& live, RetargetOutcome& outcome
+      mln_render_session_object& target_session, RetargetOutcome& outcome
     ) -> mln_status {
-      return live.texture.backend->set_opengl_borrowed_target(
+      return target_session.texture.backend->set_opengl_borrowed_target(
         *descriptor, outcome
       );
     }

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -1199,6 +1199,12 @@ auto render_session_set_target(
       // exception carries on to the C boundary, so the session cannot come back
       // from MLN_STATUS_NATIVE_ERROR still holding pipelines built against a
       // target that no longer exists.
+      //
+      // Backends report the failures they can see coming — a mismatched target,
+      // a query they could not answer — so reaching here means a swap was
+      // already under way. It cannot be unwound: a Vulkan swapchain is gone
+      // before its replacement is built. The session is left for the host to
+      // destroy, which the headers say.
       live->renderer.reset();
       throw;
     }

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -242,19 +242,23 @@ auto vulkan_context_matches(
 
 auto opengl_context_matches(
   const mln_opengl_context_descriptor& lhs,
-  const mln_opengl_context_descriptor& rhs
+  const mln_opengl_context_descriptor& rhs, OpenGLContextMatch strictness
 ) -> bool {
   if (lhs.platform != rhs.platform) {
     return false;
   }
   switch (lhs.platform) {
     case MLN_OPENGL_CONTEXT_PLATFORM_WGL:
-      // The share group alone. A session's WGL context is made current against
-      // whichever HDC the target names, and a recreated window brings a new
-      // one, so an HDC is a surface here rather than a piece of context
-      // identity.
+      if (
+        strictness == OpenGLContextMatch::Exact &&
+        lhs.data.wgl.device_context != rhs.data.wgl.device_context
+      ) {
+        return false;
+      }
       return lhs.data.wgl.share_context == rhs.data.wgl.share_context;
     case MLN_OPENGL_CONTEXT_PLATFORM_EGL:
+      // EGL names its drawable in the target rather than in the context, so
+      // both strictnesses ask for the same three handles.
       return lhs.data.egl.display == rhs.data.egl.display &&
              lhs.data.egl.config == rhs.data.egl.config &&
              lhs.data.egl.share_context == rhs.data.egl.share_context;
@@ -1186,10 +1190,9 @@ auto render_session_set_target(
     return status;
   }
 
-  auto outcome = RetargetOutcome::RendererPreserved;
   const auto replace_status = [&]() -> mln_status {
     try {
-      return replace(*live, outcome);
+      return replace(*live);
     } catch (...) {
       // The backend threw partway through swapping targets, so whatever the
       // renderer caches against may already be gone. Retire it before the
@@ -1213,12 +1216,10 @@ auto render_session_set_target(
   //
   // The same bargain a resize strikes: the renderer carries the tile pyramid,
   // glyph and image atlases, symbol placement, and feature state over to the
-  // new target. It starts over only when its shaders no longer match the pixel
-  // ratio, or when the backend had to rebuild something it caches against.
-  if (
-    extent.scale_factor != live->scale_factor ||
-    outcome == RetargetOutcome::RendererInvalidated
-  ) {
+  // new target. The pixel ratio is the one thing it cannot carry, being fixed
+  // when a renderer is built and baked into its shaders. Anything else the
+  // compiled state would not match was refused above rather than rebuilt here.
+  if (extent.scale_factor != live->scale_factor) {
     live->renderer.reset();
   }
   live->rendered_generation = 0;

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -230,6 +230,40 @@ auto validate_opengl_context(
   return MLN_STATUS_INVALID_ARGUMENT;
 }
 
+auto vulkan_context_matches(
+  const mln_vulkan_context_descriptor& lhs,
+  const mln_vulkan_context_descriptor& rhs
+) -> bool {
+  return lhs.instance == rhs.instance &&
+         lhs.physical_device == rhs.physical_device &&
+         lhs.device == rhs.device && lhs.graphics_queue == rhs.graphics_queue &&
+         lhs.graphics_queue_family_index == rhs.graphics_queue_family_index;
+}
+
+auto opengl_context_matches(
+  const mln_opengl_context_descriptor& lhs,
+  const mln_opengl_context_descriptor& rhs
+) -> bool {
+  if (lhs.platform != rhs.platform) {
+    return false;
+  }
+  switch (lhs.platform) {
+    case MLN_OPENGL_CONTEXT_PLATFORM_WGL:
+      // The share group alone. A session's WGL context is made current against
+      // whichever HDC the target names, and a recreated window brings a new
+      // one, so an HDC is a surface here rather than a piece of context
+      // identity.
+      return lhs.data.wgl.share_context == rhs.data.wgl.share_context;
+    case MLN_OPENGL_CONTEXT_PLATFORM_EGL:
+      return lhs.data.egl.display == rhs.data.egl.display &&
+             lhs.data.egl.config == rhs.data.egl.config &&
+             lhs.data.egl.share_context == rhs.data.egl.share_context;
+    case MLN_OPENGL_CONTEXT_PLATFORM_UNSPECIFIED:
+      break;
+  }
+  return false;
+}
+
 }  // namespace mln::core
 
 namespace mln::core {
@@ -1063,9 +1097,7 @@ auto render_session_resize(
   if (live->kind == RenderSessionKind::Surface) {
     live->surface.backend->resize(physical_width, physical_height);
   } else {
-    live->texture.backend->headless_backend().setSize(
-      mbgl::Size{physical_width, physical_height}
-    );
+    live->texture.backend->resize(mbgl::Size{physical_width, physical_height});
     live->texture.rendered_native_texture = nullptr;
     live->texture.acquired_native_texture = nullptr;
     live->texture.acquired_frame_kind = TextureSessionFrameKind::None;
@@ -1075,7 +1107,19 @@ auto render_session_resize(
     return size_status;
   }
   warn_on_scale_factor_mismatch(live->map, scale_factor);
-  live->renderer.reset();
+  // Keep the renderer. mbgl::Renderer reads the backend renderable's size at
+  // the top of every frame, so a resized target is all it needs, and holding on
+  // to it carries the tile pyramid, glyph and image atlases, symbol placement,
+  // and feature state across the resize instead of rebuilding them cold.
+  //
+  // The backends hold up the other half of this bargain: a resize preserves
+  // whatever the renderer keys cached GPU state against, which on Vulkan means
+  // the render pass. Pixel ratio is the exception, fixed when a Renderer is
+  // constructed and baked into its shaders, so a scale factor change is the one
+  // resize that still starts over.
+  if (scale_factor != live->scale_factor) {
+    live->renderer.reset();
+  }
   live->rendered_generation = 0;
   live->width = width;
   live->height = height;
@@ -1084,6 +1128,104 @@ auto render_session_resize(
   live->scale_factor = scale_factor;
   ++live->generation;
   return MLN_STATUS_OK;
+}
+
+auto unsupported_retarget(const char* message) -> mln_status {
+  set_thread_error(message);
+  return MLN_STATUS_UNSUPPORTED;
+}
+
+auto render_session_set_target(
+  mln_render_session session, RetargetTargetKind kind,
+  const mln_render_target_extent& extent, uint32_t physical_width,
+  uint32_t physical_height, const RenderTargetReplacer& replace
+) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto status = validate_live_attached_render_session(session, live);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  if (kind == RetargetTargetKind::Surface) {
+    if (live->kind != RenderSessionKind::Surface) {
+      return unsupported_retarget(
+        "session does not render through a native surface"
+      );
+    }
+  } else {
+    if (live->kind != RenderSessionKind::Texture) {
+      return unsupported_retarget(
+        "session does not render into a caller-owned texture"
+      );
+    }
+    if (live->texture.acquired) {
+      set_thread_error(
+        "cannot replace the render target while a texture frame is acquired"
+      );
+      return MLN_STATUS_INVALID_STATE;
+    }
+    if (live->texture.mode != TextureSessionMode::Borrowed) {
+      return unsupported_retarget(
+        "a session-owned texture is sized and replaced by its session; resize "
+        "it instead"
+      );
+    }
+  }
+
+  auto outcome = RetargetOutcome::RendererPreserved;
+  const auto replace_status = replace(*live, outcome);
+  if (replace_status != MLN_STATUS_OK) {
+    return replace_status;
+  }
+
+  const auto size_status =
+    map_post_set_size(live->map, extent.width, extent.height);
+  if (size_status != MLN_STATUS_OK) {
+    return size_status;
+  }
+  warn_on_scale_factor_mismatch(live->map, extent.scale_factor);
+
+  // The same bargain a resize strikes: the renderer carries the tile pyramid,
+  // glyph and image atlases, symbol placement, and feature state over to the
+  // new target. It starts over only when its shaders no longer match the pixel
+  // ratio, or when the backend had to rebuild something it caches against.
+  if (
+    extent.scale_factor != live->scale_factor ||
+    outcome == RetargetOutcome::RendererInvalidated
+  ) {
+    live->renderer.reset();
+  }
+  live->rendered_generation = 0;
+  live->width = extent.width;
+  live->height = extent.height;
+  live->physical_width = physical_width;
+  live->physical_height = physical_height;
+  live->scale_factor = extent.scale_factor;
+  if (live->kind == RenderSessionKind::Texture) {
+    live->texture.rendered_native_texture = nullptr;
+    live->texture.acquired_native_texture = nullptr;
+    live->texture.acquired_frame_kind = TextureSessionFrameKind::None;
+  }
+  ++live->generation;
+  return MLN_STATUS_OK;
+}
+
+auto surface_session_set_target(
+  mln_render_session session, const mln_render_target_extent& extent,
+  const RenderTargetReplacer& replace
+) -> mln_status {
+  const auto physical_status = validate_physical_size(
+    extent.width, extent.height, extent.scale_factor,
+    "scaled surface dimensions are too large"
+  );
+  if (physical_status != MLN_STATUS_OK) {
+    return physical_status;
+  }
+  return render_session_set_target(
+    session, RetargetTargetKind::Surface, extent,
+    physical_dimension(extent.width, extent.scale_factor),
+    physical_dimension(extent.height, extent.scale_factor), replace
+  );
 }
 
 auto render_session_render_update(

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -1078,7 +1078,8 @@ auto render_session_resize(
     live->texture.mode == TextureSessionMode::Borrowed
   ) {
     set_thread_error(
-      "borrowed texture sessions cannot be resized; attach a new target"
+      "a caller-owned texture is sized by its owner; hand over a replacement "
+      "with the borrowed-texture set_target function for this backend"
     );
     return MLN_STATUS_UNSUPPORTED;
   }
@@ -1135,56 +1136,81 @@ auto unsupported_retarget(const char* message) -> mln_status {
   return MLN_STATUS_UNSUPPORTED;
 }
 
+auto validate_render_session_retarget(
+  mln_render_session session, RetargetTargetKind kind,
+  mln_render_session_object*& out_session
+) -> mln_status {
+  const auto status =
+    validate_live_attached_render_session(session, out_session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  if (kind == RetargetTargetKind::Surface) {
+    if (out_session->kind != RenderSessionKind::Surface) {
+      return unsupported_retarget(
+        "session does not render through a native surface"
+      );
+    }
+    return MLN_STATUS_OK;
+  }
+
+  if (out_session->kind != RenderSessionKind::Texture) {
+    return unsupported_retarget(
+      "session does not render into a caller-owned texture"
+    );
+  }
+  if (out_session->texture.acquired) {
+    set_thread_error(
+      "cannot replace the render target while a texture frame is acquired"
+    );
+    return MLN_STATUS_INVALID_STATE;
+  }
+  if (out_session->texture.mode != TextureSessionMode::Borrowed) {
+    return unsupported_retarget(
+      "a session-owned texture is sized and replaced by its session; resize it "
+      "instead"
+    );
+  }
+  return MLN_STATUS_OK;
+}
+
 auto render_session_set_target(
   mln_render_session session, RetargetTargetKind kind,
   const mln_render_target_extent& extent, uint32_t physical_width,
   uint32_t physical_height, const RenderTargetReplacer& replace
 ) -> mln_status {
   mln_render_session_object* live = nullptr;
-  const auto status = validate_live_attached_render_session(session, live);
+  const auto status = validate_render_session_retarget(session, kind, live);
   if (status != MLN_STATUS_OK) {
     return status;
   }
 
-  if (kind == RetargetTargetKind::Surface) {
-    if (live->kind != RenderSessionKind::Surface) {
-      return unsupported_retarget(
-        "session does not render through a native surface"
-      );
-    }
-  } else {
-    if (live->kind != RenderSessionKind::Texture) {
-      return unsupported_retarget(
-        "session does not render into a caller-owned texture"
-      );
-    }
-    if (live->texture.acquired) {
-      set_thread_error(
-        "cannot replace the render target while a texture frame is acquired"
-      );
-      return MLN_STATUS_INVALID_STATE;
-    }
-    if (live->texture.mode != TextureSessionMode::Borrowed) {
-      return unsupported_retarget(
-        "a session-owned texture is sized and replaced by its session; resize "
-        "it instead"
-      );
-    }
-  }
-
   auto outcome = RetargetOutcome::RendererPreserved;
-  const auto replace_status = replace(*live, outcome);
+  const auto replace_status = [&]() -> mln_status {
+    try {
+      return replace(*live, outcome);
+    } catch (...) {
+      // The backend threw partway through swapping targets, so whatever the
+      // renderer caches against may already be gone. Retire it before the
+      // exception carries on to the C boundary, so the session cannot come back
+      // from MLN_STATUS_NATIVE_ERROR still holding pipelines built against a
+      // target that no longer exists.
+      live->renderer.reset();
+      throw;
+    }
+  }();
+  // Backends validate before they touch anything, so a reported failure leaves
+  // the target and the renderer as they were.
   if (replace_status != MLN_STATUS_OK) {
     return replace_status;
   }
 
-  const auto size_status =
-    map_post_set_size(live->map, extent.width, extent.height);
-  if (size_status != MLN_STATUS_OK) {
-    return size_status;
-  }
-  warn_on_scale_factor_mismatch(live->map, extent.scale_factor);
-
+  // Land the session's own bookkeeping before anything that can fail again.
+  // Everything past this point describes the target the backend now holds, so a
+  // later failure leaves a session that is merely waiting for the map to catch
+  // up, which is the same state an ordinary resize passes through.
+  //
   // The same bargain a resize strikes: the renderer carries the tile pyramid,
   // glyph and image atlases, symbol placement, and feature state over to the
   // new target. It starts over only when its shaders no longer match the pixel
@@ -1207,6 +1233,13 @@ auto render_session_set_target(
     live->texture.acquired_frame_kind = TextureSessionFrameKind::None;
   }
   ++live->generation;
+
+  const auto size_status =
+    map_post_set_size(live->map, extent.width, extent.height);
+  if (size_status != MLN_STATUS_OK) {
+    return size_status;
+  }
+  warn_on_scale_factor_mismatch(live->map, extent.scale_factor);
   return MLN_STATUS_OK;
 }
 

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -523,6 +523,19 @@ auto render_session_resize(
 
 enum class RetargetTargetKind : uint8_t { Surface, BorrowedTexture };
 
+// Checks that a session can take a replacement target of this kind, before any
+// descriptor is looked at.
+//
+// Entry points call this first so a retired handle, a foreign thread, or a
+// session of the wrong kind reports what it is, rather than whatever the
+// descriptor happened to be missing. This runs even in builds whose answer is
+// "that backend is not compiled in", so the status a caller gets does not
+// depend on which failure the build happens to notice first.
+auto validate_render_session_retarget(
+  mln_render_session session, RetargetTargetKind kind,
+  mln_render_session_object*& out_session
+) -> mln_status;
+
 // Hands a validated descriptor to the session's backend.
 using RenderTargetReplacer =
   std::function<mln_status(mln_render_session_object&, RetargetOutcome&)>;

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -14,6 +14,7 @@
 #include <mbgl/gfx/headless_backend.hpp>
 #include <mbgl/gfx/renderer_backend.hpp>
 #include <mbgl/renderer/renderer.hpp>
+#include <mbgl/util/size.hpp>
 
 #include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
@@ -32,6 +33,22 @@ enum class TextureSessionFrameKind : uint8_t {
 };
 enum class TextureSessionMode : uint8_t { Owned, Borrowed };
 
+// Whether replacing a render target left the renderer's cached GPU state
+// usable.
+//
+// A host target can be replaced by one the backend cannot serve from the same
+// resources: on Vulkan a surface whose swapchain reports a different color
+// format, or a borrowed image with a different format or layout, forces a new
+// render pass, and mbgl keys its pipeline cache on that. The backend says so,
+// and the session builds a new renderer rather than letting a stale key decide
+// which pipeline a draw gets.
+enum class RetargetOutcome : uint8_t { RendererPreserved, RendererInvalidated };
+
+// Reports a target replacement the backend does not implement. Every backend
+// serves exactly one descriptor kind, and the session checks that before
+// dispatching, so reaching a default is a mismatch the caller can fix.
+auto unsupported_retarget(const char* message) -> mln_status;
+
 class SurfaceSessionBackend {
  public:
   SurfaceSessionBackend() = default;
@@ -44,6 +61,40 @@ class SurfaceSessionBackend {
 
   virtual auto renderer_backend() -> mbgl::gfx::RendererBackend& = 0;
   virtual void resize(uint32_t physical_width, uint32_t physical_height) = 0;
+
+  // Presents through a new host surface, keeping the graphics context and every
+  // resource the renderer holds against it. The descriptor names the same
+  // context as the one this session attached with; a backend rejects anything
+  // else, because a context change is what destroy-and-attach is for.
+  virtual auto set_metal_target(
+    const mln_metal_surface_descriptor& descriptor, RetargetOutcome& out_outcome
+  ) -> mln_status {
+    (void)descriptor;
+    (void)out_outcome;
+    return unsupported_retarget(
+      "session does not render through a Metal surface"
+    );
+  }
+  virtual auto set_vulkan_target(
+    const mln_vulkan_surface_descriptor& descriptor,
+    RetargetOutcome& out_outcome
+  ) -> mln_status {
+    (void)descriptor;
+    (void)out_outcome;
+    return unsupported_retarget(
+      "session does not render through a Vulkan surface"
+    );
+  }
+  virtual auto set_opengl_target(
+    const mln_opengl_surface_descriptor& descriptor,
+    RetargetOutcome& out_outcome
+  ) -> mln_status {
+    (void)descriptor;
+    (void)out_outcome;
+    return unsupported_retarget(
+      "session does not render through an OpenGL surface"
+    );
+  }
 };
 
 class TextureSessionBackend {
@@ -60,6 +111,47 @@ class TextureSessionBackend {
   virtual auto renderer_backend() -> mbgl::gfx::RendererBackend* {
     return headless_backend().getRendererBackend();
   }
+  // Follows a new physical size. The default drops the renderable resource and
+  // rebuilds it lazily, which suits backends that cache nothing across it. A
+  // backend whose renderer keys cached GPU state on part of that resource
+  // overrides this to rebuild only what the size actually changed.
+  virtual void resize(mbgl::Size size) { headless_backend().setSize(size); }
+
+  // Renders into a new caller-owned texture, keeping the graphics context and
+  // every resource the renderer holds against it. The descriptor names the same
+  // context as the one this session attached with; a backend rejects anything
+  // else, because a context change is what destroy-and-attach is for.
+  virtual auto set_metal_borrowed_target(
+    const mln_metal_borrowed_texture_descriptor& descriptor,
+    RetargetOutcome& out_outcome
+  ) -> mln_status {
+    (void)descriptor;
+    (void)out_outcome;
+    return unsupported_retarget(
+      "session does not render into a caller-owned Metal texture"
+    );
+  }
+  virtual auto set_vulkan_borrowed_target(
+    const mln_vulkan_borrowed_texture_descriptor& descriptor,
+    RetargetOutcome& out_outcome
+  ) -> mln_status {
+    (void)descriptor;
+    (void)out_outcome;
+    return unsupported_retarget(
+      "session does not render into a caller-owned Vulkan image"
+    );
+  }
+  virtual auto set_opengl_borrowed_target(
+    const mln_opengl_borrowed_texture_descriptor& descriptor,
+    RetargetOutcome& out_outcome
+  ) -> mln_status {
+    (void)descriptor;
+    (void)out_outcome;
+    return unsupported_retarget(
+      "session does not render into a caller-owned OpenGL texture"
+    );
+  }
+
   virtual void prepare_render_resources() {}
   virtual auto after_render(
     mln_render_session_object& session, bool& out_rendered
@@ -349,6 +441,23 @@ auto validate_opengl_context(
   const mln_opengl_context_descriptor& context, bool require_supported_provider
 ) -> mln_status;
 
+// Whether two Vulkan context descriptors name the same device and queue, which
+// is what lets a session keep every resource the renderer allocated on it
+// across a target replacement.
+auto vulkan_context_matches(
+  const mln_vulkan_context_descriptor& lhs,
+  const mln_vulkan_context_descriptor& rhs
+) -> bool;
+
+// Whether two OpenGL context descriptors name the same host context, which is
+// what lets a session keep its own context — and every object the renderer
+// holds in it — across a target replacement. The proc-address loader is left
+// out: it is a way to reach a context, not part of its identity.
+auto opengl_context_matches(
+  const mln_opengl_context_descriptor& lhs,
+  const mln_opengl_context_descriptor& rhs
+) -> bool;
+
 inline auto set_session_extent(
   mln_render_session_object& session, const mln_render_target_extent& extent
 ) -> void {
@@ -410,6 +519,35 @@ auto attach_render_session(
 auto render_session_resize(
   mln_render_session session, uint32_t width, uint32_t height,
   double scale_factor
+) -> mln_status;
+
+enum class RetargetTargetKind : uint8_t { Surface, BorrowedTexture };
+
+// Hands a validated descriptor to the session's backend.
+using RenderTargetReplacer =
+  std::function<mln_status(mln_render_session_object&, RetargetOutcome&)>;
+
+// Shared body behind every set-target entry point.
+//
+// Checks that the session is live, attached, owned by this thread, and of the
+// kind the descriptor targets, then calls `replace` to hand the descriptor to
+// the backend. On success the session takes the new extent, the map is resized
+// to match, and the renderer is kept unless the scale factor changed or the
+// backend reported that it rebuilt state the renderer caches against.
+//
+// The per-backend entry point validates its own descriptor first, including
+// that the graphics context is the one the session attached with.
+auto render_session_set_target(
+  mln_render_session session, RetargetTargetKind kind,
+  const mln_render_target_extent& extent, uint32_t physical_width,
+  uint32_t physical_height, const RenderTargetReplacer& replace
+) -> mln_status;
+
+// render_session_set_target() for a surface, whose physical size follows from
+// its logical extent rather than being stated by the caller.
+auto surface_session_set_target(
+  mln_render_session session, const mln_render_target_extent& extent,
+  const RenderTargetReplacer& replace
 ) -> mln_status;
 auto render_session_render_update(
   mln_render_session session, bool* out_rendered

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -33,16 +33,19 @@ enum class TextureSessionFrameKind : uint8_t {
 };
 enum class TextureSessionMode : uint8_t { Owned, Borrowed };
 
-// Whether replacing a render target left the renderer's cached GPU state
-// usable.
+// A replacement target that the session's compiled GPU state cannot serve is
+// refused rather than accepted with a rebuild.
 //
-// A host target can be replaced by one the backend cannot serve from the same
-// resources: on Vulkan a surface whose swapchain reports a different color
-// format, or a borrowed image with a different format or layout, forces a new
-// render pass, and mbgl keys its pipeline cache on that. The backend says so,
-// and the session builds a new renderer rather than letting a stale key decide
-// which pipeline a draw gets.
-enum class RetargetOutcome : uint8_t { RendererPreserved, RendererInvalidated };
+// The state in question is not all owned by the renderer. mbgl's Vulkan
+// pipeline cache lives in the renderer's shader registry, but the Metal context
+// caches a clip-mask pipeline keyed only on the renderable's address, and both
+// backends compile shader variants against properties of the target. Retiring
+// the renderer would leave the context's share of that behind, so a target that
+// does not match what is already compiled is reported as unsupported and the
+// host destroys the session and attaches again, which rebuilds all of it.
+//
+// Backends check this before they touch anything, so a refusal leaves the
+// session rendering into the target it already had.
 
 // Reports a target replacement the backend does not implement. Every backend
 // serves exactly one descriptor kind, and the session checks that before
@@ -66,31 +69,25 @@ class SurfaceSessionBackend {
   // resource the renderer holds against it. The descriptor names the same
   // context as the one this session attached with; a backend rejects anything
   // else, because a context change is what destroy-and-attach is for.
-  virtual auto set_metal_target(
-    const mln_metal_surface_descriptor& descriptor, RetargetOutcome& out_outcome
-  ) -> mln_status {
+  virtual auto set_metal_target(const mln_metal_surface_descriptor& descriptor)
+    -> mln_status {
     (void)descriptor;
-    (void)out_outcome;
     return unsupported_retarget(
       "session does not render through a Metal surface"
     );
   }
   virtual auto set_vulkan_target(
-    const mln_vulkan_surface_descriptor& descriptor,
-    RetargetOutcome& out_outcome
+    const mln_vulkan_surface_descriptor& descriptor
   ) -> mln_status {
     (void)descriptor;
-    (void)out_outcome;
     return unsupported_retarget(
       "session does not render through a Vulkan surface"
     );
   }
   virtual auto set_opengl_target(
-    const mln_opengl_surface_descriptor& descriptor,
-    RetargetOutcome& out_outcome
+    const mln_opengl_surface_descriptor& descriptor
   ) -> mln_status {
     (void)descriptor;
-    (void)out_outcome;
     return unsupported_retarget(
       "session does not render through an OpenGL surface"
     );
@@ -122,31 +119,25 @@ class TextureSessionBackend {
   // context as the one this session attached with; a backend rejects anything
   // else, because a context change is what destroy-and-attach is for.
   virtual auto set_metal_borrowed_target(
-    const mln_metal_borrowed_texture_descriptor& descriptor,
-    RetargetOutcome& out_outcome
+    const mln_metal_borrowed_texture_descriptor& descriptor
   ) -> mln_status {
     (void)descriptor;
-    (void)out_outcome;
     return unsupported_retarget(
       "session does not render into a caller-owned Metal texture"
     );
   }
   virtual auto set_vulkan_borrowed_target(
-    const mln_vulkan_borrowed_texture_descriptor& descriptor,
-    RetargetOutcome& out_outcome
+    const mln_vulkan_borrowed_texture_descriptor& descriptor
   ) -> mln_status {
     (void)descriptor;
-    (void)out_outcome;
     return unsupported_retarget(
       "session does not render into a caller-owned Vulkan image"
     );
   }
   virtual auto set_opengl_borrowed_target(
-    const mln_opengl_borrowed_texture_descriptor& descriptor,
-    RetargetOutcome& out_outcome
+    const mln_opengl_borrowed_texture_descriptor& descriptor
   ) -> mln_status {
     (void)descriptor;
-    (void)out_outcome;
     return unsupported_retarget(
       "session does not render into a caller-owned OpenGL texture"
     );
@@ -449,13 +440,23 @@ auto vulkan_context_matches(
   const mln_vulkan_context_descriptor& rhs
 ) -> bool;
 
-// Whether two OpenGL context descriptors name the same host context, which is
-// what lets a session keep its own context — and every object the renderer
-// holds in it — across a target replacement. The proc-address loader is left
-// out: it is a way to reach a context, not part of its identity.
+// How strictly two OpenGL context descriptors have to agree for a session to
+// keep its own context — and every object the renderer holds in it — across a
+// target replacement.
+//
+// A surface target carries its own drawable, so only the share group has to
+// match: WGL makes the session's context current against whichever HDC the
+// target names, and a recreated window brings a new one. A texture target
+// carries no drawable, so the session keeps making its context current against
+// the handles it attached with, and those have to be the same ones.
+enum class OpenGLContextMatch : uint8_t { ShareGroup, Exact };
+
+// Whether two OpenGL context descriptors name the same host context. The
+// proc-address loader is left out either way: it is a way to reach a context,
+// not part of its identity.
 auto opengl_context_matches(
   const mln_opengl_context_descriptor& lhs,
-  const mln_opengl_context_descriptor& rhs
+  const mln_opengl_context_descriptor& rhs, OpenGLContextMatch strictness
 ) -> bool;
 
 inline auto set_session_extent(
@@ -538,7 +539,7 @@ auto validate_render_session_retarget(
 
 // Hands a validated descriptor to the session's backend.
 using RenderTargetReplacer =
-  std::function<mln_status(mln_render_session_object&, RetargetOutcome&)>;
+  std::function<mln_status(mln_render_session_object&)>;
 
 // Shared body behind every set-target entry point.
 //

--- a/src/render/surface_session.hpp
+++ b/src/render/surface_session.hpp
@@ -43,5 +43,14 @@ auto opengl_surface_attach(
   mln_map map, const mln_opengl_surface_descriptor* descriptor,
   mln_render_session* out_session
 ) -> mln_status;
+auto metal_surface_set_target(
+  mln_render_session session, const mln_metal_surface_descriptor* descriptor
+) -> mln_status;
+auto vulkan_surface_set_target(
+  mln_render_session session, const mln_vulkan_surface_descriptor* descriptor
+) -> mln_status;
+auto opengl_surface_set_target(
+  mln_render_session session, const mln_opengl_surface_descriptor* descriptor
+) -> mln_status;
 
 }  // namespace mln::core

--- a/src/render/texture_session.hpp
+++ b/src/render/texture_session.hpp
@@ -78,6 +78,18 @@ auto opengl_borrowed_texture_attach(
   mln_map map, const mln_opengl_borrowed_texture_descriptor* descriptor,
   mln_render_session* out_session
 ) -> mln_status;
+auto metal_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_metal_borrowed_texture_descriptor* descriptor
+) -> mln_status;
+auto vulkan_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_vulkan_borrowed_texture_descriptor* descriptor
+) -> mln_status;
+auto opengl_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_opengl_borrowed_texture_descriptor* descriptor
+) -> mln_status;
 auto texture_read_premultiplied_rgba8(
   mln_render_session texture, uint8_t* out_data, size_t out_data_capacity,
   mln_texture_image_info* out_info

--- a/src/render/unsupported_sessions.cpp
+++ b/src/render/unsupported_sessions.cpp
@@ -179,6 +179,31 @@ auto metal_owned_texture_release_frame(
   return MLN_STATUS_UNSUPPORTED;
 }
 
+auto metal_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_metal_borrowed_texture_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status = validate_metal_borrowed_texture_descriptor(descriptor);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  static_cast<void>(session);
+  set_thread_error("Metal texture sessions are not supported by this build");
+  return MLN_STATUS_UNSUPPORTED;
+}
+
+auto metal_surface_set_target(
+  mln_render_session session, const mln_metal_surface_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status = validate_metal_surface_descriptor(descriptor);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  static_cast<void>(session);
+  set_thread_error("Metal surface sessions are not supported by this build");
+  return MLN_STATUS_UNSUPPORTED;
+}
+
 #endif
 
 #if !defined(MLN_RENDER_BACKEND_VULKAN)
@@ -282,6 +307,32 @@ auto vulkan_owned_texture_release_frame(
     return status;
   }
   set_thread_error("Vulkan texture sessions are not supported by this build");
+  return MLN_STATUS_UNSUPPORTED;
+}
+
+auto vulkan_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_vulkan_borrowed_texture_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status =
+    validate_vulkan_borrowed_texture_descriptor(descriptor);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  static_cast<void>(session);
+  set_thread_error("Vulkan texture sessions are not supported by this build");
+  return MLN_STATUS_UNSUPPORTED;
+}
+
+auto vulkan_surface_set_target(
+  mln_render_session session, const mln_vulkan_surface_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status = validate_vulkan_surface_descriptor(descriptor);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  static_cast<void>(session);
+  set_thread_error("Vulkan surface sessions are not supported by this build");
   return MLN_STATUS_UNSUPPORTED;
 }
 
@@ -389,6 +440,33 @@ auto opengl_owned_texture_release_frame(
     return status;
   }
   set_thread_error("OpenGL texture sessions are not supported by this build");
+  return MLN_STATUS_UNSUPPORTED;
+}
+
+auto opengl_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_opengl_borrowed_texture_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status =
+    validate_opengl_borrowed_texture_descriptor(descriptor, false);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  static_cast<void>(session);
+  set_thread_error("OpenGL texture sessions are not supported by this build");
+  return MLN_STATUS_UNSUPPORTED;
+}
+
+auto opengl_surface_set_target(
+  mln_render_session session, const mln_opengl_surface_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status =
+    validate_opengl_surface_descriptor(descriptor, false);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  static_cast<void>(session);
+  set_thread_error("OpenGL surface sessions are not supported by this build");
   return MLN_STATUS_UNSUPPORTED;
 }
 

--- a/src/render/unsupported_sessions.cpp
+++ b/src/render/unsupported_sessions.cpp
@@ -183,11 +183,17 @@ auto metal_borrowed_texture_set_target(
   mln_render_session session,
   const mln_metal_borrowed_texture_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::BorrowedTexture, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status = validate_metal_borrowed_texture_descriptor(descriptor);
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  static_cast<void>(session);
   set_thread_error("Metal texture sessions are not supported by this build");
   return MLN_STATUS_UNSUPPORTED;
 }
@@ -195,11 +201,17 @@ auto metal_borrowed_texture_set_target(
 auto metal_surface_set_target(
   mln_render_session session, const mln_metal_surface_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::Surface, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status = validate_metal_surface_descriptor(descriptor);
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  static_cast<void>(session);
   set_thread_error("Metal surface sessions are not supported by this build");
   return MLN_STATUS_UNSUPPORTED;
 }
@@ -314,12 +326,18 @@ auto vulkan_borrowed_texture_set_target(
   mln_render_session session,
   const mln_vulkan_borrowed_texture_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::BorrowedTexture, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status =
     validate_vulkan_borrowed_texture_descriptor(descriptor);
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  static_cast<void>(session);
   set_thread_error("Vulkan texture sessions are not supported by this build");
   return MLN_STATUS_UNSUPPORTED;
 }
@@ -327,11 +345,17 @@ auto vulkan_borrowed_texture_set_target(
 auto vulkan_surface_set_target(
   mln_render_session session, const mln_vulkan_surface_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::Surface, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status = validate_vulkan_surface_descriptor(descriptor);
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  static_cast<void>(session);
   set_thread_error("Vulkan surface sessions are not supported by this build");
   return MLN_STATUS_UNSUPPORTED;
 }
@@ -447,12 +471,18 @@ auto opengl_borrowed_texture_set_target(
   mln_render_session session,
   const mln_opengl_borrowed_texture_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::BorrowedTexture, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status =
     validate_opengl_borrowed_texture_descriptor(descriptor, false);
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  static_cast<void>(session);
   set_thread_error("OpenGL texture sessions are not supported by this build");
   return MLN_STATUS_UNSUPPORTED;
 }
@@ -460,12 +490,18 @@ auto opengl_borrowed_texture_set_target(
 auto opengl_surface_set_target(
   mln_render_session session, const mln_opengl_surface_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::Surface, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status =
     validate_opengl_surface_descriptor(descriptor, false);
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  static_cast<void>(session);
   set_thread_error("OpenGL surface sessions are not supported by this build");
   return MLN_STATUS_UNSUPPORTED;
 }

--- a/src/render/unsupported_sessions.cpp
+++ b/src/render/unsupported_sessions.cpp
@@ -190,7 +190,8 @@ auto metal_borrowed_texture_set_target(
   if (session_status != MLN_STATUS_OK) {
     return session_status;
   }
-  const auto descriptor_status = validate_metal_borrowed_texture_descriptor(descriptor);
+  const auto descriptor_status =
+    validate_metal_borrowed_texture_descriptor(descriptor);
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }

--- a/src/render/vulkan/vulkan_surface_session.cpp
+++ b/src/render/vulkan/vulkan_surface_session.cpp
@@ -200,18 +200,55 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
 
     void bind() override {}
 
+    // Rebuilds the swapchain and everything sized with it, and deliberately
+    // keeps the render pass. mbgl keys its Vulkan pipeline cache on the render
+    // pass handle, and that cache lives in the renderer's shader registry, so
+    // destroying the pass here would strand every cached pipeline behind a dead
+    // key — and hand a recycled handle a cache hit on a pipeline built for the
+    // pass that used to own it. Attachment formats and layouts do not change
+    // across a resize, so the pass stays correct as it is. This mirrors
+    // mbgl::vulkan::SurfaceRenderableResource::recreateSwapchain(), which
+    // preserves it for the same reason; initRenderPass() is a no-op while it
+    // lives.
     void resize(mbgl::Size size) {
       if (!renderPass) {
         return;
       }
       backend.getDevice()->waitIdle(backend.getDispatcher());
       swapchainFramebuffers.clear();
-      renderPass.reset();
       swapchainImageViews.clear();
       swapchainImages.clear();
       acquireSemaphores.clear();
       presentSemaphores.clear();
       init(size.width, size.height);
+    }
+
+    // Presents through a different host surface from here on. Returns whether
+    // the render pass survived: initSwapchain() picks a color format from the
+    // new surface, and setColorFormat() drops the pass when that format
+    // differs, taking mbgl's pipeline cache with it.
+    auto set_surface(VkSurfaceKHR surface_, mbgl::Size size) -> bool {
+      backend.getDevice()->waitIdle(backend.getDispatcher());
+      swapchainFramebuffers.clear();
+      swapchainImageViews.clear();
+      swapchainImages.clear();
+      acquireSemaphores.clear();
+      presentSemaphores.clear();
+      readTexture.reset();
+      // Before the surface it was created from goes away, and not as an
+      // oldSwapchain for the new one: a swapchain may only be recycled into
+      // another on the same surface.
+      swapchain.reset();
+
+      // The outgoing VkSurfaceKHR belongs to the host, so let go of the wrapper
+      // without running the Vulkan deleter over it.
+      static_cast<void>(surface.release());
+      borrowed_surface = surface_;
+      createPlatformSurface();
+
+      const VkRenderPass previous_pass = renderPass.get();
+      init(size.width, size.height);
+      return renderPass.get() == previous_pass;
     }
 
    private:
@@ -256,6 +293,34 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
     if (resource) {
       getResource<VulkanSurfaceRenderableResource>().resize(size);
     }
+  }
+
+  // Returns whether the renderer's cached state survives, which on Vulkan comes
+  // down to whether the render pass did.
+  auto set_surface(const mln_vulkan_surface_descriptor& descriptor) -> bool {
+    const auto new_size = mbgl::Size{
+      mln::core::physical_dimension(
+        descriptor.extent.width, descriptor.extent.scale_factor
+      ),
+      mln::core::physical_dimension(
+        descriptor.extent.height, descriptor.extent.scale_factor
+      )
+    };
+    descriptor_.surface = descriptor.surface;
+    mbgl::vulkan::Renderable::setSize(new_size);
+    // Nothing has been built yet, so the lazy path already takes the new
+    // surface: the wrapper is created against descriptor_ on first use.
+    if (!resource) {
+      return true;
+    }
+    return getResource<VulkanSurfaceRenderableResource>().set_surface(
+      static_cast<VkSurfaceKHR>(descriptor.surface), new_size
+    );
+  }
+
+  [[nodiscard]] auto context_descriptor() const
+    -> const mln_vulkan_context_descriptor& {
+    return descriptor_.context;
   }
 
   void activate() override {}
@@ -347,6 +412,29 @@ class VulkanSurfaceSessionBackend final
     backend_.resize(mbgl::Size{physical_width, physical_height});
   }
 
+  auto set_vulkan_target(
+    const mln_vulkan_surface_descriptor& descriptor,
+    mln::core::RetargetOutcome& out_outcome
+  ) -> mln_status override {
+    if (!mln::core::vulkan_context_matches(
+          backend_.context_descriptor(), descriptor.context
+        )) {
+      mln::core::set_thread_error(
+        "Vulkan surface target must name the instance, physical device, "
+        "device, and graphics queue this session attached with"
+      );
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+    const auto handles_status = validate_vulkan_handles(descriptor);
+    if (handles_status != MLN_STATUS_OK) {
+      return handles_status;
+    }
+    out_outcome = backend_.set_surface(descriptor)
+                    ? mln::core::RetargetOutcome::RendererPreserved
+                    : mln::core::RetargetOutcome::RendererInvalidated;
+    return MLN_STATUS_OK;
+  }
+
  private:
   VulkanSurfaceBackend backend_;
 };
@@ -399,6 +487,23 @@ auto vulkan_surface_attach(
       .null_session = "surface session must not be null",
       .null_output = "out_session must not be null",
       .non_null_output = "out_session must point to a null handle"
+    }
+  );
+}
+
+auto vulkan_surface_set_target(
+  mln_render_session session, const mln_vulkan_surface_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status = validate_vulkan_surface_descriptor(descriptor);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  return surface_session_set_target(
+    session, descriptor->extent,
+    [descriptor](
+      mln_render_session_object& live, RetargetOutcome& outcome
+    ) -> mln_status {
+      return live.surface.backend->set_vulkan_target(*descriptor, outcome);
     }
   );
 }

--- a/src/render/vulkan/vulkan_surface_session.cpp
+++ b/src/render/vulkan/vulkan_surface_session.cpp
@@ -388,12 +388,12 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
   // pre-rotated display, and mbgl::Renderer reads its viewport and scissor from
   // the renderable's size. mbgl::vulkan::RendererBackend::initSwapchain() does
   // the same after building a swapchain of its own.
+  // Only the width and height swap is tied to surface transform support. A
+  // fixed currentExtent and the min/max clamp apply to every surface, so the
+  // extent is taken whatever the transform support is.
   void adopt_swapchain_extent() {
     const auto& renderable_resource =
       getResource<VulkanSurfaceRenderableResource>();
-    if (!renderable_resource.hasSurfaceTransformSupport()) {
-      return;
-    }
     const auto& extent = renderable_resource.getExtent();
     mbgl::vulkan::Renderable::setSize({extent.width, extent.height});
   }

--- a/src/render/vulkan/vulkan_surface_session.cpp
+++ b/src/render/vulkan/vulkan_surface_session.cpp
@@ -227,6 +227,15 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
     // the render pass survived: initSwapchain() picks a color format from the
     // new surface, and setColorFormat() drops the pass when that format
     // differs, taking mbgl's pipeline cache with it.
+    //
+    // The answer comes from comparing the color format by value rather than
+    // comparing VkRenderPass handles across the rebuild. A destroyed handle is
+    // free to come back with the same value from the next create call, and
+    // mbgl's pipeline cache is a bare hash map over that value with no equality
+    // check behind it, so a recycled handle would hand the new pass every
+    // pipeline built for the old one. Color format is the only input to
+    // initRenderPass() that a replacement surface can change; the depth format
+    // follows from the physical device, which does not change here.
     auto set_surface(VkSurfaceKHR surface_, mbgl::Size size) -> bool {
       backend.getDevice()->waitIdle(backend.getDispatcher());
       swapchainFramebuffers.clear();
@@ -246,9 +255,9 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
       borrowed_surface = surface_;
       createPlatformSurface();
 
-      const VkRenderPass previous_pass = renderPass.get();
+      const auto previous_format = colorFormat;
       init(size.width, size.height);
-      return renderPass.get() == previous_pass;
+      return colorFormat == previous_format;
     }
 
    private:
@@ -494,6 +503,13 @@ auto vulkan_surface_attach(
 auto vulkan_surface_set_target(
   mln_render_session session, const mln_vulkan_surface_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::Surface, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status = validate_vulkan_surface_descriptor(descriptor);
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
@@ -501,9 +517,11 @@ auto vulkan_surface_set_target(
   return surface_session_set_target(
     session, descriptor->extent,
     [descriptor](
-      mln_render_session_object& live, RetargetOutcome& outcome
+      mln_render_session_object& target_session, RetargetOutcome& outcome
     ) -> mln_status {
-      return live.surface.backend->set_vulkan_target(*descriptor, outcome);
+      return target_session.surface.backend->set_vulkan_target(
+        *descriptor, outcome
+      );
     }
   );
 }

--- a/src/render/vulkan/vulkan_surface_session.cpp
+++ b/src/render/vulkan/vulkan_surface_session.cpp
@@ -354,16 +354,23 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
         descriptor.extent.height, descriptor.extent.scale_factor
       )
     };
-    descriptor_.surface = descriptor.surface;
-    mbgl::vulkan::Renderable::setSize(new_size);
     // Nothing has been built yet, so the lazy path already takes the new
     // surface: the wrapper is created against descriptor_ on first use.
     if (!resource) {
+      descriptor_.surface = descriptor.surface;
+      mbgl::vulkan::Renderable::setSize(new_size);
       return;
     }
+    // The resource first, then this backend's own view of the target. Building
+    // a swapchain can throw, and recording the surface before that would leave
+    // the backend naming a target it does not have. The resource cannot be
+    // unwound either way once it starts — its old swapchain is gone by then —
+    // which is why a throw from here leaves the session for destruction.
     getResource<VulkanSurfaceRenderableResource>().set_surface(
       static_cast<VkSurfaceKHR>(descriptor.surface), new_size
     );
+    descriptor_.surface = descriptor.surface;
+    mbgl::vulkan::Renderable::setSize(new_size);
     adopt_swapchain_extent();
   }
 
@@ -493,7 +500,17 @@ class VulkanSurfaceSessionBackend final
     if (handles_status != MLN_STATUS_OK) {
       return handles_status;
     }
-    if (!backend_.matches_surface(descriptor)) {
+    auto matches = false;
+    try {
+      matches = backend_.matches_surface(descriptor);
+    } catch (const std::exception& exception) {
+      // Reported rather than thrown: nothing has been touched yet, and letting
+      // it escape would put the session through the mid-swap recovery path and
+      // cost it a renderer it could have kept.
+      mln::core::set_thread_error(exception);
+      return MLN_STATUS_NATIVE_ERROR;
+    }
+    if (!matches) {
       return mln::core::unsupported_retarget(
         "Vulkan surface target must report the color format and surface "
         "transform support this session compiled its render pass and shaders "

--- a/src/render/vulkan/vulkan_surface_session.cpp
+++ b/src/render/vulkan/vulkan_surface_session.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <stdexcept>
@@ -223,20 +224,48 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
       init(size.width, size.height);
     }
 
-    // Presents through a different host surface from here on. Returns whether
-    // the render pass survived: initSwapchain() picks a color format from the
-    // new surface, and setColorFormat() drops the pass when that format
-    // differs, taking mbgl's pipeline cache with it.
+    // Whether a replacement surface can use the render pass and the shaders
+    // this session already compiled.
     //
-    // The answer comes from comparing the color format by value rather than
-    // comparing VkRenderPass handles across the rebuild. A destroyed handle is
-    // free to come back with the same value from the next create call, and
-    // mbgl's pipeline cache is a bare hash map over that value with no equality
-    // check behind it, so a recycled handle would hand the new pass every
-    // pipeline built for the old one. Color format is the only input to
-    // initRenderPass() that a replacement surface can change; the depth format
-    // follows from the physical device, which does not change here.
-    auto set_surface(VkSurfaceKHR surface_, mbgl::Size size) -> bool {
+    // Two properties of a surface reach into that compiled state. The color
+    // format decides the render pass, which mbgl keys its pipeline cache on,
+    // and mbgl compiles a distinct shader variant for surfaces that support a
+    // pre-rotation transform (USE_SURFACE_TRANSFORM). Both are read from the
+    // replacement before anything is torn down, so a mismatch is refused with
+    // the session still rendering into the surface it has.
+    [[nodiscard]] auto matches_surface(VkSurfaceKHR candidate) const -> bool {
+      const auto& physical_device = backend.getPhysicalDevice();
+      const auto& dispatcher = backend.getDispatcher();
+      const auto candidate_surface = vk::SurfaceKHR(candidate);
+
+      const auto candidate_capabilities =
+        physical_device.getSurfaceCapabilitiesKHR(
+          candidate_surface, dispatcher
+        );
+      const auto candidate_transform =
+        candidate_capabilities.supportedTransforms !=
+        vk::SurfaceTransformFlagBitsKHR::eIdentity;
+      if (candidate_transform != hasSurfaceTransformSupport()) {
+        return false;
+      }
+
+      // The same choice initSwapchain() makes, so the comparison is against the
+      // format the replacement would actually be given.
+      const auto formats =
+        physical_device.getSurfaceFormatsKHR(candidate_surface, dispatcher);
+      const auto found =
+        std::find_if(formats.begin(), formats.end(), [](const auto& format) {
+          return (format.format == vk::Format::eB8G8R8A8Unorm ||
+                  format.format == vk::Format::eR8G8B8A8Unorm) &&
+                 format.colorSpace == vk::ColorSpaceKHR::eSrgbNonlinear;
+        });
+      return found != formats.end() && found->format == colorFormat;
+    }
+
+    // Presents through a different host surface from here on. The caller has
+    // already established that it matches, so the render pass survives: the
+    // color format is unchanged, and setColorFormat() leaves the pass alone.
+    void set_surface(VkSurfaceKHR surface_, mbgl::Size size) {
       backend.getDevice()->waitIdle(backend.getDispatcher());
       swapchainFramebuffers.clear();
       swapchainImageViews.clear();
@@ -255,9 +284,7 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
       borrowed_surface = surface_;
       createPlatformSurface();
 
-      const auto previous_format = colorFormat;
       init(size.width, size.height);
-      return colorFormat == previous_format;
     }
 
    private:
@@ -301,12 +328,24 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
     mbgl::vulkan::Renderable::setSize(size);
     if (resource) {
       getResource<VulkanSurfaceRenderableResource>().resize(size);
+      adopt_swapchain_extent();
     }
   }
 
-  // Returns whether the renderer's cached state survives, which on Vulkan comes
-  // down to whether the render pass did.
-  auto set_surface(const mln_vulkan_surface_descriptor& descriptor) -> bool {
+  // Whether a replacement surface can use what this session already compiled.
+  [[nodiscard]] auto matches_surface(
+    const mln_vulkan_surface_descriptor& descriptor
+  ) const -> bool {
+    // Nothing has been built yet, so there is nothing to be incompatible with.
+    if (!resource) {
+      return true;
+    }
+    return getResource<VulkanSurfaceRenderableResource>().matches_surface(
+      static_cast<VkSurfaceKHR>(descriptor.surface)
+    );
+  }
+
+  void set_surface(const mln_vulkan_surface_descriptor& descriptor) {
     const auto new_size = mbgl::Size{
       mln::core::physical_dimension(
         descriptor.extent.width, descriptor.extent.scale_factor
@@ -320,11 +359,12 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
     // Nothing has been built yet, so the lazy path already takes the new
     // surface: the wrapper is created against descriptor_ on first use.
     if (!resource) {
-      return true;
+      return;
     }
-    return getResource<VulkanSurfaceRenderableResource>().set_surface(
+    getResource<VulkanSurfaceRenderableResource>().set_surface(
       static_cast<VkSurfaceKHR>(descriptor.surface), new_size
     );
+    adopt_swapchain_extent();
   }
 
   [[nodiscard]] auto context_descriptor() const
@@ -335,6 +375,23 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
   void activate() override {}
   void deactivate() override {}
 
+ private:
+  // Takes the extent the swapchain actually got. A surface may report a fixed
+  // currentExtent, clamp what was asked for, or swap width and height for a
+  // pre-rotated display, and mbgl::Renderer reads its viewport and scissor from
+  // the renderable's size. mbgl::vulkan::RendererBackend::initSwapchain() does
+  // the same after building a swapchain of its own.
+  void adopt_swapchain_extent() {
+    const auto& renderable_resource =
+      getResource<VulkanSurfaceRenderableResource>();
+    if (!renderable_resource.hasSurfaceTransformSupport()) {
+      return;
+    }
+    const auto& extent = renderable_resource.getExtent();
+    mbgl::vulkan::Renderable::setSize({extent.width, extent.height});
+  }
+
+ public:
  protected:
   void initInstance() override {
     usingSharedContext = true;
@@ -421,10 +478,8 @@ class VulkanSurfaceSessionBackend final
     backend_.resize(mbgl::Size{physical_width, physical_height});
   }
 
-  auto set_vulkan_target(
-    const mln_vulkan_surface_descriptor& descriptor,
-    mln::core::RetargetOutcome& out_outcome
-  ) -> mln_status override {
+  auto set_vulkan_target(const mln_vulkan_surface_descriptor& descriptor)
+    -> mln_status override {
     if (!mln::core::vulkan_context_matches(
           backend_.context_descriptor(), descriptor.context
         )) {
@@ -438,9 +493,14 @@ class VulkanSurfaceSessionBackend final
     if (handles_status != MLN_STATUS_OK) {
       return handles_status;
     }
-    out_outcome = backend_.set_surface(descriptor)
-                    ? mln::core::RetargetOutcome::RendererPreserved
-                    : mln::core::RetargetOutcome::RendererInvalidated;
+    if (!backend_.matches_surface(descriptor)) {
+      return mln::core::unsupported_retarget(
+        "Vulkan surface target must report the color format and surface "
+        "transform support this session compiled its render pass and shaders "
+        "for; destroy the session and attach again to change them"
+      );
+    }
+    backend_.set_surface(descriptor);
     return MLN_STATUS_OK;
   }
 
@@ -516,12 +576,8 @@ auto vulkan_surface_set_target(
   }
   return surface_session_set_target(
     session, descriptor->extent,
-    [descriptor](
-      mln_render_session_object& target_session, RetargetOutcome& outcome
-    ) -> mln_status {
-      return target_session.surface.backend->set_vulkan_target(
-        *descriptor, outcome
-      );
+    [descriptor](mln_render_session_object& target_session) -> mln_status {
+      return target_session.surface.backend->set_vulkan_target(*descriptor);
     }
   );
 }

--- a/src/render/vulkan/vulkan_surface_session.cpp
+++ b/src/render/vulkan/vulkan_surface_session.cpp
@@ -211,6 +211,13 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
     // mbgl::vulkan::SurfaceRenderableResource::recreateSwapchain(), which
     // preserves it for the same reason; initRenderPass() is a no-op while it
     // lives.
+    //
+    // Correctness does not rest on that assumption. Should the surface report a
+    // different format, initSwapchain() passes it to setColorFormat(), which
+    // drops the pass, and initRenderPass() builds one to match before init()
+    // creates the framebuffers — so the framebuffers always name the pass that
+    // is live. Only the pipeline cache pays, and only in a case a driver does
+    // not produce for a surface it is already presenting.
     void resize(mbgl::Size size) {
       if (!renderPass) {
         return;

--- a/src/render/vulkan/vulkan_texture_backend.cpp
+++ b/src/render/vulkan/vulkan_texture_backend.cpp
@@ -85,28 +85,32 @@ class VulkanTextureBackend::VulkanTextureRenderableResource final
     create_framebuffers();
   }
 
-  // Renders into a different caller-owned image from here on. Returns whether
-  // the render pass survived, which it does while the image keeps the format
-  // and layouts the pass was built around; mbgl keys its pipeline cache on that
-  // pass.
-  auto set_borrowed(
+  // Whether a replacement image can use the render pass this resource already
+  // has, which needs the format and both layouts the pass was built around.
+  // mbgl keys its pipeline cache on that pass, and the Metal and Vulkan
+  // contexts cache more against it besides, so a mismatch is refused rather
+  // than rebuilt.
+  [[nodiscard]] auto matches_borrowed(
+    const mln_vulkan_borrowed_texture_descriptor& descriptor
+  ) const -> bool {
+    return colorFormat == static_cast<vk::Format>(descriptor.format) &&
+           initial_layout_ ==
+             static_cast<vk::ImageLayout>(descriptor.initial_layout) &&
+           final_layout_ ==
+             static_cast<vk::ImageLayout>(descriptor.final_layout);
+  }
+
+  // Renders into a different caller-owned image from here on. The caller has
+  // already established that it matches the live render pass, which is why that
+  // pass is kept.
+  void set_borrowed(
     const mln_vulkan_borrowed_texture_descriptor& descriptor, uint32_t width,
     uint32_t height
-  ) -> bool {
+  ) {
     backend.getDevice()->waitIdle(backend.getDispatcher());
-    const auto compatible =
-      colorFormat == static_cast<vk::Format>(descriptor.format) &&
-      initial_layout_ ==
-        static_cast<vk::ImageLayout>(descriptor.initial_layout) &&
-      final_layout_ == static_cast<vk::ImageLayout>(descriptor.final_layout);
-
     swapchainFramebuffers.clear();
     swapchainImages.clear();
-    if (!compatible) {
-      renderPass.reset();
-    }
     init_borrowed(descriptor, width, height);
-    return compatible;
   }
 
   void init_borrowed(
@@ -395,19 +399,31 @@ auto VulkanTextureBackend::getDefaultRenderable() -> mbgl::gfx::Renderable& {
   return *this;
 }
 
-auto VulkanTextureBackend::set_borrowed_target(
+auto VulkanTextureBackend::matches_borrowed_target(
   const mln_vulkan_borrowed_texture_descriptor& descriptor
-) -> bool {
+) const -> bool {
+  // Nothing is built yet, so there is no render pass to be incompatible with.
+  if (!resource) {
+    return true;
+  }
+  return getResource<VulkanTextureRenderableResource>().matches_borrowed(
+    descriptor
+  );
+}
+
+void VulkanTextureBackend::set_borrowed_target(
+  const mln_vulkan_borrowed_texture_descriptor& descriptor
+) {
   borrowed_descriptor_ = descriptor;
   const auto new_size =
     mbgl::Size{descriptor.physical_width, descriptor.physical_height};
   // Nothing is built yet, so the lazy path already takes the new image.
   if (!resource) {
     setSize(new_size);
-    return true;
+    return;
   }
   size = new_size;
-  return getResource<VulkanTextureRenderableResource>().set_borrowed(
+  getResource<VulkanTextureRenderableResource>().set_borrowed(
     descriptor, new_size.width, new_size.height
   );
 }

--- a/src/render/vulkan/vulkan_texture_backend.cpp
+++ b/src/render/vulkan/vulkan_texture_backend.cpp
@@ -64,6 +64,51 @@ class VulkanTextureBackend::VulkanTextureRenderableResource final
     create_framebuffers();
   }
 
+  // Rebuilds everything sized with the texture and deliberately keeps the
+  // render pass. mbgl keys its Vulkan pipeline cache on the render pass handle,
+  // and that cache lives in the renderer's shader registry, so destroying the
+  // pass here would strand every cached pipeline behind a dead key — and hand a
+  // recycled handle a cache hit on a pipeline built for the pass that used to
+  // own it. Attachment formats and layouts are the same at every size, so the
+  // pass stays correct as it is.
+  void resize_sampled(vk::Extent2D sampled_extent) {
+    backend.getDevice()->waitIdle(backend.getDispatcher());
+    swapchainFramebuffers.clear();
+    swapchainImageViews.clear();
+    swapchainImages.clear();
+    colorAllocations.clear();
+    readTexture.reset();
+
+    init_sampled_color(sampled_extent);
+    create_color_image_views();
+    initDepthStencil();
+    create_framebuffers();
+  }
+
+  // Renders into a different caller-owned image from here on. Returns whether
+  // the render pass survived, which it does while the image keeps the format
+  // and layouts the pass was built around; mbgl keys its pipeline cache on that
+  // pass.
+  auto set_borrowed(
+    const mln_vulkan_borrowed_texture_descriptor& descriptor, uint32_t width,
+    uint32_t height
+  ) -> bool {
+    backend.getDevice()->waitIdle(backend.getDispatcher());
+    const auto compatible =
+      colorFormat == static_cast<vk::Format>(descriptor.format) &&
+      initial_layout_ ==
+        static_cast<vk::ImageLayout>(descriptor.initial_layout) &&
+      final_layout_ == static_cast<vk::ImageLayout>(descriptor.final_layout);
+
+    swapchainFramebuffers.clear();
+    swapchainImages.clear();
+    if (!compatible) {
+      renderPass.reset();
+    }
+    init_borrowed(descriptor, width, height);
+    return compatible;
+  }
+
   void init_borrowed(
     const mln_vulkan_borrowed_texture_descriptor& descriptor, uint32_t width,
     uint32_t height
@@ -179,9 +224,19 @@ class VulkanTextureBackend::VulkanTextureRenderableResource final
     }
   }
 
+  // Idempotent, like mbgl::vulkan::SurfaceRenderableResource::initRenderPass():
+  // a live pass is left alone so the pipelines mbgl cached against it stay
+  // reachable. Whoever changes an attachment format or layout drops the pass
+  // first, which is the signal that those pipelines go too.
   void create_render_pass(
     vk::ImageLayout initial_layout, vk::ImageLayout final_layout
   ) {
+    initial_layout_ = initial_layout;
+    final_layout_ = final_layout;
+    if (renderPass) {
+      return;
+    }
+
     const auto& device = backend.getDevice();
     const auto& dispatcher = backend.getDispatcher();
 
@@ -288,6 +343,10 @@ class VulkanTextureBackend::VulkanTextureRenderableResource final
   bool usesBorrowedImage = false;
   vk::Image borrowedImage;
   vk::ImageView borrowedImageView;
+  // What the live render pass was built around, so a replacement target can be
+  // measured against it.
+  vk::ImageLayout initial_layout_ = vk::ImageLayout::eUndefined;
+  vk::ImageLayout final_layout_ = vk::ImageLayout::eUndefined;
 };
 
 VulkanTextureBackend::VulkanTextureBackend(
@@ -334,6 +393,37 @@ auto VulkanTextureBackend::getDefaultRenderable() -> mbgl::gfx::Renderable& {
     resource = std::make_unique<VulkanTextureRenderableResource>(*this);
   }
   return *this;
+}
+
+auto VulkanTextureBackend::set_borrowed_target(
+  const mln_vulkan_borrowed_texture_descriptor& descriptor
+) -> bool {
+  borrowed_descriptor_ = descriptor;
+  const auto new_size =
+    mbgl::Size{descriptor.physical_width, descriptor.physical_height};
+  // Nothing is built yet, so the lazy path already takes the new image.
+  if (!resource) {
+    setSize(new_size);
+    return true;
+  }
+  size = new_size;
+  return getResource<VulkanTextureRenderableResource>().set_borrowed(
+    descriptor, new_size.width, new_size.height
+  );
+}
+
+void VulkanTextureBackend::resize(mbgl::Size new_size) {
+  // Nothing is built yet, so the lazy path already produces the new size. A
+  // borrowed texture is sized by its owner and never reaches here; the session
+  // rejects resizing one.
+  if (!resource || uses_borrowed_texture_) {
+    setSize(new_size);
+    return;
+  }
+  size = new_size;
+  getResource<VulkanTextureRenderableResource>().resize_sampled(
+    vk::Extent2D{new_size.width, new_size.height}
+  );
 }
 
 auto VulkanTextureBackend::readStillImage() -> mbgl::PremultipliedImage {

--- a/src/render/vulkan/vulkan_texture_backend.cpp
+++ b/src/render/vulkan/vulkan_texture_backend.cpp
@@ -414,18 +414,22 @@ auto VulkanTextureBackend::matches_borrowed_target(
 void VulkanTextureBackend::set_borrowed_target(
   const mln_vulkan_borrowed_texture_descriptor& descriptor
 ) {
-  borrowed_descriptor_ = descriptor;
   const auto new_size =
     mbgl::Size{descriptor.physical_width, descriptor.physical_height};
   // Nothing is built yet, so the lazy path already takes the new image.
   if (!resource) {
+    borrowed_descriptor_ = descriptor;
     setSize(new_size);
     return;
   }
-  size = new_size;
+  // The resource first, then this backend's own view of the target, so a
+  // framebuffer that fails to build cannot leave the backend naming an image it
+  // is not rendering into.
   getResource<VulkanTextureRenderableResource>().set_borrowed(
     descriptor, new_size.width, new_size.height
   );
+  borrowed_descriptor_ = descriptor;
+  size = new_size;
 }
 
 void VulkanTextureBackend::resize(mbgl::Size new_size) {

--- a/src/render/vulkan/vulkan_texture_backend.hpp
+++ b/src/render/vulkan/vulkan_texture_backend.hpp
@@ -41,6 +41,19 @@ class VulkanTextureBackend final : public mbgl::vulkan::RendererBackend,
   ~VulkanTextureBackend() override;
 
   auto getDefaultRenderable() -> mbgl::gfx::Renderable& override;
+  // Follows a new physical size while preserving the render pass, so the
+  // renderer's Vulkan pipeline cache survives the resize.
+  void resize(mbgl::Size new_size);
+  // Renders into a different caller-owned image from here on. Returns whether
+  // the renderer's cached state survives, which comes down to whether the
+  // render pass did.
+  auto set_borrowed_target(
+    const mln_vulkan_borrowed_texture_descriptor& descriptor
+  ) -> bool;
+  [[nodiscard]] auto context_descriptor() const
+    -> const mln_vulkan_context_descriptor& {
+    return descriptor_.context;
+  }
   auto readStillImage() -> mbgl::PremultipliedImage override;
   auto getRendererBackend() -> mbgl::gfx::RendererBackend* override;
   void activate() override;

--- a/src/render/vulkan/vulkan_texture_backend.hpp
+++ b/src/render/vulkan/vulkan_texture_backend.hpp
@@ -44,12 +44,15 @@ class VulkanTextureBackend final : public mbgl::vulkan::RendererBackend,
   // Follows a new physical size while preserving the render pass, so the
   // renderer's Vulkan pipeline cache survives the resize.
   void resize(mbgl::Size new_size);
-  // Renders into a different caller-owned image from here on. Returns whether
-  // the renderer's cached state survives, which comes down to whether the
-  // render pass did.
-  auto set_borrowed_target(
+  // Whether a replacement image can use the render pass already in hand.
+  [[nodiscard]] auto matches_borrowed_target(
     const mln_vulkan_borrowed_texture_descriptor& descriptor
-  ) -> bool;
+  ) const -> bool;
+  // Renders into a different caller-owned image from here on. The caller has
+  // already established that it matches the live render pass.
+  void set_borrowed_target(
+    const mln_vulkan_borrowed_texture_descriptor& descriptor
+  );
   [[nodiscard]] auto context_descriptor() const
     -> const mln_vulkan_context_descriptor& {
     return descriptor_.context;

--- a/src/render/vulkan/vulkan_texture_session.cpp
+++ b/src/render/vulkan/vulkan_texture_session.cpp
@@ -376,6 +376,13 @@ auto vulkan_borrowed_texture_set_target(
   mln_render_session session,
   const mln_vulkan_borrowed_texture_descriptor* descriptor
 ) -> mln_status {
+  mln_render_session_object* live = nullptr;
+  const auto session_status = validate_render_session_retarget(
+    session, RetargetTargetKind::BorrowedTexture, live
+  );
+  if (session_status != MLN_STATUS_OK) {
+    return session_status;
+  }
   const auto descriptor_status =
     validate_vulkan_borrowed_texture_descriptor(descriptor);
   if (descriptor_status != MLN_STATUS_OK) {
@@ -391,9 +398,9 @@ auto vulkan_borrowed_texture_set_target(
     session, RetargetTargetKind::BorrowedTexture, descriptor->extent,
     descriptor->physical_width, descriptor->physical_height,
     [descriptor](
-      mln_render_session_object& live, RetargetOutcome& outcome
+      mln_render_session_object& target_session, RetargetOutcome& outcome
     ) -> mln_status {
-      return live.texture.backend->set_vulkan_borrowed_target(
+      return target_session.texture.backend->set_vulkan_borrowed_target(
         *descriptor, outcome
       );
     }

--- a/src/render/vulkan/vulkan_texture_session.cpp
+++ b/src/render/vulkan/vulkan_texture_session.cpp
@@ -125,6 +125,27 @@ class VulkanTextureSessionBackend final
     return backend_;
   }
 
+  void resize(mbgl::Size size) override { backend_.resize(size); }
+
+  auto set_vulkan_borrowed_target(
+    const mln_vulkan_borrowed_texture_descriptor& descriptor,
+    mln::core::RetargetOutcome& out_outcome
+  ) -> mln_status override {
+    if (!mln::core::vulkan_context_matches(
+          backend_.context_descriptor(), descriptor.context
+        )) {
+      mln::core::set_thread_error(
+        "Vulkan texture target must name the instance, physical device, "
+        "device, and graphics queue this session attached with"
+      );
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+    out_outcome = backend_.set_borrowed_target(descriptor)
+                    ? mln::core::RetargetOutcome::RendererPreserved
+                    : mln::core::RetargetOutcome::RendererInvalidated;
+    return MLN_STATUS_OK;
+  }
+
   void prepare_render_resources() override {
     // Renderer::render creates the Vulkan context before requesting the default
     // renderable, so shared-device resources must be ready first.
@@ -349,6 +370,34 @@ auto vulkan_owned_texture_release_frame(
   live->texture.acquired_frame_id = 0;
   live->texture.acquired_frame_kind = TextureSessionFrameKind::None;
   return MLN_STATUS_OK;
+}
+
+auto vulkan_borrowed_texture_set_target(
+  mln_render_session session,
+  const mln_vulkan_borrowed_texture_descriptor* descriptor
+) -> mln_status {
+  const auto descriptor_status =
+    validate_vulkan_borrowed_texture_descriptor(descriptor);
+  if (descriptor_status != MLN_STATUS_OK) {
+    return descriptor_status;
+  }
+  const auto physical_status = validate_borrowed_physical_size(
+    descriptor->physical_width, descriptor->physical_height
+  );
+  if (physical_status != MLN_STATUS_OK) {
+    return physical_status;
+  }
+  return render_session_set_target(
+    session, RetargetTargetKind::BorrowedTexture, descriptor->extent,
+    descriptor->physical_width, descriptor->physical_height,
+    [descriptor](
+      mln_render_session_object& live, RetargetOutcome& outcome
+    ) -> mln_status {
+      return live.texture.backend->set_vulkan_borrowed_target(
+        *descriptor, outcome
+      );
+    }
+  );
 }
 
 }  // namespace mln::core

--- a/src/render/vulkan/vulkan_texture_session.cpp
+++ b/src/render/vulkan/vulkan_texture_session.cpp
@@ -128,8 +128,7 @@ class VulkanTextureSessionBackend final
   void resize(mbgl::Size size) override { backend_.resize(size); }
 
   auto set_vulkan_borrowed_target(
-    const mln_vulkan_borrowed_texture_descriptor& descriptor,
-    mln::core::RetargetOutcome& out_outcome
+    const mln_vulkan_borrowed_texture_descriptor& descriptor
   ) -> mln_status override {
     if (!mln::core::vulkan_context_matches(
           backend_.context_descriptor(), descriptor.context
@@ -140,9 +139,14 @@ class VulkanTextureSessionBackend final
       );
       return MLN_STATUS_INVALID_ARGUMENT;
     }
-    out_outcome = backend_.set_borrowed_target(descriptor)
-                    ? mln::core::RetargetOutcome::RendererPreserved
-                    : mln::core::RetargetOutcome::RendererInvalidated;
+    if (!backend_.matches_borrowed_target(descriptor)) {
+      return mln::core::unsupported_retarget(
+        "Vulkan image target must have the format and layouts this session's "
+        "render pass was built for; destroy the session and attach again to "
+        "change them"
+      );
+    }
+    backend_.set_borrowed_target(descriptor);
     return MLN_STATUS_OK;
   }
 
@@ -397,11 +401,9 @@ auto vulkan_borrowed_texture_set_target(
   return render_session_set_target(
     session, RetargetTargetKind::BorrowedTexture, descriptor->extent,
     descriptor->physical_width, descriptor->physical_height,
-    [descriptor](
-      mln_render_session_object& target_session, RetargetOutcome& outcome
-    ) -> mln_status {
+    [descriptor](mln_render_session_object& target_session) -> mln_status {
       return target_session.texture.backend->set_vulkan_borrowed_target(
-        *descriptor, outcome
+        *descriptor
       );
     }
   );


### PR DESCRIPTION
## Summary

Adds `mln_*_set_target` so a live render session can take a replacement surface or
caller-owned texture while keeping its renderer, and threads it through every binding and
example so a resize no longer restarts the map.

## Test plan

`mise run test`, plus manual resize checks of rust-map on Metal and compose-map on Metal,
Vulkan-on-Metal, and OpenGL-on-Metal.

## AI assistance

- **Tools:** Claude Code; Codex (gpt-5.6-sol) as an adversarial reviewer
- **Context:**
  Written with Claude Code and reviewed round-by-round with Codex, per phase: the C API,
  then the bindings, then the examples. Two things worth reviewer attention: `22f87ade` is
  a fix built on a mechanism that turned out to be wrong, reverted in `3fead862` and
  replaced by `231123b3`, which pins the real behaviour with a test; and the
  texture-retention machinery in the compose-map bridges (`b0233df3`) is only runtime
  verified on the three macOS bridges, the Linux and Windows ones being compile verified
  only.
