### PR TITLE
Add glob matching to callback adapter rules

### DIFF
--- a/bindings/dart/lib/src/internal/c/maplibre_native_c.g.dart
+++ b/bindings/dart/lib/src/internal/c/maplibre_native_c.g.dart
@@ -5604,9 +5604,28 @@ final class mln_texture_image_info extends ffi.Struct {
   external int byte_length;
 }
 
+enum mln_adapter_url_match_flags {
+  MLN_ADAPTER_URL_MATCH_FLAGS_NONE(0),
+  MLN_ADAPTER_URL_MATCH_GLOB(1);
+
+  final int value;
+  const mln_adapter_url_match_flags(this.value);
+
+  static mln_adapter_url_match_flags fromValue(int value) => switch (value) {
+    0 => MLN_ADAPTER_URL_MATCH_FLAGS_NONE,
+    1 => MLN_ADAPTER_URL_MATCH_GLOB,
+    _ => throw ArgumentError(
+      'Unknown value for mln_adapter_url_match_flags: $value',
+    ),
+  };
+}
+
 final class mln_adapter_resource_rewrite_rule extends ffi.Struct {
   @ffi.Uint32()
   external int kind;
+
+  @ffi.Uint32()
+  external int flags;
 
   external ffi.Pointer<ffi.Char> url;
 
@@ -5618,23 +5637,6 @@ final class mln_adapter_resource_rewrite_rules extends ffi.Struct {
 
   @ffi.Size()
   external int count;
-}
-
-enum mln_adapter_http_header_route_flags {
-  MLN_ADAPTER_HTTP_HEADER_ROUTE_FLAGS_NONE(0),
-  MLN_ADAPTER_HTTP_HEADER_ROUTE_MATCH_PREFIX(1);
-
-  final int value;
-  const mln_adapter_http_header_route_flags(this.value);
-
-  static mln_adapter_http_header_route_flags fromValue(int value) =>
-      switch (value) {
-        0 => MLN_ADAPTER_HTTP_HEADER_ROUTE_FLAGS_NONE,
-        1 => MLN_ADAPTER_HTTP_HEADER_ROUTE_MATCH_PREFIX,
-        _ => throw ArgumentError(
-          'Unknown value for mln_adapter_http_header_route_flags: $value',
-        ),
-      };
 }
 
 final class mln_adapter_http_header extends ffi.Struct {
@@ -5669,6 +5671,9 @@ final class mln_adapter_resource_provider_rule extends ffi.Struct {
   @ffi.Uint32()
   external int kind;
 
+  @ffi.Uint32()
+  external int flags;
+
   external ffi.Pointer<ffi.Char> requested_url;
 
   external mln_resource_response response;
@@ -5683,7 +5688,7 @@ final class mln_adapter_resource_provider_rules extends ffi.Struct {
 
 enum mln_adapter_resource_route_flags {
   MLN_ADAPTER_RESOURCE_ROUTE_FLAGS_NONE(0),
-  MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX(1),
+  MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB(1),
   MLN_ADAPTER_RESOURCE_ROUTE_USE_REQUESTED_URL(2);
 
   final int value;
@@ -5692,7 +5697,7 @@ enum mln_adapter_resource_route_flags {
   static mln_adapter_resource_route_flags fromValue(int value) =>
       switch (value) {
         0 => MLN_ADAPTER_RESOURCE_ROUTE_FLAGS_NONE,
-        1 => MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX,
+        1 => MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB,
         2 => MLN_ADAPTER_RESOURCE_ROUTE_USE_REQUESTED_URL,
         _ => throw ArgumentError(
           'Unknown value for mln_adapter_resource_route_flags: $value',

--- a/bindings/dart/lib/src/resource/resource.dart
+++ b/bindings/dart/lib/src/resource/resource.dart
@@ -216,20 +216,42 @@ final class ResourceErrorReason {
   final String name;
 }
 
-/// Exact URL rewrite rule used by the runtime resource transform.
+/// URL rewrite rule used by the runtime resource transform.
 final class ResourceUrlRewriteRule {
-  /// Creates an exact URL rewrite rule.
+  /// Creates a URL rewrite rule.
   const ResourceUrlRewriteRule({
     this.kind,
     required this.url,
+    this.matchGlob = false,
     required this.replacementUrl,
   });
 
   /// Optional resource kind filter. Null matches any kind.
   final ResourceKind? kind;
 
-  /// Original URL to match exactly.
+  /// Original URL to match, compared case-sensitively with no URL parsing or
+  /// normalization.
   final String url;
+
+  /// Reads [url] as a glob pattern instead of comparing the complete URL byte
+  /// for byte.
+  ///
+  /// A pattern matches the complete URL, so a pattern that describes a suffix
+  /// opens with a wildcard:
+  ///
+  /// - `*` matches a run of any length that contains no `/`, including an empty
+  ///   run.
+  /// - `**` matches a run of any length, including one that contains `/`.
+  /// - `?` matches one character other than `/`.
+  /// - `\` matches the next character literally, and a trailing `\` matches
+  ///   itself.
+  ///
+  /// Confining `*` to one path segment is what makes a host pattern hold:
+  /// `https://*.example.com/**` matches every subdomain of example.com, and a
+  /// request for `https://attacker.example/x.example.com/tile` matches it
+  /// nowhere. Use `**` wherever a pattern spans path segments, as in
+  /// `https://tiles.example.com/**` for one whole host.
+  final bool matchGlob;
 
   /// Replacement URL returned to native code.
   final String replacementUrl;
@@ -246,17 +268,21 @@ final class HttpHeader {
 
 /// Native-owned route supplying headers for matching transformed URLs.
 final class HttpHeaderTransformRule {
-  /// Creates an exact or prefix route.
+  /// Creates a route matching the complete transformed URL or a glob pattern.
   const HttpHeaderTransformRule({
     this.kind,
     required this.url,
-    this.matchPrefix = false,
+    this.matchGlob = false,
     required this.headers,
   });
 
   final ResourceKind? kind;
   final String url;
-  final bool matchPrefix;
+
+  /// Reads [url] as a glob pattern. See [ResourceUrlRewriteRule.matchGlob] for
+  /// the pattern language.
+  final bool matchGlob;
+
   final List<HttpHeader> headers;
 }
 
@@ -323,40 +349,46 @@ final class ResourceProviderRoute {
   const ResourceProviderRoute({
     this.kind,
     required this.url,
-    this.matchPrefix = false,
+    this.matchGlob = false,
     this.useRequestedUrl = false,
   });
 
   /// Optional resource kind filter. Null matches any kind.
   final ResourceKind? kind;
 
-  /// Literal URL comparison value, compared case-sensitively with no glob
-  /// expansion, regular expressions, URL parsing, or normalization.
+  /// URL comparison value, compared case-sensitively with no URL parsing or
+  /// normalization.
   final String url;
 
-  /// Matches [url] against the start of the request URL instead of the whole
-  /// request URL. An empty [url] then matches every request URL.
-  final bool matchPrefix;
+  /// Reads [url] as a glob pattern. See [ResourceUrlRewriteRule.matchGlob] for
+  /// the pattern language.
+  final bool matchGlob;
 
   /// Compares [ResourceRequest.requestedUrl] instead of
   /// [ResourceRequest.resolvedUrl].
   final bool useRequestedUrl;
 }
 
-/// Exact URL provider rule used by the runtime resource provider.
+/// URL provider rule used by the runtime resource provider.
 final class ResourceProviderRule {
-  /// Creates an exact URL provider rule.
+  /// Creates a provider rule.
   const ResourceProviderRule({
     this.kind,
     required this.requestedUrl,
+    this.matchGlob = false,
     required this.response,
   });
 
   /// Optional resource kind filter. Null matches any kind.
   final ResourceKind? kind;
 
-  /// Requested URL to match exactly.
+  /// Requested URL to match, compared case-sensitively with no URL parsing or
+  /// normalization.
   final String requestedUrl;
+
+  /// Reads [requestedUrl] as a glob pattern. See
+  /// [ResourceUrlRewriteRule.matchGlob] for the pattern language.
+  final bool matchGlob;
 
   /// Response to complete for matching requests.
   final ResourceResponse response;

--- a/bindings/dart/lib/src/runtime/runtime_resource_callbacks.dart
+++ b/bindings/dart/lib/src/runtime/runtime_resource_callbacks.dart
@@ -1,5 +1,9 @@
 part of 'runtime.dart';
 
+int _urlMatchFlags(bool matchGlob) => matchGlob
+    ? raw.mln_adapter_url_match_flags.MLN_ADAPTER_URL_MATCH_GLOB.value
+    : raw.mln_adapter_url_match_flags.MLN_ADAPTER_URL_MATCH_FLAGS_NONE.value;
+
 final class _ResourceTransformState {
   _ResourceTransformState(List<ResourceUrlRewriteRule> rules) {
     for (final rule in rules) {
@@ -15,6 +19,7 @@ final class _ResourceTransformState {
       final rule = rules[index];
       pointer.ref.rules[index].kind =
           rule.kind?.rawValue ?? _resourceKindWildcard;
+      pointer.ref.rules[index].flags = _urlMatchFlags(rule.matchGlob);
       pointer.ref.rules[index].url = _nativeOwnedCString(rule.url);
       pointer.ref.rules[index].replacement_url = _nativeOwnedCString(
         rule.replacementUrl,
@@ -61,15 +66,7 @@ final class _HttpHeaderTransformState {
       final rule = rules[ruleIndex];
       final nativeRule = pointer.ref.rules[ruleIndex];
       nativeRule.kind = rule.kind?.rawValue ?? _resourceKindWildcard;
-      nativeRule.flags = rule.matchPrefix
-          ? raw
-                .mln_adapter_http_header_route_flags
-                .MLN_ADAPTER_HTTP_HEADER_ROUTE_MATCH_PREFIX
-                .value
-          : raw
-                .mln_adapter_http_header_route_flags
-                .MLN_ADAPTER_HTTP_HEADER_ROUTE_FLAGS_NONE
-                .value;
+      nativeRule.flags = _urlMatchFlags(rule.matchGlob);
       nativeRule.url = _nativeOwnedCString(rule.url);
       nativeRule.header_count = rule.headers.length;
       nativeRule.headers = rule.headers.isEmpty
@@ -145,6 +142,7 @@ final class _ResourceProviderRulesState {
       final rule = rules[index];
       pointer.ref.rules[index].kind =
           rule.kind?.rawValue ?? _resourceKindWildcard;
+      pointer.ref.rules[index].flags = _urlMatchFlags(rule.matchGlob);
       pointer.ref.rules[index].requested_url = _nativeOwnedCString(
         rule.requestedUrl,
       );
@@ -175,10 +173,10 @@ int _resourceRouteFlags(ResourceProviderRoute route) {
       .mln_adapter_resource_route_flags
       .MLN_ADAPTER_RESOURCE_ROUTE_FLAGS_NONE
       .value;
-  if (route.matchPrefix) {
+  if (route.matchGlob) {
     flags |= raw
         .mln_adapter_resource_route_flags
-        .MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX
+        .MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB
         .value;
   }
   if (route.useRequestedUrl) {

--- a/bindings/dart/test/maplibre_native_ffi_test.dart
+++ b/bindings/dart/test/maplibre_native_ffi_test.dart
@@ -317,16 +317,18 @@ void main() {
     runtime.close();
   });
 
-  // BND-156: a prefix route claims a URL family whose members are known only
+  // BND-156: a glob route claims a URL family whose members are known only
   // when they are requested.
-  test('queued resource provider prefix routes claim a URL family', () async {
-    const prefix = 'custom://dart-provider-prefix/';
+  test('queued resource provider glob routes claim a URL family', () async {
+    const origin = 'custom://dart-provider-glob/';
     final runtime = RuntimeHandle.create();
     final claimed = <String>[];
 
     runtime.setResourceProvider(
       ResourceProvider(
-        routes: const [ResourceProviderRoute(url: prefix, matchPrefix: true)],
+        routes: const [
+          ResourceProviderRoute(url: '$origin**', matchGlob: true),
+        ],
         callback: (request, handle) {
           claimed.add(request.resolvedUrl);
           handle.complete(
@@ -341,21 +343,21 @@ void main() {
     );
 
     final map = runtime.createMap();
-    map.setStyleUrl('${prefix}unenumerated/style.json');
+    map.setStyleUrl('${origin}unenumerated/style.json');
     await _pumpUntilEvent(
       runtime,
       (candidate) => candidate.eventType == RuntimeEventType.mapStyleLoaded,
     );
 
-    // The prefix is start-anchored, so a URL that merely contains it stays with
-    // native loading.
-    map.setStyleUrl('custom://elsewhere/${prefix}style.json');
+    // A pattern matches the complete URL, so a URL that merely contains the
+    // route's origin stays with native loading.
+    map.setStyleUrl('custom://elsewhere/${origin}style.json');
     await _pumpUntilEvent(
       runtime,
       (candidate) => candidate.eventType == RuntimeEventType.mapLoadingFailed,
     );
 
-    expect(claimed, ['${prefix}unenumerated/style.json']);
+    expect(claimed, ['${origin}unenumerated/style.json']);
 
     map.close();
     runtime.close();
@@ -959,8 +961,8 @@ void main() {
     );
     runtime.setHttpHeaderTransformRules([
       const HttpHeaderTransformRule(
-        url: 'https://example.com/',
-        matchPrefix: true,
+        url: 'https://example.com/**',
+        matchGlob: true,
         headers: [HttpHeader(name: 'X-Test', value: 'café')],
       ),
     ]);

--- a/docs/src/content/docs/development/binding-specification.md
+++ b/docs/src/content/docs/development/binding-specification.md
@@ -516,10 +516,11 @@ callback state. Replacement, clear, and runtime close release the old state only
 after the native registration call has retired every in-flight callback.
 
 Bindings that cannot answer a synchronous callback expose native rule tables. An
-exact rule matches the complete transformed URL, a prefix rule performs a
-literal case-sensitive prefix match, and the first matching rule supplies its
-complete header collection. Unknown flags, null match operands, and requests
-outside the matched URL family pass through without transformed headers.
+exact rule matches the complete transformed URL, a glob rule matches it against
+the pattern language the C API reference defines, and the first matching rule
+supplies its complete header collection. Unknown flags, null match operands, and
+requests outside the matched URL family pass through without transformed
+headers.
 
 Every transformed header is redirect-sensitive. A same-origin redirect, with the
 same scheme, host, and effective port, preserves transformed headers. A redirect
@@ -949,7 +950,7 @@ When the binding routes provider requests through
 
 | ID      | Test                                                                                                                                                                                       |
 | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| BND-156 | A prefix route claims every request URL that starts with its value, and a request URL outside that prefix passes through to native loading.                                                |
+| BND-156 | A glob route claims every request URL its pattern matches, and a request URL the pattern leaves unmatched passes through to native loading.                                                |
 | BND-157 | A route comparing the requested URL claims a request for a configured URI-scheme alias, and a route comparing the resolved URL claims that same request by its tile-server-normalized URL. |
 
 ### Rendering

--- a/include/maplibre_native_c/callback_adapter.h
+++ b/include/maplibre_native_c/callback_adapter.h
@@ -51,15 +51,49 @@ extern "C" {
 /** Rule kind that matches every resource kind. */
 #define MLN_ADAPTER_RESOURCE_KIND_ANY UINT32_MAX
 
+// This block uses line comments because its examples contain URL patterns that
+// a block comment cannot carry.
+
+/// How a rule compares its url against a request URL.
+///
+/// With no flags, a rule compares the complete URL byte for byte.
+/// MLN_ADAPTER_URL_MATCH_GLOB reads the url as a glob pattern instead:
+///
+/// - `*` matches a run of any length that contains no `/`, including an empty
+///   run.
+/// - `**` matches a run of any length, including one that contains `/`.
+/// - `?` matches one character other than `/`.
+/// - `\` matches the next character literally, and a trailing `\` matches
+///   itself.
+///
+/// Every other byte compares literally. A pattern matches the complete URL, so
+/// a pattern that describes a suffix opens with a wildcard. Comparison is
+/// case-sensitive either way, and applies no URL parsing or normalization.
+///
+/// Confining `*` to one path segment is what makes a host pattern hold:
+/// `https://*.example.com/**` matches every subdomain of example.com, and a
+/// request for `https://attacker.example/x.example.com/tile` matches it
+/// nowhere. Use `**` wherever a pattern spans path segments, as in
+/// `https://tiles.example.com/**` for one whole host.
+typedef enum mln_adapter_url_match_flags : uint32_t {
+  MLN_ADAPTER_URL_MATCH_FLAGS_NONE = 0U,
+  MLN_ADAPTER_URL_MATCH_GLOB = 1U << 0U,
+} mln_adapter_url_match_flags;
+
 /**
- * One exact-URL resource rewrite rule.
+ * One resource rewrite rule.
  *
  * The kind field matches mln_resource_kind values, or
- * MLN_ADAPTER_RESOURCE_KIND_ANY for every kind. A null replacement_url leaves
- * the URL unchanged. Both strings are borrowed and must outlive the rule table.
+ * MLN_ADAPTER_RESOURCE_KIND_ANY for every kind. The flags field is a bitwise OR
+ * of mln_adapter_url_match_flags values choosing how url compares against the
+ * request URL. A null url or an unknown flag bit makes the rule match nothing.
+ *
+ * A null replacement_url leaves the URL unchanged. Both strings are borrowed
+ * and must outlive the rule table.
  */
 typedef struct mln_adapter_resource_rewrite_rule {
   uint32_t kind;
+  uint32_t flags;
   const char* url;
   const char* replacement_url;
 } mln_adapter_resource_rewrite_rule;
@@ -75,12 +109,6 @@ typedef struct mln_adapter_resource_rewrite_rules {
   size_t count;
 } mln_adapter_resource_rewrite_rules;
 
-/** How an HTTP header transform rule compares its URL. */
-typedef enum mln_adapter_http_header_route_flags : uint32_t {
-  MLN_ADAPTER_HTTP_HEADER_ROUTE_FLAGS_NONE = 0U,
-  MLN_ADAPTER_HTTP_HEADER_ROUTE_MATCH_PREFIX = 1U << 0U,
-} mln_adapter_http_header_route_flags;
-
 /** One borrowed header supplied by an HTTP header transform rule. */
 typedef struct mln_adapter_http_header {
   const char* name;
@@ -90,11 +118,13 @@ typedef struct mln_adapter_http_header {
 /**
  * One native-owned matching rule for an HTTP header transform.
  *
- * kind is one mln_resource_kind value or MLN_ADAPTER_RESOURCE_KIND_ANY. With
- * no flags, url matches the complete transformed URL. MATCH_PREFIX selects a
- * literal, case-sensitive prefix comparison. Unknown flags and a null url make
- * the rule non-matching. The first matching rule supplies its complete header
- * list. Every pointer is borrowed and must outlive the registration.
+ * kind is one mln_resource_kind value or MLN_ADAPTER_RESOURCE_KIND_ANY. The
+ * flags field is a bitwise OR of mln_adapter_url_match_flags values choosing
+ * how url compares against the complete transformed URL. A null url or an
+ * unknown flag bit makes the rule match nothing.
+ *
+ * The first matching rule supplies its complete header list. Every pointer is
+ * borrowed and must outlive the registration.
  */
 typedef struct mln_adapter_http_header_transform_rule {
   uint32_t kind;
@@ -111,14 +141,21 @@ typedef struct mln_adapter_http_header_transform_rules {
 } mln_adapter_http_header_transform_rules;
 
 /**
- * One exact-URL resource provider rule.
+ * One resource provider rule.
  *
- * A rule matches mln_resource_request.requested_url. A matching request is
- * completed with the rule's response without reaching the host. The response
- * and its buffers are borrowed and must outlive the rule table.
+ * The kind field matches mln_resource_kind values, or
+ * MLN_ADAPTER_RESOURCE_KIND_ANY for every kind. The flags field is a bitwise OR
+ * of mln_adapter_url_match_flags values choosing how requested_url compares
+ * against mln_resource_request.requested_url. A null requested_url or an
+ * unknown flag bit makes the rule match nothing.
+ *
+ * A matching request is completed with the rule's response without reaching the
+ * host. The response and its buffers are borrowed and must outlive the rule
+ * table.
  */
 typedef struct mln_adapter_resource_provider_rule {
   uint32_t kind;
+  uint32_t flags;
   const char* requested_url;
   mln_resource_response response;
 } mln_adapter_resource_provider_rule;
@@ -137,16 +174,15 @@ typedef struct mln_adapter_resource_provider_rules {
 /**
  * How a queued provider route compares its url against a request.
  *
- * MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX compares the url against the start of
- * the request URL instead of the whole request URL.
+ * MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB reads the url as a glob pattern, in the
+ * language mln_adapter_url_match_flags describes.
  * MLN_ADAPTER_RESOURCE_ROUTE_USE_REQUESTED_URL selects
  * mln_resource_request.requested_url as the compared URL instead of
- * mln_resource_request.resolved_url. Setting both matches a requested-URL
- * prefix.
+ * mln_resource_request.resolved_url. Setting both matches a requested-URL glob.
  */
 typedef enum mln_adapter_resource_route_flags : uint32_t {
   MLN_ADAPTER_RESOURCE_ROUTE_FLAGS_NONE = 0U,
-  MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX = 1U << 0U,
+  MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB = 1U << 0U,
   MLN_ADAPTER_RESOURCE_ROUTE_USE_REQUESTED_URL = 1U << 1U,
 } mln_adapter_resource_route_flags;
 
@@ -156,14 +192,12 @@ typedef enum mln_adapter_resource_route_flags : uint32_t {
  * The kind field matches mln_resource_kind values, or
  * MLN_ADAPTER_RESOURCE_KIND_ANY for every kind. The flags field is a bitwise OR
  * of mln_adapter_resource_route_flags values choosing which URL the route
- * compares and whether it compares a prefix; with no flags the route matches
+ * compares and how; with no flags the route matches
  * mln_resource_request.resolved_url exactly.
  *
- * The url field is a literal comparison value. Comparison is case-sensitive and
- * applies no glob expansion, regular expressions, URL parsing, or
- * normalization, so an empty prefix matches every URL. A null url or an unknown
- * flag bit makes the route match nothing. The url pointer is borrowed and must
- * outlive the provider.
+ * The url field is a comparison value, read literally or as a glob pattern
+ * according to flags. A null url or an unknown flag bit makes the route match
+ * nothing. The url pointer is borrowed and must outlive the provider.
  */
 typedef struct mln_adapter_queued_resource_provider_route {
   uint32_t kind;

--- a/src/c_api/callback_adapter.cpp
+++ b/src/c_api/callback_adapter.cpp
@@ -32,11 +32,8 @@
 
 namespace {
 
-using AdapterResourceRewriteRule = mln_adapter_resource_rewrite_rule;
 using AdapterResourceRewriteRules = mln_adapter_resource_rewrite_rules;
-using AdapterHttpHeaderTransformRule = mln_adapter_http_header_transform_rule;
 using AdapterHttpHeaderTransformRules = mln_adapter_http_header_transform_rules;
-using AdapterResourceProviderRule = mln_adapter_resource_provider_rule;
 using AdapterResourceProviderRules = mln_adapter_resource_provider_rules;
 using AdapterQueuedResourceProviderRoute =
   mln_adapter_queued_resource_provider_route;
@@ -81,67 +78,149 @@ auto matches_rule(std::uint32_t rule_kind, std::uint32_t request_kind) -> bool {
          rule_kind == request_kind;
 }
 
-auto string_equals(const char* left, const char* right) -> bool {
-  if (left == nullptr || right == nullptr) {
-    return false;
+// Compares one non-wildcard pattern element against one candidate character,
+// and reports how many pattern characters it spans. Zero reports no match.
+auto literal_span(std::string_view pattern, std::size_t index, char candidate)
+  -> std::size_t {
+  const auto element = pattern[index];
+  if (element == '?') {
+    return candidate == '/' ? 0 : 1;
   }
-  return std::strcmp(left, right) == 0;
+  if (element == '\\' && index + 1 < pattern.size()) {
+    return pattern[index + 1] == candidate ? 2 : 0;
+  }
+  return element == candidate ? 1 : 0;
 }
 
-constexpr auto KnownHttpHeaderRouteFlags =
-  static_cast<std::uint32_t>(MLN_ADAPTER_HTTP_HEADER_ROUTE_MATCH_PREFIX);
+// Matches one glob pattern against a candidate URL, in the language
+// callback_adapter.h documents.
+//
+// Confining '*' to one path segment is what the host patterns rely on, so a
+// wildcard run stops at a '/' unless the pattern spelled '**'. The latest run
+// of each kind stays available as a backtrack point, so an exhausted '*' can
+// yield to an earlier '**'. This costs at most the product of the two lengths.
+// Matching allocates nothing and never recurses, so a host pattern cannot
+// overflow the MapLibre thread this runs on.
+auto glob_matches(std::string_view pattern, std::string_view candidate)
+  -> bool {
+  auto pattern_index = std::size_t{0};
+  auto candidate_index = std::size_t{0};
 
-auto http_header_rule_matches_url(
-  const AdapterHttpHeaderTransformRule& rule, const char* url
-) -> bool {
-  if (
-    rule.url == nullptr || url == nullptr ||
-    (rule.flags & ~KnownHttpHeaderRouteFlags) != 0
-  ) {
-    return false;
+  struct WildcardCheckpoint {
+    std::size_t pattern_index = std::string_view::npos;
+    std::size_t candidate_index = 0;
+  };
+  auto segment_wildcard = WildcardCheckpoint{};
+  auto spanning_wildcard = WildcardCheckpoint{};
+
+  const auto backtrack = [&]() -> bool {
+    if (segment_wildcard.pattern_index != std::string_view::npos) {
+      if (
+        segment_wildcard.candidate_index < candidate.size() &&
+        candidate[segment_wildcard.candidate_index] != '/'
+      ) {
+        ++segment_wildcard.candidate_index;
+        pattern_index = segment_wildcard.pattern_index;
+        candidate_index = segment_wildcard.candidate_index;
+        return true;
+      }
+      segment_wildcard = {};
+    }
+    if (
+      spanning_wildcard.pattern_index == std::string_view::npos ||
+      spanning_wildcard.candidate_index == candidate.size()
+    ) {
+      return false;
+    }
+    ++spanning_wildcard.candidate_index;
+    segment_wildcard = {};
+    pattern_index = spanning_wildcard.pattern_index;
+    candidate_index = spanning_wildcard.candidate_index;
+    return true;
+  };
+
+  while (true) {
+    if (pattern_index < pattern.size() && pattern[pattern_index] == '*') {
+      const auto run_start = pattern_index;
+      while (pattern_index < pattern.size() && pattern[pattern_index] == '*') {
+        ++pattern_index;
+      }
+      const auto checkpoint =
+        WildcardCheckpoint{pattern_index, candidate_index};
+      if (pattern_index - run_start > 1) {
+        spanning_wildcard = checkpoint;
+        segment_wildcard = {};
+      } else {
+        segment_wildcard = checkpoint;
+      }
+      continue;
+    }
+    if (candidate_index < candidate.size()) {
+      const auto span =
+        pattern_index < pattern.size()
+          ? literal_span(pattern, pattern_index, candidate[candidate_index])
+          : 0;
+      if (span != 0) {
+        pattern_index += span;
+        ++candidate_index;
+        continue;
+      }
+    } else if (pattern_index == pattern.size()) {
+      return true;
+    }
+    if (!backtrack()) {
+      return false;
+    }
   }
-  const auto expected = std::string_view{rule.url};
-  const auto candidate = std::string_view{url};
-  if (
-    (rule.flags &
-     static_cast<std::uint32_t>(MLN_ADAPTER_HTTP_HEADER_ROUTE_MATCH_PREFIX)) !=
-    0
-  ) {
-    return candidate.starts_with(expected);
-  }
-  return candidate == expected;
 }
+
+constexpr auto KnownUrlMatchFlags =
+  static_cast<std::uint32_t>(MLN_ADAPTER_URL_MATCH_GLOB);
 
 constexpr auto KnownRouteFlags =
-  static_cast<std::uint32_t>(MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX) |
+  static_cast<std::uint32_t>(MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB) |
   static_cast<std::uint32_t>(MLN_ADAPTER_RESOURCE_ROUTE_USE_REQUESTED_URL);
+
+static_assert(
+  static_cast<std::uint32_t>(MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB) ==
+    static_cast<std::uint32_t>(MLN_ADAPTER_URL_MATCH_GLOB),
+  "a queued provider route selects glob matching with the shared flag bit"
+);
+
+// Compares one rule's url against the candidate URL under the rule's flags. A
+// null url, an absent candidate, or a flag bit outside known_flags describes no
+// URL family this version can compare, so such a rule claims nothing rather
+// than everything.
+auto url_matches(
+  std::uint32_t flags, std::uint32_t known_flags, const char* url,
+  const char* candidate
+) -> bool {
+  if (url == nullptr || candidate == nullptr || (flags & ~known_flags) != 0) {
+    return false;
+  }
+  const auto pattern = std::string_view{url};
+  const auto target = std::string_view{candidate};
+  if ((flags & static_cast<std::uint32_t>(MLN_ADAPTER_URL_MATCH_GLOB)) != 0) {
+    return glob_matches(pattern, target);
+  }
+  return pattern == target;
+}
 
 auto has_flag(std::uint32_t flags, mln_adapter_resource_route_flags flag)
   -> bool {
   return (flags & static_cast<std::uint32_t>(flag)) != 0;
 }
 
-// Compares one route's literal url against the request URL its flags select. A
-// null url or an unknown flag bit describes no URL family this version can
-// compare, so such a route claims nothing rather than everything.
+// Compares one route's url against the request URL its flags select.
 auto route_matches_url(
   const AdapterQueuedResourceProviderRoute& route,
   const mln_resource_request& request
 ) -> bool {
-  if (route.url == nullptr || (route.flags & ~KnownRouteFlags) != 0) {
-    return false;
-  }
   const auto* candidate =
     has_flag(route.flags, MLN_ADAPTER_RESOURCE_ROUTE_USE_REQUESTED_URL)
       ? request.requested_url
       : request.resolved_url;
-  if (candidate == nullptr) {
-    return false;
-  }
-  if (has_flag(route.flags, MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX)) {
-    return std::string_view{candidate}.starts_with(std::string_view{route.url});
-  }
-  return string_equals(candidate, route.url);
+  return url_matches(route.flags, KnownRouteFlags, route.url, candidate);
 }
 
 auto request_matches_route(
@@ -396,7 +475,10 @@ extern "C" MLN_API auto mln_adapter_resource_transform_rewrite_callback(
   const auto& table =
     *static_cast<const AdapterResourceRewriteRules*>(user_data);
   for (const auto& rule : std::span{table.rules, table.count}) {
-    if (matches_rule(rule.kind, kind) && string_equals(rule.url, url)) {
+    if (
+      matches_rule(rule.kind, kind) &&
+      url_matches(rule.flags, KnownUrlMatchFlags, rule.url, url)
+    ) {
       if (rule.replacement_url == nullptr) {
         return MLN_STATUS_OK;
       }
@@ -423,7 +505,8 @@ extern "C" MLN_API auto mln_adapter_http_header_transform_callback(
   }
   for (const auto& rule : std::span{table.rules, table.count}) {
     if (
-      !matches_rule(rule.kind, kind) || !http_header_rule_matches_url(rule, url)
+      !matches_rule(rule.kind, kind) ||
+      !url_matches(rule.flags, KnownUrlMatchFlags, rule.url, url)
     ) {
       continue;
     }
@@ -476,7 +559,10 @@ extern "C" MLN_API auto mln_adapter_resource_provider_rules_callback(
   for (const auto& rule : std::span{table.rules, table.count}) {
     if (
       matches_rule(rule.kind, request->kind) &&
-      string_equals(rule.requested_url, request->requested_url)
+      url_matches(
+        rule.flags, KnownUrlMatchFlags, rule.requested_url,
+        request->requested_url
+      )
     ) {
       static_cast<void>(mln_resource_request_complete(handle, &rule.response));
       mln_resource_request_release(handle);

--- a/src/c_api/tests/callback_adapter_abi.c
+++ b/src/c_api/tests/callback_adapter_abi.c
@@ -1,7 +1,8 @@
 // Raw C ABI coverage for queued provider route matching: route descriptors a
-// binding's own route type cannot express, and a request that carries no
-// requested URL. Which URL each flag combination compares is semantic, so it
-// belongs to the binding suites that register these routes.
+// binding's own route type cannot express, a request that carries no requested
+// URL, and the glob language every binding shares. Which URL each flag
+// combination compares is semantic, so it belongs to the binding suites that
+// register these routes.
 //
 // The adapter decides a route before it reads the handle, so these drive the
 // callback directly with a synthesized request rather than through a loader.
@@ -93,7 +94,7 @@ static void assert_passes_through(
 // This verifies the two route descriptors a binding route type cannot express:
 // a null comparison URL and a flag bit this C API version does not define.
 // Neither names a URL family the adapter can compare, so each matches nothing
-// rather than claiming every request the way an empty prefix does.
+// rather than claiming every request the way `**` does.
 static void queued_provider_routes_reject_raw_invalid_route_descriptors(void) {
   const mln_resource_request request = style_request();
 
@@ -108,7 +109,7 @@ static void queued_provider_routes_reject_raw_invalid_route_descriptors(void) {
   assert_passes_through(
     (mln_adapter_queued_resource_provider_route){
       .kind = MLN_ADAPTER_RESOURCE_KIND_ANY,
-      .flags = MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX,
+      .flags = MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB,
       .url = NULL,
     },
     &request
@@ -116,18 +117,18 @@ static void queued_provider_routes_reject_raw_invalid_route_descriptors(void) {
   assert_passes_through(
     (mln_adapter_queued_resource_provider_route){
       .kind = MLN_ADAPTER_RESOURCE_KIND_ANY,
-      .flags = MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX | (1U << 31U),
-      .url = "",
+      .flags = MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB | (1U << 31U),
+      .url = "**",
     },
     &request
   );
 }
 
 // This verifies a request whose requested URL is absent, which the loader does
-// not produce and a binding cannot synthesize. An empty prefix over the URL
-// that is present still claims the request, while the same prefix over the
-// absent URL matches nothing. A claimed record reports the absent URL as the
-// empty string, so a listener reads it without a null check.
+// not produce and a binding cannot synthesize. A `**` route over the URL that
+// is present still claims the request, while the same route over the absent URL
+// matches nothing. A claimed record reports the absent URL as the empty string,
+// so a listener reads it without a null check.
 static void queued_provider_routes_tolerate_raw_absent_request_urls(void) {
   mln_resource_request request = style_request();
   request.requested_url = NULL;
@@ -135,8 +136,8 @@ static void queued_provider_routes_tolerate_raw_absent_request_urls(void) {
   assert_claims(
     (mln_adapter_queued_resource_provider_route){
       .kind = MLN_ADAPTER_RESOURCE_KIND_ANY,
-      .flags = MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX,
-      .url = "",
+      .flags = MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB,
+      .url = "**",
     },
     &request
   );
@@ -145,11 +146,86 @@ static void queued_provider_routes_tolerate_raw_absent_request_urls(void) {
   assert_passes_through(
     (mln_adapter_queued_resource_provider_route){
       .kind = MLN_ADAPTER_RESOURCE_KIND_ANY,
-      .flags = MLN_ADAPTER_RESOURCE_ROUTE_MATCH_PREFIX |
+      .flags = MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB |
                MLN_ADAPTER_RESOURCE_ROUTE_USE_REQUESTED_URL,
-      .url = "",
+      .url = "**",
     },
     &request
+  );
+}
+
+// Reports whether one glob pattern claims one resolved URL. Every binding
+// shares this matcher, so the language itself is covered here rather than once
+// per binding suite.
+static bool glob_claims(const char* pattern, const char* resolved_url) {
+  mln_resource_request request = style_request();
+  request.resolved_url = resolved_url;
+  return route_decision(
+           (mln_adapter_queued_resource_provider_route){
+             .kind = MLN_ADAPTER_RESOURCE_KIND_ANY,
+             .flags = MLN_ADAPTER_RESOURCE_ROUTE_MATCH_GLOB,
+             .url = pattern,
+           },
+           &request
+         ) == MLN_RESOURCE_PROVIDER_DECISION_HANDLE;
+}
+
+static void glob_routes_confine_a_star_to_one_path_segment(void) {
+  static const char host_pattern[] = "https://*.maplibre.org/**";
+
+  TEST_ASSERT_TRUE(glob_claims(host_pattern, normalized_url));
+  TEST_ASSERT_TRUE(
+    glob_claims(host_pattern, "https://tiles.maplibre.org/1/2/3.pbf")
+  );
+  // A path segment carrying the host name reaches the same rule under a
+  // separator-crossing wildcard, which is what confining `*` prevents.
+  TEST_ASSERT_FALSE(
+    glob_claims(host_pattern, "https://attacker.test/x.maplibre.org/style.json")
+  );
+  // A single `*` spans one segment, and `**` spans the rest of the URL.
+  TEST_ASSERT_TRUE(glob_claims("https://*/style.json", normalized_url));
+  TEST_ASSERT_TRUE(glob_claims("https://*.maplibre.org/*", normalized_url));
+  TEST_ASSERT_FALSE(glob_claims("https://*.maplibre.org/*/*", normalized_url));
+  TEST_ASSERT_TRUE(glob_claims("**", normalized_url));
+  TEST_ASSERT_FALSE(glob_claims("*", normalized_url));
+}
+
+static void glob_routes_anchor_match_wildcards_and_escapes(void) {
+  // A pattern matches the complete URL, so a bare suffix or infix claims
+  // nothing without a leading wildcard.
+  TEST_ASSERT_TRUE(glob_claims("**.json", normalized_url));
+  TEST_ASSERT_FALSE(glob_claims(".json", normalized_url));
+  TEST_ASSERT_FALSE(glob_claims("**.pbf", normalized_url));
+  TEST_ASSERT_TRUE(glob_claims("https://demotiles**", normalized_url));
+
+  // A pattern with no metacharacters compares byte for byte.
+  TEST_ASSERT_TRUE(glob_claims(normalized_url, normalized_url));
+  TEST_ASSERT_FALSE(glob_claims("", normalized_url));
+  TEST_ASSERT_TRUE(glob_claims("", ""));
+
+  // `?` spans one character other than a separator, and `\` makes the next
+  // character literal.
+  TEST_ASSERT_TRUE(
+    glob_claims("?ttps://demotiles.maplibre.org/style.json", normalized_url)
+  );
+  TEST_ASSERT_TRUE(
+    glob_claims("https://demotiles.maplibre.org/style?json", normalized_url)
+  );
+  TEST_ASSERT_FALSE(
+    glob_claims("https://demotiles.maplibre.org/style\\?json", normalized_url)
+  );
+  TEST_ASSERT_FALSE(glob_claims("https:?**", normalized_url));
+  TEST_ASSERT_TRUE(
+    glob_claims("https://star\\*.test/x", "https://star*.test/x")
+  );
+  TEST_ASSERT_FALSE(
+    glob_claims("https://star\\*.test/x", "https://starry.test/x")
+  );
+}
+
+static void glob_routes_backtrack_across_wildcard_runs(void) {
+  TEST_ASSERT_TRUE(
+    glob_claims("https://**/tiles/*", "https://host/tiles/a/b/tiles/x")
   );
 }
 
@@ -169,20 +245,20 @@ static mln_status header_route_status(
   );
 }
 
-static void http_header_routes_match_exact_prefix_kind_and_order(void) {
+static void http_header_routes_match_exact_glob_kind_and_order(void) {
   const mln_adapter_http_header invalid[] = {{.name = "Host", .value = "bad"}};
   const mln_adapter_http_header_transform_rule rules[] = {
     {
       .kind = MLN_RESOURCE_KIND_TILE,
-      .flags = MLN_ADAPTER_HTTP_HEADER_ROUTE_FLAGS_NONE,
+      .flags = MLN_ADAPTER_URL_MATCH_FLAGS_NONE,
       .url = "https://tiles.test/exact",
       .headers = invalid,
       .header_count = 1,
     },
     {
       .kind = MLN_ADAPTER_RESOURCE_KIND_ANY,
-      .flags = MLN_ADAPTER_HTTP_HEADER_ROUTE_MATCH_PREFIX,
-      .url = "https://tiles.test/",
+      .flags = MLN_ADAPTER_URL_MATCH_GLOB,
+      .url = "https://tiles.test/**",
       .headers = NULL,
       .header_count = 0,
     },
@@ -239,6 +315,9 @@ void run_callback_adapter_abi_tests(void) {
   UnitySetTestFile(__FILE__);
   RUN_TEST(queued_provider_routes_reject_raw_invalid_route_descriptors);
   RUN_TEST(queued_provider_routes_tolerate_raw_absent_request_urls);
-  RUN_TEST(http_header_routes_match_exact_prefix_kind_and_order);
+  RUN_TEST(glob_routes_confine_a_star_to_one_path_segment);
+  RUN_TEST(glob_routes_anchor_match_wildcards_and_escapes);
+  RUN_TEST(glob_routes_backtrack_across_wildcard_runs);
+  RUN_TEST(http_header_routes_match_exact_glob_kind_and_order);
   RUN_TEST(http_header_validation_uses_the_native_policy);
 }


### PR DESCRIPTION
Resolves #531 

## Summary

Replace prefix with glob URL matching to callback adapter rules and Dart APIs so hosts can match URL families consistently.

## Test plan

Validated with `mise run test`, `mise run //bindings/dart:test`, and `mise exec -- hk check --check --no-stage`.

## AI assistance

- **Tools:** Codex
- **Context:** Codex helped implement and validate the shared glob matcher, Dart binding updates, documentation, and regression tests.