### PR TITLE
Fix snapshot feed publishing

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -417,6 +417,9 @@ jobs:
     name: Deploy Docs Pages
     needs:
       - docs-pages
+    # The Pages build preserves live feeds after a package staging failure.
+    # This status check lets the resulting artifact deploy in that case.
+    if: ${{ !cancelled() && needs.docs-pages.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/ci/dotnet_snapshot.py
+++ b/ci/dotnet_snapshot.py
@@ -146,7 +146,7 @@ def feed(args: argparse.Namespace) -> None:
         sleet("init", "--config", str(config_path), "--source", "snapshot")
         sleet(
             "push",
-            str(args.packages),
+            str(args.packages.resolve()),
             "--config",
             str(config_path),
             "--source",


### PR DESCRIPTION
## Summary

Resolve the NuGet package path before invoking Sleet and deploy a successfully assembled Pages artifact after a handled package-staging failure.

## Test plan

Run the targeted `hk` checks and replay the failed NuGet feed generation with run 30737290961's package artifact, confirming that Sleet creates and validates the feed.

## AI assistance

- **Tools:** Codex
- **Context:** Codex inspected the failed Actions job, implemented the focused fixes, and replayed the failing feed step with its archived packages.