### PR TITLE
Constrain Dart simulator smoke build to arm64

### DIFF
--- a/bindings/dart/mise.toml
+++ b/bindings/dart/mise.toml
@@ -97,6 +97,9 @@ case "$usage_preset" in
     flutter build ios --release --no-codesign
     ;;
   ios-simulator-arm64-*)
+    # Flutter prepares native assets for every standard simulator architecture
+    # before Xcode narrows a debug build to the active architecture.
+    printf '\nARCHS = arm64\n' >>ios/Flutter/Debug.xcconfig
     flutter build ios --debug --simulator --no-codesign
     ;;
 esac


### PR DESCRIPTION
## Summary

Constrain the generated Flutter iOS simulator smoke app to arm64 because Flutter prepares an x64 native-assets build that cannot use the `ios-simulator-arm64-metal` prefix.

## Test plan

Ran `mise run //bindings/dart:analyze`, `mise run ci:generate-workflow`, and `mise run check`.

## AI assistance

- **Tools:** Codex
- **Context:** Inspected the failing GitHub Actions job and Flutter 3.44.8 iOS build path, then implemented and validated the focused task fix.