### PR TITLE
Add macOS support to the C map example and fixed owned-texture bugs

### DIFF
--- a/.devcontainer/mise.toml
+++ b/.devcontainer/mise.toml
@@ -8,7 +8,7 @@
 "aqua:mvdan/gofumpt" = "{{vars.gofumpt_version}}"
 "conda:doxygen" = { version = "{{vars.doxygen_version}}", os = ["linux", "macos", "windows/x64"] }
 "conda:libxml2" = { version = "{{vars.libxml2_version}}", os = ["linux/x64"] }
-"conda:sdl3" = { version = "3.2", os = ["linux"] }
+"conda:sdl3" = { version = "3.2", os = ["linux", "macos"] }
 "core:dart" = "{{vars.dart_version}}"
 "core:dotnet" = "{{vars.dotnet_version}}"
 "core:flutter" = { version = "{{vars.flutter_version}}", os = ["linux/x64", "macos/arm64", "windows/x64"] }

--- a/bindings/dotnet/src/Maplibre.NativeFfi/Render/RenderHandles.cs
+++ b/bindings/dotnet/src/Maplibre.NativeFfi/Render/RenderHandles.cs
@@ -467,10 +467,9 @@ public sealed unsafe class RenderSessionHandle : IDisposable
     /// latest update, so repeated calls re-render it and return true again;
     /// use this to redraw on demand after resize or surface expose, and gate
     /// frame loops on render-update-available events instead of the return
-    /// value. Returns false when no frame was rendered,
-    /// because the map has not published an update yet or the renderer
-    /// skipped the frame; both are normal during startup, so keep pumping
-    /// the runtime until an update is reported.
+    /// value. Returns false when no frame was rendered. That is a normal
+    /// transient: call again on the next frame rather than wait for
+    /// another render-update event.
     /// </summary>
     public bool RenderUpdate()
     {

--- a/bindings/go/render.go
+++ b/bindings/go/render.go
@@ -893,9 +893,8 @@ func (session *RenderSessionHandle) setTarget(call func(nativeRenderSession) int
 // calls re-render it and report true again; use this to redraw on demand
 // after resize or surface expose, and gate frame loops on
 // render-update-available events instead of the return value. It reports
-// false when no frame was rendered, because the map has not published an
-// update yet or the renderer skipped the frame; both are normal during
-// startup, so keep pumping the runtime until an update is reported.
+// false when no frame was rendered. That is a normal transient: call again
+// on the next frame rather than wait for another render-update event.
 func (session *RenderSessionHandle) RenderUpdate() (bool, error) {
 	ptr, release, err := session.ptr()
 	if err != nil {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -114,8 +114,8 @@ public expect class RenderSessionHandle : AutoCloseable {
    * The map retains its latest update, so repeated calls re-render it and return true again; use
    * this to redraw on demand after resize or surface expose, and gate frame loops on
    * render-update-available events instead of the return value. Returns false when no frame was
-   * rendered, because the map has not published an update yet or the renderer skipped the frame;
-   * both are normal during startup, so keep pumping the runtime until an update is reported.
+   * rendered. That is a normal transient: call again on the next frame rather than wait for another
+   * render-update event.
    */
   public fun renderUpdate(): Boolean
 

--- a/bindings/python/python/maplibre_native_ffi/render.py
+++ b/bindings/python/python/maplibre_native_ffi/render.py
@@ -639,10 +639,9 @@ class RenderSessionHandle(NativeHandleMixin):
         The map retains its latest update, so repeated calls re-render it and
         return True again; use this to redraw on demand after resize or surface
         expose, and gate frame loops on render-update-available events instead
-        of the return value. Returns False when no frame was rendered,
-        because the map has not published an update yet or the renderer skipped
-        the frame; both are normal during startup, so keep pumping the runtime
-        until an update is reported.
+        of the return value. Returns False when no frame was rendered. That is
+        a normal transient: call again on the next frame rather than wait for
+        another render-update event.
         """
         return bool(self._native.render_update())
 

--- a/bindings/rust/crates/maplibre-native-ffi-sys/build.rs
+++ b/bindings/rust/crates/maplibre-native-ffi-sys/build.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Duration;
 
 use flate2::read::GzDecoder;
@@ -39,13 +40,27 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:runtime-dir={}", runtime_dir.display());
     println!("cargo:rerun-if-env-changed=LIBCLANG_PATH");
     println!("cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS");
+    println!("cargo:rerun-if-env-changed=SDKROOT");
     print_rerun_if_changed(&include_dir);
 
-    let bindings = bindgen::Builder::default()
+    let mut builder = bindgen::Builder::default()
         .header(header.display().to_string())
         .clang_arg("-xc")
         .clang_arg("-std=c23")
-        .clang_arg(format!("-I{}", include_dir.display()))
+        .clang_arg(format!("-I{}", include_dir.display()));
+
+    // bindgen parses through libclang, which has none of the clang driver's
+    // logic for locating an Apple SDK, and these headers include the SDK's
+    // stdint.h. Ask the toolchain where that SDK is. An SDKROOT the caller set
+    // already reaches libclang, so this fills in only when one is absent.
+    if env::var_os("SDKROOT").is_none() {
+        let target = env::var("TARGET")?;
+        if let Some(sdk_path) = apple_sdk_name(&target_os, &target).and_then(apple_sdk_path) {
+            builder = builder.clang_arg(format!("-isysroot{sdk_path}"));
+        }
+    }
+
+    let bindings = builder
         .allowlist_function("^mln_.*")
         .allowlist_type("^mln_.*")
         .allowlist_var("^MLN_.*")
@@ -99,6 +114,33 @@ fn native_library_dir(install_dir: &Path) -> PathBuf {
         }
     }
     install_dir.join("lib")
+}
+
+/// The SDK that xcrun knows this target by, or None for a target that needs no
+/// Apple SDK.
+fn apple_sdk_name(target_os: &str, target: &str) -> Option<&'static str> {
+    let simulator = target.ends_with("-sim");
+    match target_os {
+        "macos" => Some("macosx"),
+        "ios" if simulator => Some("iphonesimulator"),
+        "ios" => Some("iphoneos"),
+        _ => None,
+    }
+}
+
+/// Where the installed Xcode command line tools keep that SDK. Reports None on
+/// a host without them, leaving libclang to its own header search.
+fn apple_sdk_path(sdk_name: &str) -> Option<String> {
+    let output = Command::new("xcrun")
+        .args(["--sdk", sdk_name, "--show-sdk-path"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?;
+    let path = path.trim().to_owned();
+    if path.is_empty() { None } else { Some(path) }
 }
 
 fn require_dir(path: &Path, label: &str) -> Result<(), Box<dyn Error>> {

--- a/bindings/rust/crates/maplibre-native-ffi/src/render.rs
+++ b/bindings/rust/crates/maplibre-native-ffi/src/render.rs
@@ -1405,9 +1405,8 @@ impl RenderSessionHandle {
     /// return `true` again; use this to redraw on demand after resize or
     /// surface expose, and gate frame loops on render-update-available events
     /// instead of the return value. Returns `false` when no frame was
-    /// rendered, because the map has not published an update yet or the
-    /// renderer skipped the frame; both are normal during startup, so keep
-    /// pumping the runtime until an update is reported.
+    /// rendered. That is a normal transient: call again on the next frame
+    /// rather than wait for another render-update event.
     pub fn render_update(&self) -> Result<bool> {
         self.inner.ensure_no_frame_acquired()?;
         let session = self.inner.native()?;

--- a/bindings/swift/Sources/MaplibreNativeFFI/Render.swift
+++ b/bindings/swift/Sources/MaplibreNativeFFI/Render.swift
@@ -618,10 +618,9 @@ public final class RenderSessionHandle {
   /// The map retains its latest update, so repeated calls re-render it and
   /// return true again; use this to redraw on demand after resize or surface
   /// expose, and gate frame loops on render-update-available events instead
-  /// of the return value. Returns false when no frame was rendered,
-  /// because the map has not published an update yet or the renderer skipped
-  /// the frame; both are normal during startup, so keep pumping the runtime
-  /// until an update is reported.
+  /// of the return value. Returns false when no frame was rendered. That is
+  /// a normal transient: call again on the next frame rather than wait for
+  /// another render-update event.
   @discardableResult
   public func renderUpdate() throws -> Bool {
     try mapNativeFailure {

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -552,10 +552,9 @@ pub const RenderSessionHandle = enum(c.mln_render_session) {
     /// latest update, so repeated calls re-render it and return true again;
     /// use this to redraw on demand after resize or surface expose, and gate
     /// frame loops on render-update-available events instead of the return
-    /// value. Returns false when no frame was rendered, because the map has
-    /// not published an update yet or the renderer skipped the frame; both are
-    /// normal during startup, so keep pumping the runtime until an update is
-    /// reported.
+    /// value. Returns false when no frame was rendered. That is a normal
+    /// transient: call again on the next frame rather than wait for another
+    /// render-update event.
     pub fn renderUpdate(self: *RenderSessionHandle) status.Error!bool {
         const lease = try renderSessionLease(self.*);
         defer lease.release();

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -473,6 +473,10 @@ Requirements:
 - After a session resize, the map applies its logical size on the runtime loop's
   next `pump`, so `render_update` reports no update until then. The render loop
   MUST keep pacing and retry rather than treating it as a failure.
+- A compositor that cannot present the frame it was handed MUST report that as
+  no frame rendered, and the render loop MUST set the render request again. A
+  minimized or occluded window produces this, and so does a swapchain awaiting
+  its rebuild. The map retains the update, so the retry draws it.
 
 Texture modes: after `render_update` reports an update was rendered, MUST run
 the compositor pass to copy the map texture into the host swapchain before
@@ -683,6 +687,20 @@ binary targets. Implement only the modes required by the active profile
 - `native-surface`: surface / swapchain presentation descriptor for the host
   `VkSurfaceKHR`.
 
+A host swapchain in the texture modes MUST:
+
+- Name the outgoing swapchain as `oldSwapchain` when it builds the replacement,
+  and destroy the retired one after that call returns. Destroying first leaves
+  the surface without images, and the window goes black until the replacement
+  presents.
+- Hold one present-wait semaphore per swapchain image and wait on the one that
+  belongs to the acquired image. A semaphore shared across images lets one
+  frame's submit signal it while another frame's present still waits on it,
+  which Vulkan forbids and which presents half-drawn frames.
+- Rebuild after `VK_SUBOPTIMAL_KHR` from acquire or present, as it rebuilds
+  after `VK_ERROR_OUT_OF_DATE_KHR`. A suboptimal swapchain presents frames that
+  no longer match the surface, and it stays suboptimal until it is rebuilt.
+
 #### Metal
 
 - `native-surface`: Metal surface descriptor for the host `CAMetalLayer`.
@@ -690,6 +708,10 @@ binary targets. Implement only the modes required by the active profile
   handles required by the C API.
 - `borrowed-texture`: exportable Metal texture sized to the viewport;
   borrowed-texture descriptor.
+
+A host compositor MUST treat a `CAMetalLayer` that hands out no drawable as a
+frame to retry. A minimized or occluded window has none to give, and the
+drawable pool empties under load.
 
 #### OpenGL / EGL / WGL
 

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -25,7 +25,7 @@ Implement a mobile example by reading Shared baseline and Mobile profile.
 
 | Example                | Profile | Binding    | Toolkit         | Platforms             | Backends              |
 | ---------------------- | ------- | ---------- | --------------- | --------------------- | --------------------- |
-| `examples/c-map`       | Desktop | C          | SDL3            | Linux                 | Vulkan, OpenGL        |
+| `examples/c-map`       | Desktop | C          | SDL3            | Linux, macOS          | Vulkan, Metal, OpenGL |
 | `examples/zig-map`     | Desktop | Zig        | SDL3            | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
 | `examples/go-map`      | Desktop | Go         | SDL3            | Linux                 | OpenGL                |
 | `examples/rust-map`    | Desktop | Rust       | winit           | Linux, macOS, Windows | Vulkan, Metal, OpenGL |

--- a/examples/c-map/CMakeLists.txt
+++ b/examples/c-map/CMakeLists.txt
@@ -51,8 +51,36 @@ set_target_properties(
 target_compile_options(c-map PRIVATE -Wall -Wextra)
 target_link_libraries(c-map PRIVATE PkgConfig::MAPLIBRE PkgConfig::SDL3 m)
 
-if(MLN_RENDER_BACKEND STREQUAL "opengl")
+if(MLN_RENDER_BACKEND STREQUAL "metal")
+  target_sources(c-map PRIVATE render/metal/metal.c)
+  find_library(MLN_METAL_FRAMEWORK Metal REQUIRED)
+  find_library(MLN_QUARTZCORE_FRAMEWORK QuartzCore REQUIRED)
+  find_library(MLN_FOUNDATION_FRAMEWORK Foundation REQUIRED)
+  target_link_libraries(
+    c-map
+    PRIVATE
+      objc "${MLN_METAL_FRAMEWORK}" "${MLN_QUARTZCORE_FRAMEWORK}"
+      "${MLN_FOUNDATION_FRAMEWORK}")
+elseif(MLN_RENDER_BACKEND STREQUAL "opengl")
   target_sources(c-map PRIVATE render/opengl/opengl.c)
+  if(APPLE)
+    # SDL's EGL loader resolves ANGLE's libraries by leaf name against images
+    # already loaded into the process, so link the installed ANGLE libraries
+    # directly.
+    find_library(
+      MLN_EGL_LIBRARY
+      NAMES EGL
+      HINTS "${MLN_NATIVE_INSTALL_DIR}/lib"
+      REQUIRED NO_DEFAULT_PATH)
+    find_library(
+      MLN_GLESV2_LIBRARY
+      NAMES GLESv2
+      HINTS "${MLN_NATIVE_INSTALL_DIR}/lib"
+      REQUIRED NO_DEFAULT_PATH)
+    target_link_libraries(
+      c-map
+      PRIVATE "${MLN_EGL_LIBRARY}" "${MLN_GLESV2_LIBRARY}")
+  endif()
 elseif(MLN_RENDER_BACKEND STREQUAL "vulkan")
   target_sources(
     c-map
@@ -67,7 +95,12 @@ elseif(MLN_RENDER_BACKEND STREQUAL "vulkan")
         "directory for the vulkan render backend")
   endif()
   target_include_directories(c-map PRIVATE "${MLN_DEPENDENCY_INCLUDE_DIR}")
-  find_library(MLN_VULKAN_LOADER_LIBRARY vulkan REQUIRED)
+  # On macOS the loader is Homebrew's keg-only vulkan-loader; the repository
+  # mise environment names its lib directory.
+  find_library(
+    MLN_VULKAN_LOADER_LIBRARY vulkan
+    HINTS ENV MLN_FFI_VULKAN_LOADER_DIR
+    REQUIRED)
   target_link_libraries(c-map PRIVATE "${MLN_VULKAN_LOADER_LIBRARY}")
 
   # The compositor shaders compile to C headers holding SPIR-V words, so the

--- a/examples/c-map/channel.c
+++ b/examples/c-map/channel.c
@@ -12,18 +12,19 @@ void command_list_deinit(command_list* list) {
 
 void command_queue_init(command_queue* queue) {
   *queue = (command_queue){};
-  if (mtx_init(&queue->lock, mtx_plain) != thrd_success) {
+  queue->lock = SDL_CreateMutex();
+  if (queue->lock == nullptr) {
     abort();
   }
 }
 
 void command_queue_deinit(command_queue* queue) {
   command_list_deinit(&queue->pending);
-  mtx_destroy(&queue->lock);
+  SDL_DestroyMutex(queue->lock);
 }
 
 void command_queue_push(command_queue* queue, camera_command command) {
-  mtx_lock(&queue->lock);
+  SDL_LockMutex(queue->lock);
   command_list* pending = &queue->pending;
   if (pending->len == pending->cap) {
     const size_t cap = pending->cap == 0 ? 16 : pending->cap * 2;
@@ -37,16 +38,16 @@ void command_queue_push(command_queue* queue, camera_command command) {
     pending->cap = cap;
   }
   pending->items[pending->len++] = command;
-  mtx_unlock(&queue->lock);
+  SDL_UnlockMutex(queue->lock);
 }
 
 void command_queue_drain_into(command_queue* queue, command_list* out) {
   out->len = 0;
-  mtx_lock(&queue->lock);
+  SDL_LockMutex(queue->lock);
   const command_list drained = queue->pending;
   queue->pending = *out;
   *out = drained;
-  mtx_unlock(&queue->lock);
+  SDL_UnlockMutex(queue->lock);
 }
 
 void render_request_init(render_request* request) {
@@ -68,41 +69,44 @@ void map_channel_init(map_channel* channel) {
     .map = MLN_HANDLE_NULL,
     .wake = MLN_HANDLE_NULL,
   };
-  if (mtx_init(&channel->lock, mtx_plain) != thrd_success) {
+  channel->lock = SDL_CreateMutex();
+  if (channel->lock == nullptr) {
     abort();
   }
 }
 
-void map_channel_deinit(map_channel* channel) { mtx_destroy(&channel->lock); }
+void map_channel_deinit(map_channel* channel) {
+  SDL_DestroyMutex(channel->lock);
+}
 
 void map_channel_publish(
   map_channel* channel, mln_map map, mln_wake_source wake
 ) {
-  mtx_lock(&channel->lock);
+  SDL_LockMutex(channel->lock);
   channel->map = map;
   channel->wake = wake;
   atomic_store_explicit(&channel->published, true, memory_order_release);
-  mtx_unlock(&channel->lock);
+  SDL_UnlockMutex(channel->lock);
 }
 
 void map_channel_wake_runtime_loop(map_channel* channel) {
   if (!atomic_load_explicit(&channel->published, memory_order_acquire)) {
     return;
   }
-  mtx_lock(&channel->lock);
+  SDL_LockMutex(channel->lock);
   if (channel->wake != MLN_HANDLE_NULL) {
     mln_wake_source_signal(channel->wake);
   }
-  mtx_unlock(&channel->lock);
+  SDL_UnlockMutex(channel->lock);
 }
 
 bool map_channel_try_map(map_channel* channel, mln_map* out_map) {
   if (!atomic_load_explicit(&channel->published, memory_order_acquire)) {
     return false;
   }
-  mtx_lock(&channel->lock);
+  SDL_LockMutex(channel->lock);
   *out_map = channel->map;
-  mtx_unlock(&channel->lock);
+  SDL_UnlockMutex(channel->lock);
   return *out_map != MLN_HANDLE_NULL;
 }
 
@@ -124,20 +128,20 @@ void map_channel_await_shutdown(map_channel* channel) {
 }
 
 void map_channel_fail(map_channel* channel, app_error error) {
-  mtx_lock(&channel->lock);
+  SDL_LockMutex(channel->lock);
   if (channel->failure == APP_OK) {
     channel->failure = error;
   }
   atomic_store_explicit(&channel->failed, true, memory_order_release);
-  mtx_unlock(&channel->lock);
+  SDL_UnlockMutex(channel->lock);
 }
 
 bool map_channel_failure(map_channel* channel, app_error* out_error) {
   if (!atomic_load_explicit(&channel->failed, memory_order_acquire)) {
     return false;
   }
-  mtx_lock(&channel->lock);
+  SDL_LockMutex(channel->lock);
   *out_error = channel->failure;
-  mtx_unlock(&channel->lock);
+  SDL_UnlockMutex(channel->lock);
   return true;
 }

--- a/examples/c-map/channel.h
+++ b/examples/c-map/channel.h
@@ -9,10 +9,10 @@
 #ifndef C_MAP_CHANNEL_H
 #define C_MAP_CHANNEL_H
 
+#include <SDL3/SDL.h>
 #include <maplibre_native_c.h>
 #include <stdatomic.h>
 #include <stddef.h>
-#include <threads.h>
 
 #include "types.h"
 
@@ -90,7 +90,7 @@ void command_list_deinit(command_list* list);
 /// attributed to no gesture. Growing does not block the render loop either,
 /// and only a stalled runtime loop grows it at all.
 typedef struct command_queue {
-  mtx_t lock;
+  SDL_Mutex* lock;
   command_list pending;
 } command_queue;
 
@@ -131,7 +131,7 @@ bool render_request_consume(render_request* request);
 /// source is signalled from this side to release the runtime loop's parked
 /// pump.
 typedef struct map_channel {
-  mtx_t lock;
+  SDL_Mutex* lock;
   mln_map map;
   mln_wake_source wake;
   atomic_bool published;

--- a/examples/c-map/main.c
+++ b/examples/c-map/main.c
@@ -6,7 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <threads.h>
 
 #include "channel.h"
 #include "diagnostics.h"
@@ -104,6 +103,76 @@ static int runtime_loop(void* userdata) {
   return 0;
 }
 
+/// One render-loop iteration: input, resize handling, and at most one
+/// consumed render request. Runs inside the frame scope the active backend
+/// opened, so every early return still closes it.
+static app_error render_loop_iteration(
+  SDL_Window* window, render_target* target, viewport* current_viewport,
+  command_queue* commands, render_request* request, map_channel* channel,
+  input_controller* controller, bool* running
+) {
+  app_error failure;
+  if (map_channel_failure(channel, &failure)) {
+    return failure;
+  }
+
+  SDL_Event event;
+  while (SDL_PollEvent(&event)) {
+    switch (event.type) {
+      case SDL_EVENT_QUIT:
+      case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+        *running = false;
+        break;
+      case SDL_EVENT_WINDOW_RESIZED:
+      case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+      case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
+        *current_viewport = viewport_get(window);
+        viewport_log("resized viewport", *current_viewport);
+        // Every mode follows a resize without losing its session: the ones
+        // the session sizes resize in place, and a caller-owned target
+        // allocates a replacement and hands it over.
+        MAP_TRY(render_target_resize(target, *current_viewport));
+        // The session resize enqueued the new extent to the map's owner
+        // thread, so release its parked pump the way an input command does.
+        map_channel_wake_runtime_loop(channel);
+        render_request_set(request);
+        break;
+      default: {
+        const input_result result = input_controller_handle_event(
+          controller, &event, commands, *current_viewport
+        );
+        if (result.handled) {
+          // Release the runtime loop's parked pump so the command just
+          // queued is applied on this frame rather than after the parking
+          // bound.
+          map_channel_wake_runtime_loop(channel);
+        }
+        if (result.camera_changed) {
+          render_request_set(request);
+        }
+        break;
+      }
+    }
+  }
+
+  MAP_TRY(render_target_finish_frame(target));
+
+  // Consume before rendering, so a request the runtime loop publishes
+  // during the render call is not discarded.
+  if (render_request_consume(request)) {
+    bool rendered = false;
+    MAP_TRY(render_target_render_update(target, *current_viewport, &rendered));
+    if (!rendered) {
+      render_request_set(request);
+    }
+  }
+
+  // Stand-in for a display-refresh subscription until the host loop is
+  // display-paced; see the frame loop section of the example spec.
+  sleep_milliseconds(8);
+  return APP_OK;
+}
+
 /// The display-paced render loop. Owns the window, input, and the render
 /// session once it adopts it.
 static app_error render_loop(
@@ -133,74 +202,15 @@ static app_error render_loop(
   bool running = true;
   input_controller controller = {};
   while (running) {
-    app_error failure;
-    if (map_channel_failure(channel, &failure)) {
-      return failure;
-    }
-
-    SDL_Event event;
-    while (SDL_PollEvent(&event)) {
-      switch (event.type) {
-        case SDL_EVENT_QUIT:
-        case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
-          running = false;
-          break;
-        case SDL_EVENT_WINDOW_RESIZED:
-        case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
-        case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
-          *current_viewport = viewport_get(window);
-          viewport_log("resized viewport", *current_viewport);
-          // Every mode follows a resize without losing its session: the ones
-          // the session sizes resize in place, and a caller-owned target
-          // allocates a replacement and hands it over.
-          error = render_target_resize(target, *current_viewport);
-          if (error != APP_OK) {
-            return error;
-          }
-          // The session resize enqueued the new extent to the map's owner
-          // thread, so release its parked pump the way an input command does.
-          map_channel_wake_runtime_loop(channel);
-          render_request_set(request);
-          break;
-        default: {
-          const input_result result = input_controller_handle_event(
-            &controller, &event, commands, *current_viewport
-          );
-          if (result.handled) {
-            // Release the runtime loop's parked pump so the command just
-            // queued is applied on this frame rather than after the parking
-            // bound.
-            map_channel_wake_runtime_loop(channel);
-          }
-          if (result.camera_changed) {
-            render_request_set(request);
-          }
-          break;
-        }
-      }
-    }
-
-    error = render_target_finish_frame(target);
+    void* frame_scope = render_target_frame_scope_open();
+    error = render_loop_iteration(
+      window, target, current_viewport, commands, request, channel, &controller,
+      &running
+    );
+    render_target_frame_scope_close(frame_scope);
     if (error != APP_OK) {
       return error;
     }
-
-    // Consume before rendering, so a request the runtime loop publishes
-    // during the render call is not discarded.
-    if (render_request_consume(request)) {
-      bool rendered = false;
-      error = render_target_render_update(target, *current_viewport, &rendered);
-      if (error != APP_OK) {
-        return error;
-      }
-      if (!rendered) {
-        render_request_set(request);
-      }
-    }
-
-    // Stand-in for a display-refresh subscription until the host loop is
-    // display-paced; see the frame loop section of the example spec.
-    sleep_milliseconds(8);
   }
   return APP_OK;
 }
@@ -319,8 +329,9 @@ int main(int argc, char** argv) {
     .request = &request,
     .channel = &channel,
   };
-  thrd_t runtime_thread;
-  if (thrd_create(&runtime_thread, runtime_loop, &args) != thrd_success) {
+  SDL_Thread* runtime_thread =
+    SDL_CreateThread(runtime_loop, "runtime-loop", &args);
+  if (runtime_thread == nullptr) {
     fprintf(
       stderr, "c-map failed: %s\n",
       app_error_name(APP_ERROR_THREAD_SPAWN_FAILED)
@@ -337,7 +348,7 @@ int main(int argc, char** argv) {
   // an attached session cannot be destroyed.
   render_target_deinit(target);
   map_channel_request_shutdown(&channel);
-  thrd_join(runtime_thread, nullptr);
+  SDL_WaitThread(runtime_thread, nullptr);
 
   app_error failure = APP_OK;
   if (error == APP_OK && map_channel_failure(&channel, &failure)) {

--- a/examples/c-map/mise.toml
+++ b/examples/c-map/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-"conda:sdl3" = { version = "3.2", os = ["linux"] }
+"conda:sdl3" = { version = "3.2", os = ["linux", "macos"] }
 
 [tasks.build]
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'

--- a/examples/c-map/render/metal/metal.c
+++ b/examples/c-map/render/metal/metal.c
@@ -1,0 +1,642 @@
+// The Metal render target: an SDL Metal view bridged to the C API through a
+// CAMetalLayer and an MTLDevice, a fullscreen-triangle compositor whose MSL
+// source compiles at startup, and the three render-target modes behind the
+// uniform interface in render.h.
+//
+// The example stays plain C, so every Metal and Cocoa call goes through typed
+// objc_msgSend casts rather than an Objective-C translation unit.
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_metal.h>
+#include <maplibre_native_c.h>
+#include <objc/message.h>
+#include <objc/runtime.h>
+#include <stdlib.h>
+
+#include "../../diagnostics.h"
+#include "../../render_target.h"
+#include "../../types.h"
+#include "../../util.h"
+#include "../render.h"
+
+extern id MTLCreateSystemDefaultDevice(void);
+extern void* objc_autoreleasePoolPush(void);
+extern void objc_autoreleasePoolPop(void* pool);
+
+// Metal enum values stated directly, so the example needs no Objective-C
+// headers. Each matches its MTL* counterpart by name.
+static constexpr unsigned long mtl_pixel_format_bgra8_unorm = 80;
+static constexpr unsigned long mtl_pixel_format_rgba8_unorm = 70;
+static constexpr unsigned long mtl_load_action_clear = 2;
+static constexpr unsigned long mtl_store_action_store = 1;
+static constexpr unsigned long mtl_primitive_type_triangle = 3;
+static constexpr unsigned long mtl_texture_usage_shader_read = 1;
+static constexpr unsigned long mtl_texture_usage_render_target = 4;
+
+/// CGSize stated directly: two CGFloat fields.
+typedef struct metal_cg_size {
+  double width;
+  double height;
+} metal_cg_size;
+
+/// MTLClearColor stated directly: four double fields.
+typedef struct metal_clear_color {
+  double red;
+  double green;
+  double blue;
+  double alpha;
+} metal_clear_color;
+
+static const char* const metal_shader_source =
+  "#include <metal_stdlib>\n"
+  "using namespace metal;\n"
+  "struct VertexOut {\n"
+  "  float4 position [[position]];\n"
+  "  float2 uv;\n"
+  "};\n"
+  "vertex VertexOut vertex_main(uint vertex_id [[vertex_id]]) {\n"
+  "  float2 positions[3] = {\n"
+  "    float2(-1.0, 1.0), float2(3.0, 1.0), float2(-1.0, -3.0),\n"
+  "  };\n"
+  "  float2 uvs[3] = {\n"
+  "    float2(0.0, 0.0), float2(2.0, 0.0), float2(0.0, 2.0),\n"
+  "  };\n"
+  "  VertexOut out;\n"
+  "  out.position = float4(positions[vertex_id], 0.0, 1.0);\n"
+  "  out.uv = uvs[vertex_id];\n"
+  "  return out;\n"
+  "}\n"
+  "fragment float4 fragment_main(\n"
+  "  VertexOut in [[stage_in]],\n"
+  "  texture2d<float> map_texture [[texture(0)]]\n"
+  ") {\n"
+  "  constexpr sampler map_sampler(address::clamp_to_edge, filter::linear);\n"
+  "  return map_texture.sample(map_sampler, in.uv);\n"
+  "}\n";
+
+// Typed objc_msgSend wrappers for the common message shapes. Less common
+// shapes cast objc_msgSend at the call site instead.
+
+static id msg_id(id receiver, const char* selector) {
+  return ((id (*)(id, SEL))objc_msgSend)(receiver, sel_registerName(selector));
+}
+
+static void msg_void(id receiver, const char* selector) {
+  ((void (*)(id, SEL))objc_msgSend)(receiver, sel_registerName(selector));
+}
+
+static void msg_set_id(id receiver, const char* selector, id value) {
+  ((void (*)(id, SEL, id))objc_msgSend)(
+    receiver, sel_registerName(selector), value
+  );
+}
+
+static void msg_set_ulong(
+  id receiver, const char* selector, unsigned long value
+) {
+  ((void (*)(id, SEL, unsigned long))objc_msgSend)(
+    receiver, sel_registerName(selector), value
+  );
+}
+
+static id msg_id_with_id(id receiver, const char* selector, id value) {
+  return ((id (*)(id, SEL, id))objc_msgSend)(
+    receiver, sel_registerName(selector), value
+  );
+}
+
+static id msg_id_at_index(
+  id receiver, const char* selector, unsigned long index
+) {
+  return ((id (*)(id, SEL, unsigned long))objc_msgSend)(
+    receiver, sel_registerName(selector), index
+  );
+}
+
+static id class_object(const char* name) { return (id)objc_getClass(name); }
+
+static id nsstring_from_utf8(const char* value) {
+  return ((id (*)(id, SEL, const char*))objc_msgSend)(
+    class_object("NSString"), sel_registerName("stringWithUTF8String:"), value
+  );
+}
+
+static void release_object(id* object) {
+  if (*object != nullptr) {
+    msg_void(*object, "release");
+    *object = nullptr;
+  }
+}
+
+static metal_cg_size drawable_size(viewport current_viewport) {
+  return (metal_cg_size){
+    .width = (double)current_viewport.physical_width,
+    .height = (double)current_viewport.physical_height,
+  };
+}
+
+/// The SDL Metal view plus the device and CAMetalLayer behind it. The layer
+/// belongs to the view; the device is the one object this struct releases.
+typedef struct metal_view {
+  SDL_MetalView view;
+  id device;
+  id layer;
+} metal_view;
+
+static void metal_view_resize(metal_view* view, viewport current_viewport) {
+  ((void (*)(id, SEL, metal_cg_size))objc_msgSend)(
+    view->layer, sel_registerName("setDrawableSize:"),
+    drawable_size(current_viewport)
+  );
+}
+
+static void metal_view_deinit(metal_view* view) {
+  release_object(&view->device);
+  if (view->view != nullptr) {
+    SDL_Metal_DestroyView(view->view);
+    view->view = nullptr;
+  }
+}
+
+static app_error metal_view_init(
+  metal_view* view, SDL_Window* window, viewport current_viewport
+) {
+  *view = (metal_view){};
+  view->view = SDL_Metal_CreateView(window);
+  if (view->view == nullptr) {
+    return APP_ERROR_BACKEND_SETUP_FAILED;
+  }
+  view->device = MTLCreateSystemDefaultDevice();
+  void* layer = SDL_Metal_GetLayer(view->view);
+  if (view->device == nullptr || layer == nullptr) {
+    metal_view_deinit(view);
+    return APP_ERROR_BACKEND_SETUP_FAILED;
+  }
+  view->layer = (id)layer;
+  msg_set_id(view->layer, "setDevice:", view->device);
+  msg_set_ulong(view->layer, "setPixelFormat:", mtl_pixel_format_bgra8_unorm);
+  metal_view_resize(view, current_viewport);
+  return APP_OK;
+}
+
+static app_error create_pipeline(id device, id* out_pipeline) {
+  const id source = nsstring_from_utf8(metal_shader_source);
+  if (source == nullptr) {
+    return APP_ERROR_BACKEND_SETUP_FAILED;
+  }
+
+  id library_error = nullptr;
+  id library = ((id (*)(id, SEL, id, id, id*))objc_msgSend)(
+    device, sel_registerName("newLibraryWithSource:options:error:"), source,
+    nullptr, &library_error
+  );
+  if (library == nullptr) {
+    return APP_ERROR_BACKEND_SETUP_FAILED;
+  }
+
+  id vertex = msg_id_with_id(
+    library, "newFunctionWithName:", nsstring_from_utf8("vertex_main")
+  );
+  id fragment = msg_id_with_id(
+    library, "newFunctionWithName:", nsstring_from_utf8("fragment_main")
+  );
+  id descriptor = nullptr;
+  id pipeline = nullptr;
+  if (vertex != nullptr && fragment != nullptr) {
+    descriptor = msg_id(
+      msg_id(class_object("MTLRenderPipelineDescriptor"), "alloc"), "init"
+    );
+  }
+  if (descriptor != nullptr) {
+    msg_set_id(descriptor, "setVertexFunction:", vertex);
+    msg_set_id(descriptor, "setFragmentFunction:", fragment);
+    const id attachment = msg_id_at_index(
+      msg_id(descriptor, "colorAttachments"), "objectAtIndexedSubscript:", 0
+    );
+    msg_set_ulong(attachment, "setPixelFormat:", mtl_pixel_format_bgra8_unorm);
+
+    id pipeline_error = nullptr;
+    pipeline = ((id (*)(id, SEL, id, id*))objc_msgSend)(
+      device, sel_registerName("newRenderPipelineStateWithDescriptor:error:"),
+      descriptor, &pipeline_error
+    );
+  }
+  release_object(&descriptor);
+  release_object(&fragment);
+  release_object(&vertex);
+  release_object(&library);
+  if (pipeline == nullptr) {
+    return APP_ERROR_BACKEND_SETUP_FAILED;
+  }
+  *out_pipeline = pipeline;
+  return APP_OK;
+}
+
+/// The compositor: a fullscreen-triangle pass that samples the map texture
+/// into the layer's next drawable.
+typedef struct metal_compositor {
+  metal_view view;
+  id queue;
+  id pipeline;
+} metal_compositor;
+
+static void metal_compositor_deinit(metal_compositor* compositor) {
+  release_object(&compositor->pipeline);
+  release_object(&compositor->queue);
+  metal_view_deinit(&compositor->view);
+}
+
+static app_error metal_compositor_init(
+  metal_compositor* compositor, SDL_Window* window, viewport current_viewport
+) {
+  *compositor = (metal_compositor){};
+  MAP_TRY(metal_view_init(&compositor->view, window, current_viewport));
+  compositor->queue = msg_id(compositor->view.device, "newCommandQueue");
+  app_error error = APP_OK;
+  if (compositor->queue == nullptr) {
+    error = APP_ERROR_BACKEND_SETUP_FAILED;
+  } else {
+    error = create_pipeline(compositor->view.device, &compositor->pipeline);
+  }
+  if (error != APP_OK) {
+    metal_compositor_deinit(compositor);
+  }
+  return error;
+}
+
+static void metal_compositor_resize(
+  metal_compositor* compositor, viewport current_viewport
+) {
+  metal_view_resize(&compositor->view, current_viewport);
+}
+
+static app_error metal_compositor_draw_texture(
+  metal_compositor* compositor, id texture
+) {
+  const id drawable = msg_id(compositor->view.layer, "nextDrawable");
+  if (drawable == nullptr) {
+    return APP_ERROR_BACKEND_DRAW_FAILED;
+  }
+
+  const id drawable_texture = msg_id(drawable, "texture");
+  const id pass_descriptor =
+    msg_id(class_object("MTLRenderPassDescriptor"), "renderPassDescriptor");
+  const id attachment = msg_id_at_index(
+    msg_id(pass_descriptor, "colorAttachments"), "objectAtIndexedSubscript:", 0
+  );
+  msg_set_id(attachment, "setTexture:", drawable_texture);
+  msg_set_ulong(attachment, "setLoadAction:", mtl_load_action_clear);
+  msg_set_ulong(attachment, "setStoreAction:", mtl_store_action_store);
+  ((void (*)(id, SEL, metal_clear_color))objc_msgSend)(
+    attachment, sel_registerName("setClearColor:"),
+    (metal_clear_color){.red = 0.08, .green = 0.09, .blue = 0.11, .alpha = 1.0}
+  );
+
+  const id command_buffer = msg_id(compositor->queue, "commandBuffer");
+  if (command_buffer == nullptr) {
+    return APP_ERROR_BACKEND_DRAW_FAILED;
+  }
+  const id encoder = msg_id_with_id(
+    command_buffer, "renderCommandEncoderWithDescriptor:", pass_descriptor
+  );
+  if (encoder == nullptr) {
+    return APP_ERROR_BACKEND_DRAW_FAILED;
+  }
+
+  msg_set_id(encoder, "setRenderPipelineState:", compositor->pipeline);
+  ((void (*)(id, SEL, id, unsigned long))objc_msgSend)(
+    encoder, sel_registerName("setFragmentTexture:atIndex:"), texture, 0
+  );
+  ((void (*)(id, SEL, unsigned long, unsigned long, unsigned long))
+     objc_msgSend)(
+    encoder, sel_registerName("drawPrimitives:vertexStart:vertexCount:"),
+    mtl_primitive_type_triangle, 0, 3
+  );
+  msg_void(encoder, "endEncoding");
+  msg_set_id(command_buffer, "presentDrawable:", drawable);
+  msg_void(command_buffer, "commit");
+  msg_void(command_buffer, "waitUntilCompleted");
+  return APP_OK;
+}
+
+static app_error borrowed_texture_create(
+  id device, viewport current_viewport, id* out_texture
+) {
+  const id descriptor = ((
+    id (*)(id, SEL, unsigned long, unsigned long, unsigned long, bool)
+  )objc_msgSend)(
+    class_object("MTLTextureDescriptor"),
+    sel_registerName(
+      "texture2DDescriptorWithPixelFormat:width:height:mipmapped:"
+    ),
+    mtl_pixel_format_rgba8_unorm, current_viewport.physical_width,
+    current_viewport.physical_height, false
+  );
+  if (descriptor == nullptr) {
+    return APP_ERROR_BACKEND_SETUP_FAILED;
+  }
+  msg_set_ulong(
+    descriptor,
+    "setUsage:", mtl_texture_usage_shader_read | mtl_texture_usage_render_target
+  );
+  const id texture =
+    msg_id_with_id(device, "newTextureWithDescriptor:", descriptor);
+  if (texture == nullptr) {
+    return APP_ERROR_BACKEND_SETUP_FAILED;
+  }
+  *out_texture = texture;
+  return APP_OK;
+}
+
+struct render_target {
+  render_target_mode mode;
+  render_session session;
+  union {
+    struct {
+      metal_compositor compositor;
+    } owned;
+    struct {
+      metal_compositor compositor;
+      id texture;
+    } borrowed;
+    struct {
+      metal_view view;
+    } surface;
+  } as;
+};
+
+uint32_t render_target_backend_flag(void) {
+  return MLN_RENDER_BACKEND_FLAG_METAL;
+}
+
+void render_target_apply_sdl_hints(void) {}
+
+app_error render_target_configure_video(void) { return APP_OK; }
+
+SDL_WindowFlags render_target_window_flags(void) { return SDL_WINDOW_METAL; }
+
+void* render_target_frame_scope_open(void) {
+  return objc_autoreleasePoolPush();
+}
+
+void render_target_frame_scope_close(void* scope) {
+  objc_autoreleasePoolPop(scope);
+}
+
+app_error render_target_init(
+  render_target** out_target, SDL_Window* window, viewport current_viewport,
+  render_target_mode mode
+) {
+  render_target* target = calloc(1, sizeof(render_target));
+  if (target == nullptr) {
+    return APP_ERROR_BACKEND_SETUP_FAILED;
+  }
+  target->mode = mode;
+
+  app_error error = APP_OK;
+  switch (mode) {
+    case RENDER_TARGET_MODE_OWNED_TEXTURE:
+      error = metal_compositor_init(
+        &target->as.owned.compositor, window, current_viewport
+      );
+      break;
+    case RENDER_TARGET_MODE_BORROWED_TEXTURE:
+      error = metal_compositor_init(
+        &target->as.borrowed.compositor, window, current_viewport
+      );
+      if (error == APP_OK) {
+        error = borrowed_texture_create(
+          target->as.borrowed.compositor.view.device, current_viewport,
+          &target->as.borrowed.texture
+        );
+        if (error != APP_OK) {
+          metal_compositor_deinit(&target->as.borrowed.compositor);
+        }
+      }
+      break;
+    case RENDER_TARGET_MODE_NATIVE_SURFACE:
+      error =
+        metal_view_init(&target->as.surface.view, window, current_viewport);
+      break;
+  }
+  if (error != APP_OK) {
+    free(target);
+    return error;
+  }
+  *out_target = target;
+  return APP_OK;
+}
+
+static mln_metal_context_descriptor metal_context_descriptor(id device) {
+  return (mln_metal_context_descriptor){
+    .size = sizeof(mln_metal_context_descriptor),
+    .device = device,
+  };
+}
+
+static mln_metal_borrowed_texture_descriptor borrowed_texture_descriptor(
+  render_target* target, viewport current_viewport
+) {
+  mln_metal_borrowed_texture_descriptor descriptor =
+    mln_metal_borrowed_texture_descriptor_default();
+  descriptor.extent = render_target_extent(current_viewport);
+  descriptor.physical_width = current_viewport.physical_width;
+  descriptor.physical_height = current_viewport.physical_height;
+  descriptor.texture = target->as.borrowed.texture;
+  return descriptor;
+}
+
+app_error render_target_attach(
+  render_target* target, mln_map map, viewport current_viewport
+) {
+  mln_render_session session = MLN_HANDLE_NULL;
+  switch (target->mode) {
+    case RENDER_TARGET_MODE_OWNED_TEXTURE: {
+      mln_metal_owned_texture_descriptor descriptor =
+        mln_metal_owned_texture_descriptor_default();
+      descriptor.extent = render_target_extent(current_viewport);
+      descriptor.context =
+        metal_context_descriptor(target->as.owned.compositor.view.device);
+      const mln_status status =
+        mln_metal_owned_texture_attach(map, &descriptor, &session);
+      if (status != MLN_STATUS_OK) {
+        diagnostics_log_status("Metal texture attach failed", status);
+        return APP_ERROR_TEXTURE_ATTACH_FAILED;
+      }
+      target->session =
+        (render_session){.kind = RENDER_SESSION_TEXTURE, .handle = session};
+      return APP_OK;
+    }
+    case RENDER_TARGET_MODE_BORROWED_TEXTURE: {
+      const mln_metal_borrowed_texture_descriptor descriptor =
+        borrowed_texture_descriptor(target, current_viewport);
+      const mln_status status =
+        mln_metal_borrowed_texture_attach(map, &descriptor, &session);
+      if (status != MLN_STATUS_OK) {
+        diagnostics_log_status("Metal borrowed texture attach failed", status);
+        return APP_ERROR_TEXTURE_ATTACH_FAILED;
+      }
+      target->session =
+        (render_session){.kind = RENDER_SESSION_TEXTURE, .handle = session};
+      return APP_OK;
+    }
+    case RENDER_TARGET_MODE_NATIVE_SURFACE: {
+      mln_metal_surface_descriptor descriptor =
+        mln_metal_surface_descriptor_default();
+      descriptor.extent = render_target_extent(current_viewport);
+      descriptor.context =
+        metal_context_descriptor(target->as.surface.view.device);
+      descriptor.layer = target->as.surface.view.layer;
+      const mln_status status =
+        mln_metal_surface_attach(map, &descriptor, &session);
+      if (status != MLN_STATUS_OK) {
+        diagnostics_log_status("Metal surface attach failed", status);
+        return APP_ERROR_SURFACE_ATTACH_FAILED;
+      }
+      target->session =
+        (render_session){.kind = RENDER_SESSION_SURFACE, .handle = session};
+      return APP_OK;
+    }
+  }
+  return APP_ERROR_BACKEND_SETUP_FAILED;
+}
+
+void render_target_deinit(render_target* target) {
+  if (target == nullptr) {
+    return;
+  }
+  render_session_close(&target->session);
+  switch (target->mode) {
+    case RENDER_TARGET_MODE_OWNED_TEXTURE:
+      metal_compositor_deinit(&target->as.owned.compositor);
+      break;
+    case RENDER_TARGET_MODE_BORROWED_TEXTURE:
+      release_object(&target->as.borrowed.texture);
+      metal_compositor_deinit(&target->as.borrowed.compositor);
+      break;
+    case RENDER_TARGET_MODE_NATIVE_SURFACE:
+      metal_view_deinit(&target->as.surface.view);
+      break;
+  }
+  free(target);
+}
+
+/// Follows a resized window in borrowed-texture mode.
+///
+/// This example sizes the borrowed texture, not the session, so following a
+/// resize means allocating one at the new size and handing it to the live
+/// session. The session stays live, which is what keeps the map from going
+/// cold on every resize.
+static app_error resize_borrowed(
+  render_target* target, viewport current_viewport
+) {
+  if (target->session.kind != RENDER_SESSION_TEXTURE) {
+    return APP_ERROR_TEXTURE_RESIZE_FAILED;
+  }
+  metal_compositor_resize(&target->as.borrowed.compositor, current_viewport);
+
+  id previous = target->as.borrowed.texture;
+  id replacement = nullptr;
+  MAP_TRY(borrowed_texture_create(
+    target->as.borrowed.compositor.view.device, current_viewport, &replacement
+  ));
+  target->as.borrowed.texture = replacement;
+  const mln_metal_borrowed_texture_descriptor descriptor =
+    borrowed_texture_descriptor(target, current_viewport);
+  const mln_status status =
+    mln_metal_borrowed_texture_set_target(target->session.handle, &descriptor);
+  if (status != MLN_STATUS_OK) {
+    // A native error may mean the session took the replacement before
+    // failing, and nothing here can tell that apart from a rejection that
+    // came first, so detach before either target is released.
+    mln_render_session_detach(target->session.handle);
+    diagnostics_log_status("Metal borrowed texture set target failed", status);
+    target->as.borrowed.texture = previous;
+    release_object(&replacement);
+    return APP_ERROR_TEXTURE_RESIZE_FAILED;
+  }
+  // Only once the session has taken the replacement, so a rejected one leaves
+  // this target on the texture it already had.
+  release_object(&previous);
+  return APP_OK;
+}
+
+app_error render_target_resize(
+  render_target* target, viewport current_viewport
+) {
+  switch (target->mode) {
+    case RENDER_TARGET_MODE_OWNED_TEXTURE:
+      metal_compositor_resize(&target->as.owned.compositor, current_viewport);
+      return render_session_resize(&target->session, current_viewport);
+    case RENDER_TARGET_MODE_BORROWED_TEXTURE:
+      return resize_borrowed(target, current_viewport);
+    case RENDER_TARGET_MODE_NATIVE_SURFACE:
+      metal_view_resize(&target->as.surface.view, current_viewport);
+      return render_session_resize(&target->session, current_viewport);
+  }
+  return APP_ERROR_BACKEND_SETUP_FAILED;
+}
+
+app_error render_target_finish_frame(render_target* target) {
+  (void)target;
+  return APP_OK;
+}
+
+static app_error render_update_owned(
+  render_target* target, bool* out_rendered
+) {
+  bool rendered = false;
+  MAP_TRY(render_session_render_update(&target->session, &rendered));
+  if (!rendered) {
+    return APP_OK;
+  }
+
+  mln_metal_owned_texture_frame frame = {.size = sizeof(frame)};
+  const mln_status status =
+    mln_metal_owned_texture_acquire_frame(target->session.handle, &frame);
+  if (status == MLN_STATUS_INVALID_STATE) {
+    return APP_OK;
+  }
+  if (status != MLN_STATUS_OK) {
+    diagnostics_log_status("Metal texture acquire failed", status);
+    return APP_ERROR_BACKEND_DRAW_FAILED;
+  }
+
+  const app_error error = metal_compositor_draw_texture(
+    &target->as.owned.compositor, (id)frame.texture
+  );
+  const mln_status release_status =
+    mln_metal_owned_texture_release_frame(target->session.handle, &frame);
+  if (release_status != MLN_STATUS_OK) {
+    diagnostics_log_status("Metal texture release failed", release_status);
+  }
+  MAP_TRY(error);
+  *out_rendered = true;
+  return APP_OK;
+}
+
+app_error render_target_render_update(
+  render_target* target, viewport current_viewport, bool* out_rendered
+) {
+  (void)current_viewport;
+  *out_rendered = false;
+  switch (target->mode) {
+    case RENDER_TARGET_MODE_OWNED_TEXTURE:
+      return render_update_owned(target, out_rendered);
+    case RENDER_TARGET_MODE_BORROWED_TEXTURE: {
+      bool rendered = false;
+      MAP_TRY(render_session_render_update(&target->session, &rendered));
+      if (!rendered) {
+        return APP_OK;
+      }
+      MAP_TRY(metal_compositor_draw_texture(
+        &target->as.borrowed.compositor, target->as.borrowed.texture
+      ));
+      *out_rendered = true;
+      return APP_OK;
+    }
+    case RENDER_TARGET_MODE_NATIVE_SURFACE:
+      return render_session_render_update(&target->session, out_rendered);
+  }
+  return APP_ERROR_BACKEND_SETUP_FAILED;
+}

--- a/examples/c-map/render/metal/metal.c
+++ b/examples/c-map/render/metal/metal.c
@@ -270,12 +270,17 @@ static void metal_compositor_resize(
   metal_view_resize(&compositor->view, current_viewport);
 }
 
+/// Samples texture into the layer's next drawable. Reports false without
+/// presenting when the layer has no drawable to hand out, which a minimized
+/// or occluded window legitimately has not; the caller's render request stays
+/// pending and the draw retries once one is available.
 static app_error metal_compositor_draw_texture(
-  metal_compositor* compositor, id texture
+  metal_compositor* compositor, id texture, bool* out_presented
 ) {
+  *out_presented = false;
   const id drawable = msg_id(compositor->view.layer, "nextDrawable");
   if (drawable == nullptr) {
-    return APP_ERROR_BACKEND_DRAW_FAILED;
+    return APP_OK;
   }
 
   const id drawable_texture = msg_id(drawable, "texture");
@@ -316,6 +321,7 @@ static app_error metal_compositor_draw_texture(
   msg_set_id(command_buffer, "presentDrawable:", drawable);
   msg_void(command_buffer, "commit");
   msg_void(command_buffer, "waitUntilCompleted");
+  *out_presented = true;
   return APP_OK;
 }
 
@@ -602,8 +608,9 @@ static app_error render_update_owned(
     return APP_ERROR_BACKEND_DRAW_FAILED;
   }
 
+  bool presented = false;
   const app_error error = metal_compositor_draw_texture(
-    &target->as.owned.compositor, (id)frame.texture
+    &target->as.owned.compositor, (id)frame.texture, &presented
   );
   const mln_status release_status =
     mln_metal_owned_texture_release_frame(target->session.handle, &frame);
@@ -611,7 +618,7 @@ static app_error render_update_owned(
     diagnostics_log_status("Metal texture release failed", release_status);
   }
   MAP_TRY(error);
-  *out_rendered = true;
+  *out_rendered = presented;
   return APP_OK;
 }
 
@@ -630,9 +637,9 @@ app_error render_target_render_update(
         return APP_OK;
       }
       MAP_TRY(metal_compositor_draw_texture(
-        &target->as.borrowed.compositor, target->as.borrowed.texture
+        &target->as.borrowed.compositor, target->as.borrowed.texture,
+        out_rendered
       ));
-      *out_rendered = true;
       return APP_OK;
     }
     case RENDER_TARGET_MODE_NATIVE_SURFACE:

--- a/examples/c-map/render/opengl/opengl.c
+++ b/examples/c-map/render/opengl/opengl.c
@@ -2,7 +2,8 @@
 // EGL handles, a GL ES 3.0 fullscreen-triangle compositor, and the three
 // render-target modes behind the uniform interface in render.h.
 //
-// This build targets EGL on Linux; the WGL arm returns with Windows support.
+// This build targets EGL on Linux and macOS, where ANGLE provides the EGL
+// implementation; the WGL arm returns with Windows support.
 
 #include <GLES3/gl3.h>
 #include <SDL3/SDL.h>
@@ -502,6 +503,10 @@ app_error render_target_configure_video(void) {
 }
 
 SDL_WindowFlags render_target_window_flags(void) { return SDL_WINDOW_OPENGL; }
+
+void* render_target_frame_scope_open(void) { return nullptr; }
+
+void render_target_frame_scope_close(void* scope) { (void)scope; }
 
 app_error render_target_init(
   render_target** out_target, SDL_Window* window, viewport current_viewport,

--- a/examples/c-map/render/render.h
+++ b/examples/c-map/render/render.h
@@ -26,6 +26,14 @@ void render_target_apply_sdl_hints(void);
 /// The SDL window flag the active backend's surface needs.
 SDL_WindowFlags render_target_window_flags(void);
 
+/// Opens the scope one render-loop iteration runs inside. Metal returns an
+/// autorelease pool that collects the iteration's presentation objects; the
+/// other backends return null.
+void* render_target_frame_scope_open(void);
+
+/// Closes a scope returned by render_target_frame_scope_open().
+void render_target_frame_scope_close(void* scope);
+
 /// Creates the graphics context and the mode's presentation resources on the
 /// calling thread, which must be the render loop thread that owns the window.
 [[nodiscard]] app_error render_target_init(

--- a/examples/c-map/render/vulkan/commands.c
+++ b/examples/c-map/render/vulkan/commands.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include "commands.h"
 
 #include "util.h"
@@ -28,9 +30,6 @@ static app_error commands_create(
   MAP_TRY(expect_vk(vkCreateSemaphore(
     device, &semaphore_info, nullptr, &commands->image_available
   )));
-  MAP_TRY(expect_vk(vkCreateSemaphore(
-    device, &semaphore_info, nullptr, &commands->render_finished
-  )));
   const VkFenceCreateInfo fence_info = {
     .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
     .flags = VK_FENCE_CREATE_SIGNALED_BIT,
@@ -51,12 +50,44 @@ app_error vulkan_commands_init(
   return error;
 }
 
+app_error vulkan_commands_create_present_semaphores(
+  vulkan_commands* commands, VkDevice device, uint32_t image_count
+) {
+  commands->render_finished = calloc(image_count, sizeof(VkSemaphore));
+  if (commands->render_finished == nullptr) {
+    return APP_ERROR_BACKEND_SETUP_FAILED;
+  }
+  commands->render_finished_count = image_count;
+  const VkSemaphoreCreateInfo semaphore_info = {
+    .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+  };
+  for (uint32_t i = 0; i < image_count; i += 1) {
+    MAP_TRY(expect_vk(vkCreateSemaphore(
+      device, &semaphore_info, nullptr, &commands->render_finished[i]
+    )));
+  }
+  return APP_OK;
+}
+
+void vulkan_commands_destroy_present_semaphores(
+  vulkan_commands* commands, VkDevice device
+) {
+  if (commands->render_finished != nullptr) {
+    for (uint32_t i = 0; i < commands->render_finished_count; i += 1) {
+      if (commands->render_finished[i] != VK_NULL_HANDLE) {
+        vkDestroySemaphore(device, commands->render_finished[i], nullptr);
+      }
+    }
+    free(commands->render_finished);
+  }
+  commands->render_finished = nullptr;
+  commands->render_finished_count = 0;
+}
+
 void vulkan_commands_deinit(vulkan_commands* commands, VkDevice device) {
+  vulkan_commands_destroy_present_semaphores(commands, device);
   if (commands->in_flight != VK_NULL_HANDLE) {
     vkDestroyFence(device, commands->in_flight, nullptr);
-  }
-  if (commands->render_finished != VK_NULL_HANDLE) {
-    vkDestroySemaphore(device, commands->render_finished, nullptr);
   }
   if (commands->image_available != VK_NULL_HANDLE) {
     vkDestroySemaphore(device, commands->image_available, nullptr);
@@ -132,7 +163,9 @@ app_error vulkan_commands_record(
   return expect_vk(vkEndCommandBuffer(commands->command_buffer));
 }
 
-app_error vulkan_commands_submit(vulkan_commands* commands, VkQueue queue) {
+app_error vulkan_commands_submit(
+  vulkan_commands* commands, VkQueue queue, uint32_t image_index
+) {
   const VkPipelineStageFlags wait_stages[] = {
     VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
   };
@@ -144,7 +177,7 @@ app_error vulkan_commands_submit(vulkan_commands* commands, VkQueue queue) {
     .commandBufferCount = 1,
     .pCommandBuffers = &commands->command_buffer,
     .signalSemaphoreCount = 1,
-    .pSignalSemaphores = &commands->render_finished,
+    .pSignalSemaphores = &commands->render_finished[image_index],
   };
   return expect_vk(vkQueueSubmit(queue, 1, &submit_info, commands->in_flight));
 }

--- a/examples/c-map/render/vulkan/commands.h
+++ b/examples/c-map/render/vulkan/commands.h
@@ -14,7 +14,12 @@ typedef struct vulkan_commands {
   VkCommandPool command_pool;
   VkCommandBuffer command_buffer;
   VkSemaphore image_available;
-  VkSemaphore render_finished;
+  /// One present-wait semaphore per swapchain image, indexed by the acquired
+  /// image. The frame fence proves a submit finished, but only the next
+  /// acquire of the same image proves its present consumed the semaphore, so
+  /// a single reused semaphore is a race the presentation engine may lose.
+  VkSemaphore* render_finished;
+  uint32_t render_finished_count;
   VkFence in_flight;
 } vulkan_commands;
 
@@ -22,6 +27,15 @@ typedef struct vulkan_commands {
   vulkan_commands* commands, VkDevice device, uint32_t queue_family_index
 );
 void vulkan_commands_deinit(vulkan_commands* commands, VkDevice device);
+
+/// Sizes the present-wait semaphores to the swapchain, on creation and on
+/// every replacement. The caller waits the device idle first.
+[[nodiscard]] app_error vulkan_commands_create_present_semaphores(
+  vulkan_commands* commands, VkDevice device, uint32_t image_count
+);
+void vulkan_commands_destroy_present_semaphores(
+  vulkan_commands* commands, VkDevice device
+);
 
 [[nodiscard]] app_error vulkan_commands_wait_for_frame_fence(
   vulkan_commands* commands, VkDevice device
@@ -33,8 +47,10 @@ void vulkan_commands_deinit(vulkan_commands* commands, VkDevice device);
   vulkan_commands* commands, const vulkan_swapchain* swapchain,
   const vulkan_pipeline* pipeline, uint32_t image_index
 );
+/// Submits the recorded commands, signaling the acquired image's
+/// present-wait semaphore.
 [[nodiscard]] app_error vulkan_commands_submit(
-  vulkan_commands* commands, VkQueue queue
+  vulkan_commands* commands, VkQueue queue, uint32_t image_index
 );
 
 #endif  // C_MAP_RENDER_VULKAN_COMMANDS_H

--- a/examples/c-map/render/vulkan/context.c
+++ b/examples/c-map/render/vulkan/context.c
@@ -132,6 +132,34 @@ static app_error pick_device(vulkan_context* context) {
   return error;
 }
 
+static app_error has_device_extension(
+  VkPhysicalDevice device, const char* name, bool* out_found
+) {
+  *out_found = false;
+  uint32_t count = 0;
+  MAP_TRY(expect_vk(
+    vkEnumerateDeviceExtensionProperties(device, nullptr, &count, nullptr)
+  ));
+  VkExtensionProperties* properties =
+    calloc(count, sizeof(VkExtensionProperties));
+  if (properties == nullptr) {
+    return APP_ERROR_BACKEND_SETUP_FAILED;
+  }
+  const app_error error = expect_vk(
+    vkEnumerateDeviceExtensionProperties(device, nullptr, &count, properties)
+  );
+  if (error == APP_OK) {
+    for (uint32_t i = 0; i < count; i += 1) {
+      if (strcmp(properties[i].extensionName, name) == 0) {
+        *out_found = true;
+        break;
+      }
+    }
+  }
+  free(properties);
+  return error;
+}
+
 static app_error create_device(vulkan_context* context) {
   const float priority = 1.0f;
   const VkDeviceQueueCreateInfo queue_info = {
@@ -140,14 +168,24 @@ static app_error create_device(vulkan_context* context) {
     .queueCount = 1,
     .pQueuePriorities = &priority,
   };
-  const char* const extensions[] = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+  // A device that exposes the portability subset requires enabling it. The
+  // name is spelled out because its declaration lives behind the provisional
+  // vulkan_beta.h header.
+  bool needs_portability = false;
+  MAP_TRY(has_device_extension(
+    context->physical_device, "VK_KHR_portability_subset", &needs_portability
+  ));
+  const char* extensions[] = {
+    VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+    "VK_KHR_portability_subset",
+  };
   VkPhysicalDeviceFeatures features;
   vkGetPhysicalDeviceFeatures(context->physical_device, &features);
   const VkDeviceCreateInfo create_info = {
     .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
     .queueCreateInfoCount = 1,
     .pQueueCreateInfos = &queue_info,
-    .enabledExtensionCount = 1,
+    .enabledExtensionCount = needs_portability ? 2 : 1,
     .ppEnabledExtensionNames = extensions,
     .pEnabledFeatures = &features,
   };

--- a/examples/c-map/render/vulkan/swapchain.c
+++ b/examples/c-map/render/vulkan/swapchain.c
@@ -50,7 +50,7 @@ static VkExtent2D choose_extent(
 
 static app_error swapchain_create(
   vulkan_swapchain* swapchain, const vulkan_context* context,
-  viewport current_viewport
+  viewport current_viewport, VkSwapchainKHR old_swapchain
 ) {
   VkSurfaceCapabilitiesKHR capabilities;
   MAP_TRY(expect_vk(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
@@ -100,7 +100,7 @@ static app_error swapchain_create(
     .compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
     .presentMode = VK_PRESENT_MODE_FIFO_KHR,
     .clipped = VK_TRUE,
-    .oldSwapchain = VK_NULL_HANDLE,
+    .oldSwapchain = old_swapchain,
   };
   MAP_TRY(expect_vk(vkCreateSwapchainKHR(
     context->device, &create_info, nullptr, &swapchain->handle
@@ -130,11 +130,11 @@ static app_error swapchain_create(
 
 app_error vulkan_swapchain_init(
   vulkan_swapchain* swapchain, const vulkan_context* context,
-  viewport current_viewport
+  viewport current_viewport, VkSwapchainKHR old_swapchain
 ) {
   *swapchain = (vulkan_swapchain){.format = VK_FORMAT_UNDEFINED};
   const app_error error =
-    swapchain_create(swapchain, context, current_viewport);
+    swapchain_create(swapchain, context, current_viewport, old_swapchain);
   if (error != APP_OK) {
     vulkan_swapchain_deinit(swapchain, context->device);
   }

--- a/examples/c-map/render/vulkan/swapchain.h
+++ b/examples/c-map/render/vulkan/swapchain.h
@@ -19,9 +19,12 @@ typedef struct vulkan_swapchain {
   VkFramebuffer* framebuffers;
 } vulkan_swapchain;
 
+/// Creates the swapchain. A replacement passes the swapchain it retires as
+/// old_swapchain, so the presentation engine hands the surface over without a
+/// gap; the caller destroys the retired one after this returns.
 [[nodiscard]] app_error vulkan_swapchain_init(
   vulkan_swapchain* swapchain, const vulkan_context* context,
-  viewport current_viewport
+  viewport current_viewport, VkSwapchainKHR old_swapchain
 );
 void vulkan_swapchain_deinit(vulkan_swapchain* swapchain, VkDevice device);
 

--- a/examples/c-map/render/vulkan/util.c
+++ b/examples/c-map/render/vulkan/util.c
@@ -3,17 +3,17 @@
 
 #include "util.h"
 
-app_error expect_vk(VkResult result) {
+app_error expect_vk_named(VkResult result, const char* what) {
   if (result != VK_SUCCESS) {
-    fprintf(stderr, "Vulkan call failed: %d\n", (int)result);
+    fprintf(stderr, "Vulkan call failed: %d in %s\n", (int)result, what);
     return APP_ERROR_BACKEND_SETUP_FAILED;
   }
   return APP_OK;
 }
 
-app_error expect_vk_or_suboptimal(VkResult result) {
+app_error expect_vk_or_suboptimal_named(VkResult result, const char* what) {
   if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
-    fprintf(stderr, "Vulkan call failed: %d\n", (int)result);
+    fprintf(stderr, "Vulkan call failed: %d in %s\n", (int)result, what);
     return APP_ERROR_BACKEND_SETUP_FAILED;
   }
   return APP_OK;

--- a/examples/c-map/render/vulkan/util.h
+++ b/examples/c-map/render/vulkan/util.h
@@ -8,8 +8,13 @@
 #include "../../types.h"
 #include "../../util.h"
 
-[[nodiscard]] app_error expect_vk(VkResult result);
-[[nodiscard]] app_error expect_vk_or_suboptimal(VkResult result);
+[[nodiscard]] app_error expect_vk_named(VkResult result, const char* what);
+[[nodiscard]] app_error expect_vk_or_suboptimal_named(
+  VkResult result, const char* what
+);
+#define expect_vk(expr) expect_vk_named((expr), #expr)
+#define expect_vk_or_suboptimal(expr) \
+  expect_vk_or_suboptimal_named((expr), #expr)
 [[nodiscard]] app_error expect_sdl(bool ok);
 
 /// Creates a 2D color image view with identity swizzle over one mip and one

--- a/examples/c-map/render/vulkan/vulkan.c
+++ b/examples/c-map/render/vulkan/vulkan.c
@@ -43,6 +43,8 @@ typedef struct vulkan_compositor {
   vulkan_swapchain swapchain;
   vulkan_pipeline pipeline;
   vulkan_commands commands;
+  viewport current_viewport;
+  bool swapchain_stale;
 } vulkan_compositor;
 
 static void vulkan_compositor_deinit(vulkan_compositor* compositor) {
@@ -78,6 +80,7 @@ static app_error vulkan_compositor_init(
   vulkan_compositor* compositor, SDL_Window* window, viewport current_viewport
 ) {
   *compositor = (vulkan_compositor){};
+  compositor->current_viewport = current_viewport;
   const app_error error =
     vulkan_compositor_create(compositor, window, current_viewport);
   if (error != APP_OK) {
@@ -86,13 +89,29 @@ static app_error vulkan_compositor_init(
   return error;
 }
 
-static app_error vulkan_compositor_resize(
+/// Notes a resized window without touching the swapchain.
+///
+/// The swapchain the window displays stays live until the present that
+/// replaces its content: destroying it here would blank the window for as
+/// long as the map takes to render at the new extent, because the compositor
+/// only presents when a map frame is ready. Presenting through the stale
+/// swapchain scales the old content in the meantime, which is what a resized
+/// native surface shows too.
+static void vulkan_compositor_resize(
   vulkan_compositor* compositor, viewport current_viewport
 ) {
+  compositor->current_viewport = current_viewport;
+  compositor->swapchain_stale = true;
+}
+
+static app_error vulkan_compositor_recreate_swapchain(
+  vulkan_compositor* compositor
+) {
+  vulkan_context_wait_idle(&compositor->context);
   const VkFormat previous_format = compositor->swapchain.format;
   vulkan_swapchain_deinit(&compositor->swapchain, compositor->context.device);
   MAP_TRY(vulkan_swapchain_init(
-    &compositor->swapchain, &compositor->context, current_viewport
+    &compositor->swapchain, &compositor->context, compositor->current_viewport
   ));
 
   if (compositor->swapchain.format != previous_format) {
@@ -130,12 +149,20 @@ static app_error vulkan_compositor_present_image_view(
 
   MAP_TRY(vulkan_compositor_wait_for_frame(compositor));
 
+  // The frame about to present is the first content the resized swapchain
+  // could show, so this is the moment the stale one is replaced.
+  if (compositor->swapchain_stale) {
+    MAP_TRY(vulkan_compositor_recreate_swapchain(compositor));
+    compositor->swapchain_stale = false;
+  }
+
   uint32_t image_index = 0;
   const VkResult acquire = vkAcquireNextImageKHR(
     compositor->context.device, compositor->swapchain.handle, UINT64_MAX,
     compositor->commands.image_available, VK_NULL_HANDLE, &image_index
   );
   if (acquire == VK_ERROR_OUT_OF_DATE_KHR) {
+    compositor->swapchain_stale = true;
     return APP_OK;
   }
   MAP_TRY(expect_vk_or_suboptimal(acquire));
@@ -165,6 +192,7 @@ static app_error vulkan_compositor_present_image_view(
     // Nothing reached the screen. The sampling pass was submitted, so wait it
     // out before the caller releases its frame, and report no present so the
     // render request is set again.
+    compositor->swapchain_stale = true;
     (void)vulkan_compositor_wait_for_frame(compositor);
     return APP_OK;
   }
@@ -485,9 +513,7 @@ static app_error resize_borrowed(
     return APP_ERROR_TEXTURE_RESIZE_FAILED;
   }
   vulkan_context_wait_idle(&target->as.borrowed.compositor.context);
-  MAP_TRY(
-    vulkan_compositor_resize(&target->as.borrowed.compositor, current_viewport)
-  );
+  vulkan_compositor_resize(&target->as.borrowed.compositor, current_viewport);
 
   borrowed_image previous = target->as.borrowed.image;
   borrowed_image replacement;
@@ -526,9 +552,7 @@ app_error render_target_resize(
     case RENDER_TARGET_MODE_OWNED_TEXTURE:
       vulkan_context_wait_idle(&target->as.owned.compositor.context);
       release_pending_frame(target);
-      MAP_TRY(
-        vulkan_compositor_resize(&target->as.owned.compositor, current_viewport)
-      );
+      vulkan_compositor_resize(&target->as.owned.compositor, current_viewport);
       return render_session_resize(&target->session, current_viewport);
     case RENDER_TARGET_MODE_BORROWED_TEXTURE:
       return resize_borrowed(target, current_viewport);

--- a/examples/c-map/render/vulkan/vulkan.c
+++ b/examples/c-map/render/vulkan/vulkan.c
@@ -160,12 +160,6 @@ static app_error vulkan_compositor_present_image_view(
   vulkan_compositor* compositor, VkImageView image_view, bool* out_presented
 ) {
   *out_presented = false;
-  if (image_view != compositor->pipeline.descriptor_image_view) {
-    vulkan_pipeline_update_descriptor(
-      &compositor->pipeline, compositor->context.device, image_view
-    );
-  }
-
   MAP_TRY(vulkan_compositor_wait_for_frame(compositor));
 
   // The frame about to present is the first content the resized swapchain
@@ -173,6 +167,15 @@ static app_error vulkan_compositor_present_image_view(
   if (compositor->swapchain_stale) {
     MAP_TRY(vulkan_compositor_recreate_swapchain(compositor));
     compositor->swapchain_stale = false;
+  }
+
+  // After the fence wait, so no in-flight commands read the descriptor set,
+  // and after the replacement, whose format change rebuilds the pipeline
+  // around an unwritten descriptor set that this check then populates.
+  if (image_view != compositor->pipeline.descriptor_image_view) {
+    vulkan_pipeline_update_descriptor(
+      &compositor->pipeline, compositor->context.device, image_view
+    );
   }
 
   uint32_t image_index = 0;

--- a/examples/c-map/render/vulkan/vulkan.c
+++ b/examples/c-map/render/vulkan/vulkan.c
@@ -310,6 +310,10 @@ app_error render_target_configure_video(void) { return APP_OK; }
 
 SDL_WindowFlags render_target_window_flags(void) { return SDL_WINDOW_VULKAN; }
 
+void* render_target_frame_scope_open(void) { return nullptr; }
+
+void render_target_frame_scope_close(void* scope) { (void)scope; }
+
 app_error render_target_init(
   render_target** out_target, SDL_Window* window, viewport current_viewport,
   render_target_mode mode

--- a/examples/c-map/render/vulkan/vulkan.c
+++ b/examples/c-map/render/vulkan/vulkan.c
@@ -60,7 +60,8 @@ static app_error vulkan_compositor_create(
 ) {
   MAP_TRY(vulkan_context_init(&compositor->context, window));
   MAP_TRY(vulkan_swapchain_init(
-    &compositor->swapchain, &compositor->context, current_viewport
+    &compositor->swapchain, &compositor->context, current_viewport,
+    VK_NULL_HANDLE
   ));
   MAP_TRY(vulkan_pipeline_init(
     &compositor->pipeline, compositor->context.device,
@@ -70,9 +71,13 @@ static app_error vulkan_compositor_create(
     &compositor->swapchain, compositor->context.device,
     compositor->pipeline.render_pass
   ));
-  return vulkan_commands_init(
+  MAP_TRY(vulkan_commands_init(
     &compositor->commands, compositor->context.device,
     compositor->context.queue_family_index
+  ));
+  return vulkan_commands_create_present_semaphores(
+    &compositor->commands, compositor->context.device,
+    compositor->swapchain.image_count
   );
 }
 
@@ -108,11 +113,18 @@ static app_error vulkan_compositor_recreate_swapchain(
   vulkan_compositor* compositor
 ) {
   vulkan_context_wait_idle(&compositor->context);
-  const VkFormat previous_format = compositor->swapchain.format;
-  vulkan_swapchain_deinit(&compositor->swapchain, compositor->context.device);
-  MAP_TRY(vulkan_swapchain_init(
-    &compositor->swapchain, &compositor->context, compositor->current_viewport
-  ));
+  // The replacement is created before the retired swapchain is destroyed and
+  // names it as oldSwapchain, so the presentation engine hands the surface
+  // over directly. Destroying it first leaves a gap that MoltenVK fills with
+  // presents that succeed but reach no drawable the window still shows.
+  vulkan_swapchain previous = compositor->swapchain;
+  const VkFormat previous_format = previous.format;
+  const app_error error = vulkan_swapchain_init(
+    &compositor->swapchain, &compositor->context, compositor->current_viewport,
+    previous.handle
+  );
+  vulkan_swapchain_deinit(&previous, compositor->context.device);
+  MAP_TRY(error);
 
   if (compositor->swapchain.format != previous_format) {
     vulkan_pipeline_deinit(&compositor->pipeline, compositor->context.device);
@@ -121,9 +133,16 @@ static app_error vulkan_compositor_recreate_swapchain(
       compositor->swapchain.format
     ));
   }
-  return vulkan_swapchain_create_framebuffers(
+  MAP_TRY(vulkan_swapchain_create_framebuffers(
     &compositor->swapchain, compositor->context.device,
     compositor->pipeline.render_pass
+  ));
+  vulkan_commands_destroy_present_semaphores(
+    &compositor->commands, compositor->context.device
+  );
+  return vulkan_commands_create_present_semaphores(
+    &compositor->commands, compositor->context.device,
+    compositor->swapchain.image_count
   );
 }
 
@@ -165,6 +184,11 @@ static app_error vulkan_compositor_present_image_view(
     compositor->swapchain_stale = true;
     return APP_OK;
   }
+  if (acquire == VK_SUBOPTIMAL_KHR) {
+    // Still presentable, but the surface has moved on; replace the swapchain
+    // before the next frame.
+    compositor->swapchain_stale = true;
+  }
   MAP_TRY(expect_vk_or_suboptimal(acquire));
   MAP_TRY(vulkan_commands_reset_fence(
     &compositor->commands, compositor->context.device
@@ -174,14 +198,14 @@ static app_error vulkan_compositor_present_image_view(
     &compositor->commands, &compositor->swapchain, &compositor->pipeline,
     image_index
   ));
-  MAP_TRY(
-    vulkan_commands_submit(&compositor->commands, compositor->context.queue)
-  );
+  MAP_TRY(vulkan_commands_submit(
+    &compositor->commands, compositor->context.queue, image_index
+  ));
 
   const VkPresentInfoKHR present_info = {
     .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
     .waitSemaphoreCount = 1,
-    .pWaitSemaphores = &compositor->commands.render_finished,
+    .pWaitSemaphores = &compositor->commands.render_finished[image_index],
     .swapchainCount = 1,
     .pSwapchains = &compositor->swapchain.handle,
     .pImageIndices = &image_index,
@@ -199,6 +223,9 @@ static app_error vulkan_compositor_present_image_view(
   if (present != VK_SUCCESS && present != VK_SUBOPTIMAL_KHR) {
     (void)vulkan_compositor_wait_for_frame(compositor);
     return expect_vk(present);
+  }
+  if (present == VK_SUBOPTIMAL_KHR) {
+    compositor->swapchain_stale = true;
   }
   *out_presented = true;
   return APP_OK;

--- a/examples/c-map/util.h
+++ b/examples/c-map/util.h
@@ -3,8 +3,7 @@
 #ifndef C_MAP_UTIL_H
 #define C_MAP_UTIL_H
 
-#include <threads.h>
-#include <time.h>
+#include <SDL3/SDL.h>
 
 #include "types.h"
 
@@ -19,9 +18,7 @@
   } while (0)
 
 static inline void sleep_milliseconds(long milliseconds) {
-  thrd_sleep(
-    &(struct timespec){.tv_nsec = milliseconds * 1000 * 1000}, nullptr
-  );
+  SDL_Delay((Uint32)milliseconds);
 }
 
 #endif  // C_MAP_UTIL_H

--- a/examples/dotnet-map/IRenderTarget.cs
+++ b/examples/dotnet-map/IRenderTarget.cs
@@ -270,7 +270,7 @@ internal sealed class BorrowedTextureRenderTarget : IRenderTarget
         {
             case MetalBorrowedTexture metalTexture
                 when compositor is MetalTextureCompositor metalCompositor:
-                metalCompositor.DrawTexture(metalTexture.Texture);
+                presented = metalCompositor.DrawTexture(metalTexture.Texture);
                 break;
             case VulkanBorrowedImage vulkanImage
                 when compositor is VulkanTextureCompositor vulkanCompositor:

--- a/examples/dotnet-map/MetalTextureCompositor.cs
+++ b/examples/dotnet-map/MetalTextureCompositor.cs
@@ -42,11 +42,15 @@ internal sealed class MetalTextureCompositor : ITextureCompositor
             );
         }
 
-        DrawTexture(frame.Texture.Address);
-        return true;
+        return DrawTexture(frame.Texture.Address);
     }
 
-    public void DrawTexture(nint texture)
+    /// <summary>
+    /// Samples the texture into the layer's next drawable. Reports false without presenting when
+    /// the layer has no drawable to hand out, which a minimized or occluded window legitimately has
+    /// not; the caller's redraw stays pending and the draw retries once one is available.
+    /// </summary>
+    public bool DrawTexture(nint texture)
     {
         nint passDescriptor = 0;
         try
@@ -55,7 +59,7 @@ internal sealed class MetalTextureCompositor : ITextureCompositor
             var drawable = context.NextDrawable();
             if (drawable == 0)
             {
-                throw new InvalidOperationException("CAMetalLayer returned no drawable.");
+                return false;
             }
 
             passDescriptor = MacObjectiveC.AllocInit("MTLRenderPassDescriptor");
@@ -99,6 +103,7 @@ internal sealed class MetalTextureCompositor : ITextureCompositor
             MacObjectiveC.SendVoid(commandBuffer, "presentDrawable:", drawable);
             MacObjectiveC.SendVoid(commandBuffer, "commit");
             MacObjectiveC.SendVoid(commandBuffer, "waitUntilCompleted");
+            return true;
         }
         finally
         {

--- a/examples/dotnet-map/Shell.cs
+++ b/examples/dotnet-map/Shell.cs
@@ -157,8 +157,9 @@ internal static class Shell
                 // render call is not discarded.
                 if (graphics.CanRenderFrame && renderRequest.Consume() && !Render(graphics, target))
                 {
-                    // The map applies its logical size on the runtime loop's next Pump, so no
-                    // update is rendered until then. Ask again rather than dropping the frame.
+                    // Nothing reached the screen. The map applies its logical size on the runtime
+                    // loop's next Pump, and a presentation target hands out no drawable while the
+                    // window is minimized. Ask again rather than dropping the frame.
                     renderRequest.Set();
                 }
 

--- a/examples/dotnet-map/VulkanTextureCompositor.cs
+++ b/examples/dotnet-map/VulkanTextureCompositor.cs
@@ -33,9 +33,14 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
     private CommandPool commandPool;
     private CommandBuffer commandBuffer;
     private VulkanSemaphore imageAvailable;
-    private VulkanSemaphore renderFinished;
+
+    // One semaphore per swapchain image. Each present waits on the semaphore that its own submit
+    // signalled, so a later submit never signals one that a pending present still waits on. Vulkan
+    // forbids that overlap, and it shows as half-drawn frames.
+    private VulkanSemaphore[] renderFinished = [];
     private Fence inFlight;
     private Viewport viewport;
+    private bool swapchainStale;
 
     public VulkanTextureCompositor(VulkanContext context, Viewport viewport)
     {
@@ -88,6 +93,7 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
         }
 
         CreateFramebuffers();
+        swapchainStale = false;
     }
 
     public bool Draw(VulkanOwnedTextureFrame frame)
@@ -121,6 +127,14 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
             vk.WaitForFences(context.Device, 1, &fence, true, ulong.MaxValue),
             "vkWaitForFences"
         );
+
+        // A suboptimal swapchain still presents, so the frame that reported it reaches the screen
+        // and the replacement is built here, ahead of the next draw.
+        if (swapchainStale)
+        {
+            RecreateSwapchain();
+        }
+
         var imageIndex = 0u;
         var acquire = vkAcquireNextImageKHR(
             context.Device.Handle,
@@ -136,7 +150,12 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
             return false;
         }
 
-        if (acquire != Result.Success && acquire != Result.SuboptimalKhr)
+        if (acquire == Result.SuboptimalKhr)
+        {
+            // Still presentable, but the surface has moved on; rebuild before the next frame.
+            swapchainStale = true;
+        }
+        else if (acquire != Result.Success)
         {
             VulkanContext.Check(acquire, "vkAcquireNextImageKHR");
         }
@@ -144,7 +163,7 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
         UpdateDescriptor(imageView);
         Record(imageIndex);
         VulkanContext.Check(vk.ResetFences(context.Device, 1, &fence), "vkResetFences");
-        Submit();
+        Submit(imageIndex);
         fence = inFlight;
         VulkanContext.Check(
             vk.WaitForFences(context.Device, 1, &fence, true, ulong.MaxValue),
@@ -156,6 +175,11 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
         {
             RecreateSwapchain();
             return false;
+        }
+
+        if (present == Result.SuboptimalKhr)
+        {
+            swapchainStale = true;
         }
 
         return true;
@@ -172,12 +196,6 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
         {
             vk.DestroyFence(context.Device, inFlight, null);
             inFlight = default;
-        }
-
-        if (renderFinished.Handle != 0)
-        {
-            vk.DestroySemaphore(context.Device, renderFinished, null);
-            renderFinished = default;
         }
 
         if (imageAvailable.Handle != 0)
@@ -316,11 +334,17 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
             "vkGetSwapchainImagesKHR"
         );
         imageViews = new ImageView[actualCount];
+        renderFinished = new VulkanSemaphore[actualCount];
+        var semaphoreInfo = new SemaphoreCreateInfo { SType = StructureType.SemaphoreCreateInfo };
         try
         {
             for (var i = 0; i < actualCount; i++)
             {
                 imageViews[i] = CreateImageView(images[i], swapchainFormat);
+                VulkanContext.Check(
+                    vk.CreateSemaphore(context.Device, &semaphoreInfo, null, out renderFinished[i]),
+                    "vkCreateSemaphore(renderFinished)"
+                );
             }
         }
         catch
@@ -634,10 +658,6 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
             vk.CreateSemaphore(context.Device, &semaphoreInfo, null, out imageAvailable),
             "vkCreateSemaphore(imageAvailable)"
         );
-        VulkanContext.Check(
-            vk.CreateSemaphore(context.Device, &semaphoreInfo, null, out renderFinished),
-            "vkCreateSemaphore(renderFinished)"
-        );
         var fenceInfo = new FenceCreateInfo
         {
             SType = StructureType.FenceCreateInfo,
@@ -721,11 +741,11 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
         VulkanContext.Check(vk.EndCommandBuffer(commandBuffer), "vkEndCommandBuffer");
     }
 
-    private void Submit()
+    private void Submit(uint imageIndex)
     {
         var waitStage = PipelineStageFlags.ColorAttachmentOutputBit;
         var waitSemaphore = imageAvailable;
-        var signalSemaphore = renderFinished;
+        var signalSemaphore = renderFinished[imageIndex];
         var buffer = commandBuffer;
         var submitInfo = new SubmitInfo
         {
@@ -751,7 +771,7 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
 
     private Result Present(uint imageIndex)
     {
-        var waitSemaphore = renderFinished;
+        var waitSemaphore = renderFinished[imageIndex];
         var swapchainHandle = swapchain;
         var presentInfo = new PresentInfoKHR
         {
@@ -861,6 +881,15 @@ internal sealed unsafe partial class VulkanTextureCompositor : ITextureComposito
         }
 
         imageViews = [];
+        foreach (var semaphore in renderFinished)
+        {
+            if (semaphore.Handle != 0)
+            {
+                vk.DestroySemaphore(context.Device, semaphore, null);
+            }
+        }
+
+        renderFinished = [];
     }
 
     private void DestroyPipeline()

--- a/examples/go-map/mise.toml
+++ b/examples/go-map/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 "core:go" = "{{vars.go_version}}"
 "aqua:mvdan/gofumpt" = "{{vars.gofumpt_version}}"
-"conda:sdl3" = { version = "3.2", os = ["linux"] }
+"conda:sdl3" = { version = "3.2", os = ["linux", "macos"] }
 
 [tasks.build]
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/MetalRenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/MetalRenderTarget.kt
@@ -117,14 +117,13 @@ internal object MetalRenderTarget {
       if (!session.renderUpdate()) {
         return false
       }
-      session.acquireMetalOwnedTextureFrame().use { frameHandle ->
+      return session.acquireMetalOwnedTextureFrame().use { frameHandle ->
         val frame = frameHandle.frame()
         check(frame.width() != 0 && frame.height() != 0 && !frame.texture().isNull) {
           "owned Metal frame has an empty extent or null texture"
         }
         compositor.drawTexture(frame.texture().address)
       }
-      return true
     }
 
     override fun close() {
@@ -167,8 +166,7 @@ internal object MetalRenderTarget {
       if (!session.renderUpdate()) {
         return false
       }
-      compositor.drawTexture(texture.texture())
-      return true
+      return compositor.drawTexture(texture.texture())
     }
 
     override fun close() {

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/MetalTextureCompositor.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/MetalTextureCompositor.kt
@@ -17,12 +17,21 @@ internal class MetalTextureCompositor(graphicsContext: GraphicsContext) : AutoCl
     }
   }
 
-  fun drawTexture(texture: Long) {
+  /**
+   * Samples the texture into the layer's next drawable, and reports whether it presented.
+   *
+   * A minimized or occluded window has no drawable to hand out, and the drawable pool is
+   * momentarily empty under load. Both are transient, so the frame is skipped rather than failed:
+   * the caller's render request stays pending and the draw retries once a drawable is available.
+   */
+  fun drawTexture(texture: Long): Boolean {
     var passDescriptor = NULL
     try {
-      MacObjectiveC.autoreleasePool().use {
+      return MacObjectiveC.autoreleasePool().use {
         val drawable = context.nextDrawable()
-        check(drawable != NULL) { "CAMetalLayer returned no drawable" }
+        if (drawable == NULL) {
+          return@use false
+        }
         passDescriptor = MacObjectiveC.allocInit("MTLRenderPassDescriptor")
         val attachment =
           MacObjectiveC.sendPointer(
@@ -56,6 +65,7 @@ internal class MetalTextureCompositor(graphicsContext: GraphicsContext) : AutoCl
         MacObjectiveC.sendVoid(commandBuffer, "presentDrawable:", drawable)
         MacObjectiveC.sendVoid(commandBuffer, "commit")
         MacObjectiveC.sendVoid(commandBuffer, "waitUntilCompleted")
+        true
       }
     } finally {
       MacObjectiveC.release(passDescriptor)

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/RenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/RenderTarget.kt
@@ -23,7 +23,12 @@ internal interface RenderTarget : AutoCloseable {
    */
   fun resize(viewport: Viewport)
 
-  /** Renders the latest map update. Returns false when no update is available yet. */
+  /**
+   * Renders the latest map update, and reports whether a frame reached the screen.
+   *
+   * A false result means no map update was available yet, or the host had no drawable to present
+   * into. The render loop keeps its redraw pending and retries.
+   */
   fun renderUpdate(): Boolean
 
   override fun close()

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanRenderTarget.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanRenderTarget.kt
@@ -130,7 +130,7 @@ internal object VulkanRenderTarget {
       if (!session.renderUpdate()) {
         return false
       }
-      session.acquireVulkanOwnedTextureFrame().use { frameHandle ->
+      return session.acquireVulkanOwnedTextureFrame().use { frameHandle ->
         val frame = frameHandle.frame()
         check(frame.width() > 0 && frame.height() > 0) {
           "MapLibre returned an empty Vulkan owned texture frame"
@@ -140,7 +140,6 @@ internal object VulkanRenderTarget {
         }
         compositor.drawImageView(frame.imageView().address)
       }
-      return true
     }
 
     override fun close() {
@@ -182,8 +181,7 @@ internal object VulkanRenderTarget {
       if (!session.renderUpdate()) {
         return false
       }
-      compositor.drawImageView(image.view())
-      return true
+      return compositor.drawImageView(image.view())
     }
 
     override fun close() {

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanTextureCompositor.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanTextureCompositor.kt
@@ -66,8 +66,14 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
     recreateSwapchain()
   }
 
-  fun drawImageView(imageView: Long) {
-    MemoryStack.stackPush().use { stack ->
+  /**
+   * Samples the image view into the swapchain, reporting whether the frame reached the screen.
+   *
+   * A swapchain the surface has outgrown presents nothing, so the caller keeps its redraw pending
+   * and draws again once the replacement is built.
+   */
+  fun drawImageView(imageView: Long): Boolean {
+    return MemoryStack.stackPush().use { stack ->
       check(vkWaitForFences(context.device(), inFlight, true, Long.MAX_VALUE), "vkWaitForFences")
       // The frame about to present is the first content a replacement could show, so this is the
       // moment a stale swapchain is replaced.
@@ -89,7 +95,7 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
         // The surface outgrew this swapchain, so nothing reaches the screen until the replacement
         // is built.
         swapchainStale = true
-        return
+        return@use false
       }
       if (acquire == VK_SUBOPTIMAL_KHR) {
         // Still presentable, but the surface has moved on; replace the swapchain before the next
@@ -666,7 +672,8 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
     check(vkQueueSubmit(context.graphicsQueue(), submitInfo, inFlight), "vkQueueSubmit")
   }
 
-  private fun present(stack: MemoryStack, imageIndex: Int) {
+  /** Presents the acquired image, reporting whether it reached the screen. */
+  private fun present(stack: MemoryStack, imageIndex: Int): Boolean {
     val indices = stack.ints(imageIndex)
     val presentInfo =
       VkPresentInfoKHR.calloc(stack)
@@ -685,6 +692,7 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
       error("vkQueuePresentKHR failed with Vulkan status $status")
     }
     check(vkQueueWaitIdle(context.graphicsQueue()), "vkQueueWaitIdle")
+    return status != VK_ERROR_OUT_OF_DATE_KHR
   }
 
   private fun destroySwapchainDependents() {

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanTextureCompositor.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/VulkanTextureCompositor.kt
@@ -29,17 +29,28 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
   private var commandPool = NULL
   private var commandBuffer: VkCommandBuffer? = null
   private var imageAvailable = NULL
-  private var renderFinished = NULL
+
+  /**
+   * One present-wait semaphore per swapchain image, indexed by the acquired image.
+   *
+   * The frame fence proves a submit finished, but only the next acquire of the same image proves
+   * its present consumed the semaphore, so a single reused semaphore is a race the presentation
+   * engine may lose.
+   */
+  private var renderFinished = LongArray(0)
   private var inFlight = NULL
+  private var currentViewport = viewport
+  private var swapchainStale = false
 
   init {
     try {
-      createSwapchain(viewport)
+      createSwapchain(NULL)
       createRenderPass()
       createDescriptorState()
       createPipeline()
       createFramebuffers()
       createCommands()
+      createPresentSemaphores()
     } catch (error: RuntimeException) {
       try {
         close()
@@ -51,15 +62,19 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
   }
 
   fun resize(viewport: Viewport) {
-    context.waitIdle()
-    destroySwapchainDependents()
-    createSwapchain(viewport)
-    createFramebuffers()
+    currentViewport = viewport
+    recreateSwapchain()
   }
 
   fun drawImageView(imageView: Long) {
     MemoryStack.stackPush().use { stack ->
       check(vkWaitForFences(context.device(), inFlight, true, Long.MAX_VALUE), "vkWaitForFences")
+      // The frame about to present is the first content a replacement could show, so this is the
+      // moment a stale swapchain is replaced.
+      if (swapchainStale) {
+        recreateSwapchain()
+        swapchainStale = false
+      }
       val imageIndex = stack.mallocInt(1)
       val acquire =
         vkAcquireNextImageKHR(
@@ -71,7 +86,15 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
           imageIndex,
         )
       if (acquire == VK_ERROR_OUT_OF_DATE_KHR) {
+        // The surface outgrew this swapchain, so nothing reaches the screen until the replacement
+        // is built.
+        swapchainStale = true
         return
+      }
+      if (acquire == VK_SUBOPTIMAL_KHR) {
+        // Still presentable, but the surface has moved on; replace the swapchain before the next
+        // frame.
+        swapchainStale = true
       }
       if (acquire != VK_SUCCESS && acquire != VK_SUBOPTIMAL_KHR) {
         error("vkAcquireNextImageKHR failed with Vulkan status $acquire")
@@ -80,13 +103,39 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
 
       updateDescriptor(imageView)
       record(imageIndex[0])
-      submit(stack)
+      submit(stack, imageIndex[0])
       check(vkWaitForFences(context.device(), inFlight, true, Long.MAX_VALUE), "vkWaitForFences")
       present(stack, imageIndex[0])
     }
   }
 
-  private fun createSwapchain(viewport: Viewport) {
+  /**
+   * Replaces the swapchain and the state sized to it.
+   *
+   * The replacement is created before the retired swapchain is destroyed and names it as
+   * oldSwapchain, so the presentation engine hands the surface over directly. Destroying it first
+   * leaves a gap that MoltenVK fills with presents that succeed but reach no drawable the window
+   * still shows.
+   */
+  private fun recreateSwapchain() {
+    context.waitIdle()
+    val retiredSwapchain = swapchain
+    val retiredImageViews = imageViews
+    val retiredFramebuffers = framebuffers
+    swapchain = NULL
+    imageViews = LongArray(0)
+    framebuffers = LongArray(0)
+    destroyPresentSemaphores()
+    try {
+      createSwapchain(retiredSwapchain)
+    } finally {
+      destroySwapchainObjects(retiredSwapchain, retiredImageViews, retiredFramebuffers)
+    }
+    createFramebuffers()
+    createPresentSemaphores()
+  }
+
+  private fun createSwapchain(oldSwapchain: Long) {
     MemoryStack.stackPush().use { stack ->
       val capabilities = VkSurfaceCapabilitiesKHR.calloc(stack)
       check(
@@ -130,9 +179,10 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
         }
       }
       swapchainFormat = chosen.format()
-      extentWidth = chooseExtentDimension(capabilities, viewport.framebufferWidth(), width = true)
+      extentWidth =
+        chooseExtentDimension(capabilities, currentViewport.framebufferWidth(), width = true)
       extentHeight =
-        chooseExtentDimension(capabilities, viewport.framebufferHeight(), width = false)
+        chooseExtentDimension(capabilities, currentViewport.framebufferHeight(), width = false)
       var imageCount = capabilities.minImageCount() + 1
       if (capabilities.maxImageCount() > 0 && imageCount > capabilities.maxImageCount()) {
         imageCount = capabilities.maxImageCount()
@@ -152,7 +202,7 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
           .compositeAlpha(VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR)
           .presentMode(VK_PRESENT_MODE_FIFO_KHR)
           .clipped(true)
-          .oldSwapchain(NULL)
+          .oldSwapchain(oldSwapchain)
       val out = stack.mallocLong(1)
       check(vkCreateSwapchainKHR(context.device(), createInfo, null, out), "vkCreateSwapchainKHR")
       swapchain = out[0]
@@ -500,11 +550,6 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
         "vkCreateSemaphore(imageAvailable)",
       )
       imageAvailable = out[0]
-      check(
-        vkCreateSemaphore(context.device(), semaphoreInfo, null, out),
-        "vkCreateSemaphore(renderFinished)",
-      )
-      renderFinished = out[0]
       val fenceInfo =
         VkFenceCreateInfo.calloc(stack)
           .sType(VK_STRUCTURE_TYPE_FENCE_CREATE_INFO)
@@ -512,6 +557,32 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
       check(vkCreateFence(context.device(), fenceInfo, null, out), "vkCreateFence")
       inFlight = out[0]
     }
+  }
+
+  /** Sizes the present-wait semaphores to the swapchain, on creation and on every replacement. */
+  private fun createPresentSemaphores() {
+    renderFinished = LongArray(imageViews.size)
+    MemoryStack.stackPush().use { stack ->
+      val semaphoreInfo =
+        VkSemaphoreCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO)
+      val out = stack.mallocLong(1)
+      for (index in renderFinished.indices) {
+        check(
+          vkCreateSemaphore(context.device(), semaphoreInfo, null, out),
+          "vkCreateSemaphore(renderFinished)",
+        )
+        renderFinished[index] = out[0]
+      }
+    }
+  }
+
+  private fun destroyPresentSemaphores() {
+    for (semaphore in renderFinished) {
+      if (semaphore != NULL) {
+        vkDestroySemaphore(context.device(), semaphore, null)
+      }
+    }
+    renderFinished = LongArray(0)
   }
 
   private fun updateDescriptor(imageView: Long) {
@@ -583,7 +654,7 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
     }
   }
 
-  private fun submit(stack: MemoryStack) {
+  private fun submit(stack: MemoryStack, imageIndex: Int) {
     val waitStages = stack.ints(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
     val submitInfo =
       VkSubmitInfo.calloc(stack)
@@ -591,7 +662,7 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
         .pWaitSemaphores(stack.longs(imageAvailable))
         .pWaitDstStageMask(waitStages)
         .pCommandBuffers(stack.pointers(commandBuffer()))
-        .pSignalSemaphores(stack.longs(renderFinished))
+        .pSignalSemaphores(stack.longs(renderFinished[imageIndex]))
     check(vkQueueSubmit(context.graphicsQueue(), submitInfo, inFlight), "vkQueueSubmit")
   }
 
@@ -600,11 +671,16 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
     val presentInfo =
       VkPresentInfoKHR.calloc(stack)
         .sType(VK_STRUCTURE_TYPE_PRESENT_INFO_KHR)
-        .pWaitSemaphores(stack.longs(renderFinished))
+        .pWaitSemaphores(stack.longs(renderFinished[imageIndex]))
         .swapchainCount(1)
         .pSwapchains(stack.longs(swapchain))
         .pImageIndices(indices)
     val status = vkQueuePresentKHR(context.graphicsQueue(), presentInfo)
+    if (status == VK_SUBOPTIMAL_KHR || status == VK_ERROR_OUT_OF_DATE_KHR) {
+      // A suboptimal frame reached the screen and an out-of-date one did not, and either way the
+      // surface has moved on; replace the swapchain before the next frame.
+      swapchainStale = true
+    }
     if (status != VK_SUCCESS && status != VK_SUBOPTIMAL_KHR && status != VK_ERROR_OUT_OF_DATE_KHR) {
       error("vkQueuePresentKHR failed with Vulkan status $status")
     }
@@ -612,21 +688,30 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
   }
 
   private fun destroySwapchainDependents() {
-    for (framebuffer in framebuffers) {
+    destroyPresentSemaphores()
+    destroySwapchainObjects(swapchain, imageViews, framebuffers)
+    framebuffers = LongArray(0)
+    imageViews = LongArray(0)
+    swapchain = NULL
+  }
+
+  private fun destroySwapchainObjects(
+    swapchainHandle: Long,
+    swapchainImageViews: LongArray,
+    swapchainFramebuffers: LongArray,
+  ) {
+    for (framebuffer in swapchainFramebuffers) {
       if (framebuffer != NULL) {
         vkDestroyFramebuffer(context.device(), framebuffer, null)
       }
     }
-    framebuffers = LongArray(0)
-    for (imageView in imageViews) {
+    for (imageView in swapchainImageViews) {
       if (imageView != NULL) {
         vkDestroyImageView(context.device(), imageView, null)
       }
     }
-    imageViews = LongArray(0)
-    if (swapchain != NULL) {
-      vkDestroySwapchainKHR(context.device(), swapchain, null)
-      swapchain = NULL
+    if (swapchainHandle != NULL) {
+      vkDestroySwapchainKHR(context.device(), swapchainHandle, null)
     }
   }
 
@@ -635,10 +720,6 @@ internal class VulkanTextureCompositor(private val context: VulkanContext, viewp
     if (inFlight != NULL) {
       vkDestroyFence(context.device(), inFlight, null)
       inFlight = NULL
-    }
-    if (renderFinished != NULL) {
-      vkDestroySemaphore(context.device(), renderFinished, null)
-      renderFinished = NULL
     }
     if (imageAvailable != NULL) {
       vkDestroySemaphore(context.device(), imageAvailable, null)

--- a/examples/rust-map/src/app.rs
+++ b/examples/rust-map/src/app.rs
@@ -193,9 +193,10 @@ impl App {
             .expect("render target is open")
             .render_update(&self.graphics)?
         {
-            // The map applies a new logical size on the runtime loop's next
-            // `pump`, so an attach or resize leaves nothing to render until
-            // then. Keep the request and retry.
+            // Nothing reached the screen. The map applies a new logical size on
+            // the runtime loop's next `pump`, so an attach or resize leaves
+            // nothing to render until then, and a host swapchain with no image
+            // to present into skips the frame. Keep the request and retry.
             self.shared.request_render();
         }
         Ok(())

--- a/examples/rust-map/src/metal.rs
+++ b/examples/rust-map/src/metal.rs
@@ -108,10 +108,12 @@ impl MetalTextureCompositor {
         })
     }
 
+    /// Samples the frame's texture into the layer's next drawable, and reports
+    /// whether it presented.
     pub fn draw(
         &mut self,
         frame: &MetalOwnedTextureFrameHandle,
-    ) -> maplibre_native_ffi::Result<()> {
+    ) -> maplibre_native_ffi::Result<bool> {
         let metadata = frame.frame()?;
         if metadata.width == 0 || metadata.height == 0 {
             return Err(metal_error("owned Metal frame has an empty extent"));
@@ -123,16 +125,21 @@ impl MetalTextureCompositor {
         self.draw_texture(texture)
     }
 
+    /// Samples texture into the layer's next drawable, and reports whether it
+    /// presented.
+    ///
+    /// A minimized or occluded window has no drawable to hand out, so the frame
+    /// is skipped rather than failed; the caller's render request stays pending
+    /// and the draw retries once one is available.
     pub fn draw_texture(
         &mut self,
         texture: &ProtocolObject<dyn MTLTexture>,
-    ) -> maplibre_native_ffi::Result<()> {
+    ) -> maplibre_native_ffi::Result<bool> {
         // SAFETY: The layer, command queue, pipeline, and texture are live for this call.
         unsafe {
-            let drawable = self
-                .layer
-                .nextDrawable()
-                .ok_or_else(|| metal_error("CAMetalLayer returned no drawable"))?;
+            let Some(drawable) = self.layer.nextDrawable() else {
+                return Ok(false);
+            };
             let drawable_texture = drawable.texture();
             let pass_descriptor = MTLRenderPassDescriptor::renderPassDescriptor();
             let color_attachment = pass_descriptor
@@ -165,7 +172,7 @@ impl MetalTextureCompositor {
             command_buffer.commit();
             command_buffer.waitUntilCompleted();
         }
-        Ok(())
+        Ok(true)
     }
 }
 

--- a/examples/rust-map/src/render_target/metal_target.rs
+++ b/examples/rust-map/src/render_target/metal_target.rs
@@ -98,9 +98,11 @@ impl RenderTarget {
                 let draw_result = compositor.draw(&frame);
                 let close_result = frame.close().map_err(|error| error.into_error());
                 match (draw_result, close_result) {
-                    (Ok(()), Ok(())) => Ok(true),
+                    // A draw that presented nothing reports no frame rendered.
+                    // The render request stays pending and the frame retries.
+                    (Ok(presented), Ok(())) => Ok(presented),
                     (Err(draw_error), Ok(())) => Err(draw_error),
-                    (Ok(()), Err(close_error)) => Err(close_error),
+                    (Ok(_), Err(close_error)) => Err(close_error),
                     (Err(draw_error), Err(close_error)) => Err(Error::new(
                         draw_error.kind(),
                         draw_error.raw_status(),
@@ -116,8 +118,7 @@ impl RenderTarget {
                 if !session.render_update()? {
                     return Ok(false);
                 }
-                compositor.draw_texture(texture.texture())?;
-                Ok(true)
+                compositor.draw_texture(texture.texture())
             }
             Self::Surface { session } => session.render_update(),
         }

--- a/examples/rust-map/src/render_target/vulkan_target.rs
+++ b/examples/rust-map/src/render_target/vulkan_target.rs
@@ -135,9 +135,9 @@ impl RenderTarget {
                 let draw_result = compositor.draw(&frame);
                 let close_result = frame.close().map_err(|error| error.into_error());
                 match (draw_result, close_result) {
-                    (Ok(()), Ok(())) => Ok(true),
+                    (Ok(presented), Ok(())) => Ok(presented),
                     (Err(draw_error), Ok(())) => Err(draw_error),
-                    (Ok(()), Err(close_error)) => Err(close_error),
+                    (Ok(_), Err(close_error)) => Err(close_error),
                     (Err(draw_error), Err(close_error)) => Err(Error::new(
                         draw_error.kind(),
                         draw_error.raw_status(),
@@ -155,8 +155,7 @@ impl RenderTarget {
                 }
                 compositor.draw_image_view(image.view()).map_err(|error| {
                     compositor_error(format!("Vulkan texture compositor draw failed: {error:?}"))
-                })?;
-                Ok(true)
+                })
             }
             Self::Surface { session } => session.render_update(),
         }

--- a/examples/rust-map/src/vulkan_texture_compositor.rs
+++ b/examples/rust-map/src/vulkan_texture_compositor.rs
@@ -33,8 +33,16 @@ pub struct VulkanTextureCompositor {
     command_pool: vk::CommandPool,
     command_buffer: vk::CommandBuffer,
     image_available: vk::Semaphore,
-    render_finished: vk::Semaphore,
+    /// One present-wait semaphore per swapchain image, indexed by the acquired
+    /// image. The frame fence proves a submit finished, but only the next
+    /// acquire of the same image proves its present consumed the semaphore, so
+    /// a single reused semaphore is a race the presentation engine may lose.
+    render_finished: Vec<vk::Semaphore>,
     in_flight: vk::Fence,
+    viewport: Viewport,
+    /// Set when the surface reports the swapchain no longer matches it. The
+    /// next frame rebuilds the swapchain before it draws.
+    swapchain_stale: bool,
     closed: bool,
 }
 
@@ -69,8 +77,10 @@ impl VulkanTextureCompositor {
             command_pool: vk::CommandPool::null(),
             command_buffer: vk::CommandBuffer::null(),
             image_available: vk::Semaphore::null(),
-            render_finished: vk::Semaphore::null(),
+            render_finished: Vec::new(),
             in_flight: vk::Fence::null(),
+            viewport,
+            swapchain_stale: false,
             closed: false,
         };
         compositor.create_swapchain(viewport, vk::SwapchainKHR::null())?;
@@ -82,15 +92,23 @@ impl VulkanTextureCompositor {
         Ok(compositor)
     }
 
+    /// Rebuilds the swapchain at a new size.
+    ///
+    /// The replacement is created before the retired swapchain is destroyed and
+    /// names it as `old_swapchain`, so the presentation engine hands the surface
+    /// over directly. Destroying it first leaves a gap that MoltenVK fills with
+    /// presents that succeed but reach no drawable the window still shows.
     pub fn resize(&mut self, viewport: Viewport) -> Result<(), vk::Result> {
         self.wait_idle()?;
         self.destroy_swapchain_dependents();
         let old_swapchain = self.swapchain;
+        self.viewport = viewport;
         self.create_swapchain(viewport, old_swapchain)?;
         if old_swapchain != vk::SwapchainKHR::null() {
             unsafe { self.swapchain_loader.destroy_swapchain(old_swapchain, None) };
         }
         self.create_framebuffers()?;
+        self.swapchain_stale = false;
         Ok(())
     }
 
@@ -127,10 +145,6 @@ impl VulkanTextureCompositor {
             if self.in_flight != vk::Fence::null() {
                 self.device.destroy_fence(self.in_flight, None);
                 self.in_flight = vk::Fence::null();
-            }
-            if self.render_finished != vk::Semaphore::null() {
-                self.device.destroy_semaphore(self.render_finished, None);
-                self.render_finished = vk::Semaphore::null();
             }
             if self.image_available != vk::Semaphore::null() {
                 self.device.destroy_semaphore(self.image_available, None);
@@ -182,21 +196,41 @@ impl VulkanTextureCompositor {
     }
 
     pub(crate) fn draw_image_view(&mut self, image_view: vk::ImageView) -> Result<(), vk::Result> {
+        // SAFETY: the fence belongs to this live device.
+        unsafe {
+            self.device
+                .wait_for_fences(&[self.in_flight], true, u64::MAX)?
+        };
+
+        // The frame about to present is the first content a replacement
+        // swapchain could show, so this is the moment a stale one is rebuilt.
+        if self.swapchain_stale {
+            self.resize(self.viewport)?;
+        }
+
         unsafe {
             let device = &self.device;
-            device.wait_for_fences(&[self.in_flight], true, u64::MAX)?;
-
             self.update_descriptor(image_view);
-            let image_index = match self.swapchain_loader.acquire_next_image(
+            let (image_index, suboptimal) = match self.swapchain_loader.acquire_next_image(
                 self.swapchain,
                 u64::MAX,
                 self.image_available,
                 vk::Fence::null(),
             ) {
-                Ok((image_index, _suboptimal)) => image_index,
-                Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => return Ok(()),
+                Ok(acquired) => acquired,
+                Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
+                    // The surface outgrew this swapchain, so nothing reaches
+                    // the screen until the replacement is built.
+                    self.swapchain_stale = true;
+                    return Ok(());
+                }
                 Err(error) => return Err(error),
             };
+            if suboptimal {
+                // Still presentable, but the surface has moved on; rebuild the
+                // swapchain before the next frame.
+                self.swapchain_stale = true;
+            }
 
             self.record(image_index)?;
             device.reset_fences(&[self.in_flight])?;
@@ -204,7 +238,7 @@ impl VulkanTextureCompositor {
             let wait_semaphores = [self.image_available];
             let wait_stages = [vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT];
             let command_buffers = [self.command_buffer];
-            let signal_semaphores = [self.render_finished];
+            let signal_semaphores = [self.render_finished[image_index as usize]];
             let submit_info = [vk::SubmitInfo::default()
                 .wait_semaphores(&wait_semaphores)
                 .wait_dst_stage_mask(&wait_stages)
@@ -223,7 +257,16 @@ impl VulkanTextureCompositor {
                 .swapchain_loader
                 .queue_present(self.graphics_queue, &present_info)
             {
-                Ok(_) | Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => Ok(()),
+                Ok(present_suboptimal) => {
+                    if present_suboptimal {
+                        self.swapchain_stale = true;
+                    }
+                    Ok(())
+                }
+                Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
+                    self.swapchain_stale = true;
+                    Ok(())
+                }
                 Err(error) => Err(error),
             }
         }
@@ -283,10 +326,28 @@ impl VulkanTextureCompositor {
                     }
                 }
             }
+            let mut render_finished = Vec::with_capacity(image_views.len());
+            let semaphore_info = vk::SemaphoreCreateInfo::default();
+            for _ in &image_views {
+                match self.device.create_semaphore(&semaphore_info, None) {
+                    Ok(semaphore) => render_finished.push(semaphore),
+                    Err(error) => {
+                        for semaphore in render_finished {
+                            self.device.destroy_semaphore(semaphore, None);
+                        }
+                        for view in image_views {
+                            self.device.destroy_image_view(view, None);
+                        }
+                        self.swapchain_loader.destroy_swapchain(swapchain, None);
+                        return Err(error);
+                    }
+                }
+            }
             self.swapchain = swapchain;
             self.swapchain_format = swapchain_format;
             self.extent = extent;
             self.image_views = image_views;
+            self.render_finished = render_finished;
             Ok(())
         }
     }
@@ -472,7 +533,6 @@ impl VulkanTextureCompositor {
             self.command_buffer = self.device.allocate_command_buffers(&alloc_info)?[0];
             let semaphore_info = vk::SemaphoreCreateInfo::default();
             self.image_available = self.device.create_semaphore(&semaphore_info, None)?;
-            self.render_finished = self.device.create_semaphore(&semaphore_info, None)?;
             let fence_info = vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
             self.in_flight = self.device.create_fence(&fence_info, None)?;
             Ok(())
@@ -559,6 +619,10 @@ impl VulkanTextureCompositor {
         for view in self.image_views.drain(..) {
             // SAFETY: image view belongs to this live device and no framebuffer references it now.
             unsafe { device.destroy_image_view(view, None) };
+        }
+        for semaphore in self.render_finished.drain(..) {
+            // SAFETY: semaphore belongs to this live device and no present waits on it after waits.
+            unsafe { device.destroy_semaphore(semaphore, None) };
         }
     }
 }

--- a/examples/rust-map/src/vulkan_texture_compositor.rs
+++ b/examples/rust-map/src/vulkan_texture_compositor.rs
@@ -115,7 +115,7 @@ impl VulkanTextureCompositor {
     pub fn draw(
         &mut self,
         frame: &VulkanOwnedTextureFrameHandle,
-    ) -> maplibre_native_ffi::Result<()> {
+    ) -> maplibre_native_ffi::Result<bool> {
         let metadata = frame.frame()?;
         if metadata.width == 0 || metadata.height == 0 {
             return Err(compositor_error("owned Vulkan frame has an empty extent"));
@@ -195,7 +195,14 @@ impl VulkanTextureCompositor {
         Ok(())
     }
 
-    pub(crate) fn draw_image_view(&mut self, image_view: vk::ImageView) -> Result<(), vk::Result> {
+    /// Samples the image view into the swapchain, reporting whether the frame
+    /// reached the screen. A swapchain the surface has outgrown presents
+    /// nothing, so the caller keeps its redraw pending and draws again once the
+    /// replacement is built.
+    pub(crate) fn draw_image_view(
+        &mut self,
+        image_view: vk::ImageView,
+    ) -> Result<bool, vk::Result> {
         // SAFETY: the fence belongs to this live device.
         unsafe {
             self.device
@@ -222,7 +229,7 @@ impl VulkanTextureCompositor {
                     // The surface outgrew this swapchain, so nothing reaches
                     // the screen until the replacement is built.
                     self.swapchain_stale = true;
-                    return Ok(());
+                    return Ok(false);
                 }
                 Err(error) => return Err(error),
             };
@@ -261,11 +268,11 @@ impl VulkanTextureCompositor {
                     if present_suboptimal {
                         self.swapchain_stale = true;
                     }
-                    Ok(())
+                    Ok(true)
                 }
                 Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
                     self.swapchain_stale = true;
-                    Ok(())
+                    Ok(false)
                 }
                 Err(error) => Err(error),
             }

--- a/examples/swift-map/Sources/SwiftMap/MetalRenderTarget.swift
+++ b/examples/swift-map/Sources/SwiftMap/MetalRenderTarget.swift
@@ -150,19 +150,21 @@ enum MetalRenderTarget {
     }
   }
 
-  /// Renders the latest map update, reporting whether a frame was drawn.
+  /// Renders the latest map update, reporting whether a frame was presented.
   ///
   /// The map applies a new logical size on the runtime loop's next `pump`,
   /// so this reports no update for a few iterations after attach or resize.
-  /// That is normal: the render loop keeps pacing and asks again.
+  /// The compositor paths also report false when the layer hands out no
+  /// drawable. That is normal: the render loop keeps pacing and asks again.
   func renderUpdate() throws -> Bool {
     switch self {
     case let .ownedTexture(session, compositor):
       guard try session.renderUpdate() else { return false }
       let frame = try session.acquireMetalOwnedTextureFrame()
+      var presented = false
       var firstError: Error?
       do {
-        try compositor.draw(frame: frame)
+        presented = try compositor.draw(frame: frame)
       } catch {
         firstError = error
       }
@@ -174,11 +176,10 @@ enum MetalRenderTarget {
       if let firstError {
         throw firstError
       }
-      return true
+      return presented
     case let .borrowedTexture(session, compositor, texture):
       guard try session.renderUpdate() else { return false }
-      try compositor.draw(texture: texture.texture)
-      return true
+      return try compositor.draw(texture: texture.texture)
     case let .nativeSurface(session):
       return try session.renderUpdate()
     }
@@ -287,18 +288,25 @@ final class MetalTextureCompositor {
     )
   }
 
-  func draw(frame: MetalOwnedTextureFrameHandle) throws {
+  func draw(frame: MetalOwnedTextureFrameHandle) throws -> Bool {
+    var presented = false
     try frame.withBackendPointers { view in
       let address = try view.texture.addressBitPattern
       let texture = try metalTexture(address: address)
-      try draw(texture: texture)
+      presented = try draw(texture: texture)
     }
+    return presented
   }
 
-  func draw(texture: any MTLTexture) throws {
-    guard let drawable = layer.nextDrawable() else {
-      throw metalError("CAMetalLayer returned no drawable")
-    }
+  /// Samples the texture into the layer's next drawable, reporting whether the
+  /// frame was presented.
+  ///
+  /// A minimized or occluded window legitimately has no drawable, and the
+  /// drawable pool can be momentarily empty, so this reports false instead of
+  /// failing the frame. The caller keeps its render request pending and draws
+  /// again once a drawable is available.
+  func draw(texture: any MTLTexture) throws -> Bool {
+    guard let drawable = layer.nextDrawable() else { return false }
     let passDescriptor = MTLRenderPassDescriptor()
     guard let colorAttachment = passDescriptor.colorAttachments[0] else {
       throw metalError("Metal render pass color attachment 0 is unavailable")
@@ -327,6 +335,7 @@ final class MetalTextureCompositor {
     encoder.endEncoding()
     commandBuffer.present(drawable)
     commandBuffer.commit()
+    return true
   }
 
   private static func makePipeline(

--- a/examples/zig-map/render/metal/mod.zig
+++ b/examples/zig-map/render/metal/mod.zig
@@ -152,7 +152,10 @@ const MetalTextureCompositor = struct {
 
     fn drawMetalTexture(self: *MetalTextureCompositor, metal_texture: *anyopaque) !bool {
         const drawable = self.view.layer.msgSend(objc.Object, "nextDrawable", .{});
-        if (drawable.value == null) return types.AppError.BackendDrawFailed;
+        // A minimized or occluded window has no drawable to hand out, so the
+        // frame is skipped rather than failed; the caller's render request
+        // stays pending and the draw retries once one is available.
+        if (drawable.value == null) return false;
 
         const drawable_texture = drawable.getProperty(objc.Object, "texture");
         const pass_descriptor = objc.getClass("MTLRenderPassDescriptor").?

--- a/examples/zig-map/render/vulkan/commands.zig
+++ b/examples/zig-map/render/vulkan/commands.zig
@@ -6,18 +6,29 @@ const Swapchain = @import("swapchain.zig").Swapchain;
 const util = @import("util.zig");
 
 pub const Commands = struct {
+    allocator: std.mem.Allocator,
     command_pool: c.VkCommandPool,
     command_buffer: c.VkCommandBuffer,
     image_available: c.VkSemaphore,
-    render_finished: c.VkSemaphore,
+    /// One present-wait semaphore per swapchain image, indexed by the
+    /// acquired image. The frame fence proves a submit finished, but only the
+    /// next acquire of the same image proves its present consumed the
+    /// semaphore, so a single reused semaphore is a race the presentation
+    /// engine may lose.
+    render_finished: []c.VkSemaphore,
     in_flight: c.VkFence,
 
-    pub fn init(device: c.VkDevice, queue_family_index: u32) !Commands {
+    pub fn init(
+        allocator: std.mem.Allocator,
+        device: c.VkDevice,
+        queue_family_index: u32,
+    ) !Commands {
         var self = Commands{
+            .allocator = allocator,
             .command_pool = null,
             .command_buffer = null,
             .image_available = null,
-            .render_finished = null,
+            .render_finished = &.{},
             .in_flight = null,
         };
         errdefer self.deinit(device);
@@ -57,12 +68,6 @@ pub const Commands = struct {
             null,
             &self.image_available,
         ));
-        try util.expectVk(c.vkCreateSemaphore(
-            device,
-            &semaphore_info,
-            null,
-            &self.render_finished,
-        ));
         const fence_info = c.VkFenceCreateInfo{
             .sType = c.VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
             .pNext = null,
@@ -73,16 +78,46 @@ pub const Commands = struct {
     }
 
     pub fn deinit(self: *Commands, device: c.VkDevice) void {
+        self.destroyPresentSemaphores(device);
         if (self.in_flight != null) c.vkDestroyFence(device, self.in_flight, null);
-        if (self.render_finished != null) {
-            c.vkDestroySemaphore(device, self.render_finished, null);
-        }
         if (self.image_available != null) {
             c.vkDestroySemaphore(device, self.image_available, null);
         }
         if (self.command_pool != null) {
             c.vkDestroyCommandPool(device, self.command_pool, null);
         }
+    }
+
+    /// Sizes the present-wait semaphores to the swapchain, on creation and on
+    /// every replacement. The caller waits the device idle first.
+    pub fn createPresentSemaphores(
+        self: *Commands,
+        device: c.VkDevice,
+        image_count: u32,
+    ) !void {
+        self.render_finished = try self.allocator.alloc(c.VkSemaphore, image_count);
+        @memset(self.render_finished, null);
+        const semaphore_info = c.VkSemaphoreCreateInfo{
+            .sType = c.VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+            .pNext = null,
+            .flags = 0,
+        };
+        for (self.render_finished) |*semaphore| {
+            try util.expectVk(c.vkCreateSemaphore(
+                device,
+                &semaphore_info,
+                null,
+                semaphore,
+            ));
+        }
+    }
+
+    pub fn destroyPresentSemaphores(self: *Commands, device: c.VkDevice) void {
+        for (self.render_finished) |semaphore| {
+            if (semaphore != null) c.vkDestroySemaphore(device, semaphore, null);
+        }
+        self.allocator.free(self.render_finished);
+        self.render_finished = &.{};
     }
 
     pub fn waitForFrameFence(self: *Commands, device: c.VkDevice) !void {
@@ -99,7 +134,9 @@ pub const Commands = struct {
         try util.expectVk(c.vkResetFences(device, 1, &self.in_flight));
     }
 
-    pub fn submit(self: *Commands, queue: c.VkQueue) !void {
+    /// Submits the recorded commands, signaling the acquired image's
+    /// present-wait semaphore.
+    pub fn submit(self: *Commands, queue: c.VkQueue, image_index: u32) !void {
         const wait_stages = [_]c.VkPipelineStageFlags{
             c.VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
         };
@@ -112,7 +149,7 @@ pub const Commands = struct {
             .commandBufferCount = 1,
             .pCommandBuffers = &self.command_buffer,
             .signalSemaphoreCount = 1,
-            .pSignalSemaphores = &self.render_finished,
+            .pSignalSemaphores = &self.render_finished[image_index],
         };
         try util.expectVk(c.vkQueueSubmit(queue, 1, &submit_info, self.in_flight));
     }

--- a/examples/zig-map/render/vulkan/context.zig
+++ b/examples/zig-map/render/vulkan/context.zig
@@ -144,6 +144,31 @@ pub const Context = struct {
         return types.AppError.BackendSetupFailed;
     }
 
+    fn hasDeviceExtension(self: *Context, name: []const u8) !bool {
+        var count: u32 = 0;
+        try util.expectVk(c.vkEnumerateDeviceExtensionProperties(
+            self.physical_device,
+            null,
+            &count,
+            null,
+        ));
+        const properties = try self.allocator.alloc(c.VkExtensionProperties, count);
+        defer self.allocator.free(properties);
+        try util.expectVk(c.vkEnumerateDeviceExtensionProperties(
+            self.physical_device,
+            null,
+            &count,
+            properties.ptr,
+        ));
+
+        for (properties[0..@intCast(count)]) |property| {
+            if (std.mem.eql(u8, std.mem.span(@as([*:0]const u8, @ptrCast(&property.extensionName))), name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     fn createDevice(self: *Context) !void {
         var priority: f32 = 1.0;
         const queue_info = c.VkDeviceQueueCreateInfo{
@@ -154,8 +179,15 @@ pub const Context = struct {
             .queueCount = 1,
             .pQueuePriorities = &priority,
         };
-        const base_extensions = [_][*:0]const u8{c.VK_KHR_SWAPCHAIN_EXTENSION_NAME};
-        const extensions = base_extensions[0..];
+        // A device that exposes the portability subset requires enabling it.
+        // The name is spelled out because its declaration lives behind the
+        // provisional vulkan_beta.h header.
+        const extensions = [_][*:0]const u8{
+            c.VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+            "VK_KHR_portability_subset",
+        };
+        const extension_count: u32 =
+            if (try self.hasDeviceExtension("VK_KHR_portability_subset")) 2 else 1;
         var features = std.mem.zeroes(c.VkPhysicalDeviceFeatures);
         c.vkGetPhysicalDeviceFeatures(self.physical_device, &features);
         const create_info = c.VkDeviceCreateInfo{
@@ -166,8 +198,8 @@ pub const Context = struct {
             .pQueueCreateInfos = &queue_info,
             .enabledLayerCount = 0,
             .ppEnabledLayerNames = null,
-            .enabledExtensionCount = @intCast(extensions.len),
-            .ppEnabledExtensionNames = extensions.ptr,
+            .enabledExtensionCount = extension_count,
+            .ppEnabledExtensionNames = &extensions,
             .pEnabledFeatures = &features,
         };
         try util.expectVk(c.vkCreateDevice(

--- a/examples/zig-map/render/vulkan/mod.zig
+++ b/examples/zig-map/render/vulkan/mod.zig
@@ -82,6 +82,8 @@ const VulkanTextureCompositor = struct {
     swapchain: Swapchain,
     pipeline: Pipeline,
     commands: Commands,
+    current_viewport: types.Viewport,
+    swapchain_stale: bool = false,
 
     fn init(
         allocator: std.mem.Allocator,
@@ -91,21 +93,23 @@ const VulkanTextureCompositor = struct {
         var context = try Context.init(allocator, window);
         errdefer context.deinit();
 
-        var swapchain = try Swapchain.init(allocator, &context, viewport);
+        var swapchain = try Swapchain.init(allocator, &context, viewport, null);
         errdefer swapchain.deinit(context.device);
 
         var pipeline = try Pipeline.init(allocator, context.device, swapchain.format);
         errdefer pipeline.deinit(context.device);
         try swapchain.createFramebuffers(context.device, pipeline.render_pass);
 
-        var commands = try Commands.init(context.device, context.queue_family_index);
+        var commands = try Commands.init(allocator, context.device, context.queue_family_index);
         errdefer commands.deinit(context.device);
+        try commands.createPresentSemaphores(context.device, @intCast(swapchain.images.len));
 
         return .{
             .context = context,
             .swapchain = swapchain,
             .pipeline = pipeline,
             .commands = commands,
+            .current_viewport = viewport,
         };
     }
 
@@ -121,14 +125,36 @@ const VulkanTextureCompositor = struct {
         self.context.waitIdle();
     }
 
-    fn resize(self: *VulkanTextureCompositor, viewport: types.Viewport) !void {
-        const previous_format = self.swapchain.format;
-        self.swapchain.deinit(self.context.device);
-        self.swapchain = try Swapchain.init(
-            self.swapchain.allocator,
+    /// Notes a resized window without touching the swapchain.
+    ///
+    /// The swapchain the window displays stays live until the present that
+    /// replaces its content: destroying it here would blank the window for as
+    /// long as the map takes to render at the new extent, because the
+    /// compositor only presents when a map frame is ready. Presenting through
+    /// the stale swapchain scales the old content in the meantime, which is
+    /// what a resized native surface shows too.
+    fn resize(self: *VulkanTextureCompositor, viewport: types.Viewport) void {
+        self.current_viewport = viewport;
+        self.swapchain_stale = true;
+    }
+
+    fn recreateSwapchain(self: *VulkanTextureCompositor) !void {
+        self.context.waitIdle();
+        // The replacement is created before the retired swapchain is
+        // destroyed and names it as oldSwapchain, so the presentation engine
+        // hands the surface over directly. Destroying it first leaves a gap
+        // that MoltenVK fills with presents that succeed but reach no
+        // drawable the window still shows.
+        var previous = self.swapchain;
+        const previous_format = previous.format;
+        const replacement = Swapchain.init(
+            previous.allocator,
             &self.context,
-            viewport,
+            self.current_viewport,
+            previous.handle,
         );
+        previous.deinit(self.context.device);
+        self.swapchain = try replacement;
 
         if (self.swapchain.format != previous_format) {
             self.pipeline.deinit(self.context.device);
@@ -141,6 +167,11 @@ const VulkanTextureCompositor = struct {
         try self.swapchain.createFramebuffers(
             self.context.device,
             self.pipeline.render_pass,
+        );
+        self.commands.destroyPresentSemaphores(self.context.device);
+        try self.commands.createPresentSemaphores(
+            self.context.device,
+            @intCast(self.swapchain.images.len),
         );
     }
 
@@ -155,6 +186,14 @@ const VulkanTextureCompositor = struct {
 
         try self.waitForFrame();
 
+        // The frame about to present is the first content the resized
+        // swapchain could show, so this is the moment the stale one is
+        // replaced.
+        if (self.swapchain_stale) {
+            try self.recreateSwapchain();
+            self.swapchain_stale = false;
+        }
+
         var image_index: u32 = 0;
         const acquire = c.vkAcquireNextImageKHR(
             self.context.device,
@@ -164,7 +203,15 @@ const VulkanTextureCompositor = struct {
             null,
             &image_index,
         );
-        if (acquire == c.VK_ERROR_OUT_OF_DATE_KHR) return false;
+        if (acquire == c.VK_ERROR_OUT_OF_DATE_KHR) {
+            self.swapchain_stale = true;
+            return false;
+        }
+        if (acquire == c.VK_SUBOPTIMAL_KHR) {
+            // Still presentable, but the surface has moved on; replace the
+            // swapchain before the next frame.
+            self.swapchain_stale = true;
+        }
         try util.expectVkOrSuboptimal(acquire);
         try self.commands.resetFence(self.context.device);
 
@@ -174,13 +221,13 @@ const VulkanTextureCompositor = struct {
             &self.pipeline,
             image_index,
         );
-        try self.commands.submit(self.context.queue);
+        try self.commands.submit(self.context.queue, image_index);
 
         const present_info = c.VkPresentInfoKHR{
             .sType = c.VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
             .pNext = null,
             .waitSemaphoreCount = 1,
-            .pWaitSemaphores = &self.commands.render_finished,
+            .pWaitSemaphores = &self.commands.render_finished[image_index],
             .swapchainCount = 1,
             .pSwapchains = &self.swapchain.handle,
             .pImageIndices = &image_index,
@@ -191,12 +238,16 @@ const VulkanTextureCompositor = struct {
             // Nothing reached the screen. The sampling pass was submitted, so
             // wait it out before the caller releases its frame, and report no
             // present so the render request is set again.
+            self.swapchain_stale = true;
             self.waitForFrame() catch {};
             return false;
         }
         if (present != c.VK_SUCCESS and present != c.VK_SUBOPTIMAL_KHR) {
             self.waitForFrame() catch {};
             try util.expectVk(present);
+        }
+        if (present == c.VK_SUBOPTIMAL_KHR) {
+            self.swapchain_stale = true;
         }
         return true;
     }
@@ -237,7 +288,7 @@ const VulkanOwnedTextureBackend = struct {
     fn resize(self: *VulkanOwnedTextureBackend, viewport: types.Viewport) !void {
         self.compositor.waitIdle();
         self.releasePendingFrame();
-        try self.compositor.resize(viewport);
+        self.compositor.resize(viewport);
         try self.session.resize(viewport, null);
     }
 
@@ -423,7 +474,7 @@ const VulkanBorrowedTextureBackend = struct {
     fn resize(self: *VulkanBorrowedTextureBackend, viewport: types.Viewport) !void {
         const session = try self.session.textureHandle();
         self.compositor.waitIdle();
-        try self.compositor.resize(viewport);
+        self.compositor.resize(viewport);
 
         var replacement = try BorrowedImage.init(&self.compositor.context, viewport);
         errdefer replacement.deinit(self.compositor.context.device);

--- a/examples/zig-map/render/vulkan/mod.zig
+++ b/examples/zig-map/render/vulkan/mod.zig
@@ -180,10 +180,6 @@ const VulkanTextureCompositor = struct {
     }
 
     fn presentImageView(self: *VulkanTextureCompositor, image_view: c.VkImageView) !bool {
-        if (image_view != self.pipeline.descriptor_image_view) {
-            self.pipeline.updateDescriptor(self.context.device, image_view);
-        }
-
         try self.waitForFrame();
 
         // The frame about to present is the first content the resized
@@ -192,6 +188,14 @@ const VulkanTextureCompositor = struct {
         if (self.swapchain_stale) {
             try self.recreateSwapchain();
             self.swapchain_stale = false;
+        }
+
+        // After the fence wait, so no in-flight commands read the descriptor
+        // set, and after the replacement, whose format change rebuilds the
+        // pipeline around an unwritten descriptor set that this check then
+        // populates.
+        if (image_view != self.pipeline.descriptor_image_view) {
+            self.pipeline.updateDescriptor(self.context.device, image_view);
         }
 
         var image_index: u32 = 0;

--- a/examples/zig-map/render/vulkan/mod.zig
+++ b/examples/zig-map/render/vulkan/mod.zig
@@ -152,9 +152,17 @@ const VulkanTextureCompositor = struct {
             &self.context,
             self.current_viewport,
             previous.handle,
-        );
+        ) catch |err| {
+            // The failed replacement cleaned up after itself. Destroying the
+            // retired swapchain empties the struct it was copied from, and
+            // storing that back keeps teardown from destroying its handles a
+            // second time.
+            previous.deinit(self.context.device);
+            self.swapchain = previous;
+            return err;
+        };
         previous.deinit(self.context.device);
-        self.swapchain = try replacement;
+        self.swapchain = replacement;
 
         if (self.swapchain.format != previous_format) {
             self.pipeline.deinit(self.context.device);

--- a/examples/zig-map/render/vulkan/swapchain.zig
+++ b/examples/zig-map/render/vulkan/swapchain.zig
@@ -14,10 +14,14 @@ pub const Swapchain = struct {
     views: []c.VkImageView,
     framebuffers: []c.VkFramebuffer,
 
+    /// Creates the swapchain. A replacement passes the swapchain it retires
+    /// as old_swapchain, so the presentation engine hands the surface over
+    /// without a gap; the caller destroys the retired one after this returns.
     pub fn init(
         allocator: std.mem.Allocator,
         context: *const Context,
         viewport: types.Viewport,
+        old_swapchain: c.VkSwapchainKHR,
     ) !Swapchain {
         var self = Swapchain{
             .allocator = allocator,
@@ -30,7 +34,7 @@ pub const Swapchain = struct {
         };
         errdefer self.deinit(context.device);
 
-        try self.create(context, viewport);
+        try self.create(context, viewport, old_swapchain);
         return self;
     }
 
@@ -80,7 +84,12 @@ pub const Swapchain = struct {
         }
     }
 
-    fn create(self: *Swapchain, context: *const Context, viewport: types.Viewport) !void {
+    fn create(
+        self: *Swapchain,
+        context: *const Context,
+        viewport: types.Viewport,
+        old_swapchain: c.VkSwapchainKHR,
+    ) !void {
         var capabilities: c.VkSurfaceCapabilitiesKHR = undefined;
         try util.expectVk(c.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
             context.physical_device,
@@ -132,7 +141,7 @@ pub const Swapchain = struct {
             .compositeAlpha = c.VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
             .presentMode = c.VK_PRESENT_MODE_FIFO_KHR,
             .clipped = c.VK_TRUE,
-            .oldSwapchain = null,
+            .oldSwapchain = old_swapchain,
         };
         try util.expectVk(c.vkCreateSwapchainKHR(
             context.device,

--- a/include/maplibre_native_c/render_session.h
+++ b/include/maplibre_native_c/render_session.h
@@ -61,30 +61,20 @@ MLN_API mln_status mln_render_session_resize(
 ) MLN_NOEXCEPT;
 
 /**
- * Processes the latest map render update for an attached render session.
+ * Renders the map's latest render update into the session's render target.
  *
- * Surface sessions render and present through their native surface. Texture
- * sessions render into their texture target.
+ * A surface session presents the frame. A texture session writes it into the
+ * target texture.
  *
- * On success, *out_rendered reports whether the latest available map render
- * update was rendered. The map retains its latest update, so repeated calls
- * re-render it and report true again; hosts use this to redraw on demand
- * after resize or surface expose, and gate frame-driven loops on
- * MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE instead of the return value.
- * *out_rendered is false when no frame was rendered: the map has not
- * published a render update yet, or the renderer skipped producing a frame
- * for the latest update (for example the Metal texture backend before content
- * is ready, or a Metal surface whose layer has no drawable to hand out while
- * its window is minimized or occluded), or the map has yet to apply a size
- * this session asked for. All are normal transients; keep pumping the runtime
- * and call again when an update is reported.
+ * *out_rendered reports whether this call rendered a frame. The map retains its
+ * latest update, so a host redraws on demand after a resize or a surface expose
+ * and gates a frame loop on MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE. A
+ * false report is a normal transient: call again on the next frame rather than
+ * wait for another update event.
  *
- * The last of those needs care in MLN_MAP_MODE_STATIC. A session applies its
- * extent on the map's owner thread, so the map still carries the previous size
- * until it is pumped, and an update built for that size renders nothing here. A
- * still-image request made before the resize lands is spent on that discarded
- * update, and a static map publishes no further update on its own. Pump the
- * resize through before requesting the still image.
+ * In MLN_MAP_MODE_STATIC, pump a resize through the map before requesting the
+ * still image. The session applies its extent on the map's owner thread, and a
+ * still image requested before that lands renders nothing.
  *
  * Returns:
  * - MLN_STATUS_OK on success, with *out_rendered set.

--- a/include/maplibre_native_c/render_session.h
+++ b/include/maplibre_native_c/render_session.h
@@ -74,9 +74,10 @@ MLN_API mln_status mln_render_session_resize(
  * *out_rendered is false when no frame was rendered: the map has not
  * published a render update yet, or the renderer skipped producing a frame
  * for the latest update (for example the Metal texture backend before content
- * is ready), or the map has yet to apply a size this session asked for. All are
- * normal during startup; keep pumping the runtime and call again when an update
- * is reported.
+ * is ready, or a Metal surface whose layer has no drawable to hand out while
+ * its window is minimized or occluded), or the map has yet to apply a size
+ * this session asked for. All are normal transients; keep pumping the runtime
+ * and call again when an update is reported.
  *
  * The last of those needs care in MLN_MAP_MODE_STATIC. A session applies its
  * extent on the map's owner thread, so the map still carries the previous size

--- a/src/render/metal/metal_surface_session.mm
+++ b/src/render/metal/metal_surface_session.mm
@@ -75,14 +75,18 @@ class MetalSurfaceBackend final : public mbgl::mtl::RendererBackend,
       setSize(size_);
     }
 
-    void bind() override {
+    // Acquires the frame's drawable, command buffer, and render pass, and
+    // reports whether the layer had a drawable to hand out. A minimized or
+    // occluded window's layer legitimately has none, so the render update
+    // asks here first and skips the frame; bind() cannot proceed without one.
+    auto try_bind() -> bool {
       if (drawable && commandBuffer && renderPassDescriptor) {
-        return;
+        return true;
       }
 
       auto* next_drawable = layer->nextDrawable();
       if (next_drawable == nullptr) {
-        throw std::runtime_error("Metal surface did not provide a drawable");
+        return false;
       }
       drawable = NS::RetainPtr(next_drawable);
 
@@ -154,6 +158,13 @@ class MetalSurfaceBackend final : public mbgl::mtl::RendererBackend,
           static_cast<mbgl::mtl::Texture2D*>(stencilTexture.get())
             ->getMetalTexture()
         );
+      }
+      return true;
+    }
+
+    void bind() override {
+      if (!try_bind()) {
+        throw std::runtime_error("Metal surface did not provide a drawable");
       }
     }
 
@@ -236,6 +247,10 @@ class MetalSurfaceBackend final : public mbgl::mtl::RendererBackend,
     getResource<MetalSurfaceRenderableResource>().set_layer(layer_, size_);
   }
 
+  auto try_bind() -> bool {
+    return getResource<MetalSurfaceRenderableResource>().try_bind();
+  }
+
   // A null device in a descriptor names no device at all, which every session
   // satisfies; the session keeps the one it attached with either way.
   [[nodiscard]] auto has_device(MTL::Device* other) const -> bool {
@@ -261,6 +276,11 @@ class MetalSurfaceSessionBackend final
 
   void resize(uint32_t physical_width, uint32_t physical_height) override {
     backend_.setSize(mbgl::Size{physical_width, physical_height});
+  }
+
+  auto prepare_frame(bool& out_ready) -> mln_status override {
+    out_ready = backend_.try_bind();
+    return MLN_STATUS_OK;
   }
 
   auto set_metal_target(const mln_metal_surface_descriptor& descriptor)

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -1356,6 +1356,21 @@ auto render_session_render_update(
 
   if (live->kind == RenderSessionKind::Texture) {
     live->texture.backend->prepare_render_resources();
+  } else {
+    bool surface_ready = true;
+    try {
+      const auto prepare_status =
+        live->surface.backend->prepare_frame(surface_ready);
+      if (prepare_status != MLN_STATUS_OK) {
+        return prepare_status;
+      }
+    } catch (const std::exception& exception) {
+      set_native_stage_error("preparing surface frame", exception);
+      return MLN_STATUS_NATIVE_ERROR;
+    }
+    if (!surface_ready) {
+      return MLN_STATUS_OK;
+    }
   }
   if (live->renderer == nullptr) {
     try {

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -72,6 +72,16 @@ class SurfaceSessionBackend {
   virtual auto renderer_backend() -> mbgl::gfx::RendererBackend& = 0;
   virtual void resize(uint32_t physical_width, uint32_t physical_height) = 0;
 
+  // Whether the surface can take a frame right now. A false report makes the
+  // render update skip the frame and report nothing rendered, which is how a
+  // minimized or occluded window's surface, with no target to hand out, stays
+  // a retry rather than a failure. The default reports ready, for surfaces
+  // that never run dry.
+  virtual auto prepare_frame(bool& out_ready) -> mln_status {
+    out_ready = true;
+    return MLN_STATUS_OK;
+  }
+
   // Presents through a new host surface, keeping the graphics context and every
   // resource the renderer holds against it. The descriptor names the same
   // context as the one this session attached with; a backend rejects anything


### PR DESCRIPTION
## Summary

Ports zig-map's Metal render target to c-map as plain C over the Objective-C runtime, and enables the macOS Vulkan (MoltenVK) and EGL (ANGLE) builds by replacing C11 threads with SDL threading and wiring the macOS link/tooling plumbing.

## Test plan

Ran all three render-target modes on macos-arm64-metal, plus owned-texture, borrowed-texture, and native-surface on macos-arm64-vulkan and macos-arm64-egl, with interactive and scripted window resizes.

## AI assistance

- **Tools:** Claude Code
- **Context:** Implemented as a file-by-file port of zig-map per my instructions; I smoke-tested the windows interactively during the session.