### PR TITLE
Avoid handle destruction during process exit

### DIFF
--- a/src/handles/handle_table.hpp
+++ b/src/handles/handle_table.hpp
@@ -272,12 +272,12 @@ class HandleTable {
   std::vector<std::uint32_t> free_indices_;
 };
 
-// One process-global table per object type. The whole C API links into a
-// single target, so the function-local static is unique.
+// Intentionally leaked because destroying live handles during C++ static
+// teardown can use resources that have already been destroyed.
 template <typename Object>
 auto handle_table() -> HandleTable<Object>& {
-  static auto value = HandleTable<Object>{};
-  return value;
+  static auto* const value = new HandleTable<Object>{};
+  return *value;
 }
 
 }  // namespace mln::core


### PR DESCRIPTION
## Summary

Keep process-global handle tables alive through C++ static teardown so process exit cannot destroy live handles after their resources are gone.

## Test plan

Run `mise run //:test macos-arm64-metal`, `mise exec -- hk check --check --no-stage`, and `git diff --check`.

## AI assistance

- **Tools:** Codex
- **Context:** Codex traced the static-lifetime failure, implemented the process-lifetime registry, and ran the listed checks.