### PR TITLE
Fix Windows mise SDK installation

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -391,11 +391,13 @@ runs:
     - name: Bootstrap repository
       uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
       with:
-        # mise 2026.8.2 rejects managed system files on Windows ARM64 before
-        # platform filtering applies. Keep CI on the last proven release.
-        version: 2026.8.0
+        version: 2026.8.2
         cache: false
         bootstrap: true
+        # mise 2026.8.2 validates the Unix-only managed-files phase even when
+        # the repository declares no managed files. Skip that unused phase on
+        # Windows until mise handles an empty configuration there.
+        bootstrap_skip: ${{ runner.os == 'Windows' && 'files' || '' }}
 
     # `mise bootstrap` above installs the root config's tools; `--monorepo` adds
     # every `[monorepo].config_roots` entry, which is what the jobs run against.

--- a/.mise/bin/sync-android-packages
+++ b/.mise/bin/sync-android-packages
@@ -67,5 +67,5 @@ echo "Installing Android SDK packages: ${missing[*]}"
 # It also prints a notice pointing at `android sdk`, its replacement, which downloads
 # a further CLI on first use and reports usage metrics by default.
 accepts="$(printf 'y\n%.0s' "${missing[@]}")"
-mise exec "core:java@$java_version" -- \
+mise exec --no-deps "core:java@$java_version" -- \
   "$sdkmanager" --sdk_root="$sdk_root" --install "${missing[@]}" <<<"$accepts"

--- a/.mise/bin/windows/python.cmd
+++ b/.mise/bin/windows/python.cmd
@@ -1,0 +1,9 @@
+@echo off
+rem The emsdk vfox plugin calls python before emsdk installs its bundled copy.
+rem Resolve the project interpreter without relying on install-hook PATH order.
+for /f "delims=" %%i in ('mise where python') do set "MISE_PROJECT_PYTHON=%%i\python.exe"
+if not defined MISE_PROJECT_PYTHON (
+  echo mise could not locate the project Python interpreter. 1>&2
+  exit /b 1
+)
+"%MISE_PROJECT_PYTHON%" %*

--- a/.mise/tasks/ci/check-action-pins
+++ b/.mise/tasks/ci/check-action-pins
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # [MISE] description="Verify GitHub Actions pins match the pins catalog."
-# [MISE] shell="python3"
+# [MISE] shell="python"
 
 import pathlib
 import sys

--- a/.mise/tasks/ci/check-snapshot-scopes
+++ b/.mise/tasks/ci/check-snapshot-scopes
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # [MISE] description="Verify snapshot component scopes classify every tracked path."
-# [MISE] shell="python3"
+# [MISE] shell="python"
 
 import pathlib
 import sys

--- a/.mise/tasks/ci/generate-devcontainer-tools
+++ b/.mise/tasks/ci/generate-devcontainer-tools
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # [MISE] description="Generate the devcontainer's aggregate tool list."
-# [MISE] shell="python3"
+# [MISE] shell="python"
 
 import argparse
 import difflib

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # [MISE] description="Generate the GitHub Actions CI workflow."
-# [MISE] shell="python3"
+# [MISE] shell="python"
 
 import argparse
 import difflib

--- a/.mise/tasks/ci/prepare-native-package-snapshot
+++ b/.mise/tasks/ci/prepare-native-package-snapshot
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # [MISE] description="Prepare native package snapshot release assets."
-# [MISE] shell="python3"
+# [MISE] shell="python"
 
 import hashlib
 import os

--- a/.mise/tasks/ci/snapshot-state
+++ b/.mise/tasks/ci/snapshot-state
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # [MISE] description="Hash snapshot component inputs and track what was published."
-# [MISE] shell="python3"
+# [MISE] shell="python"
 
 """Gate snapshot publishing on the inputs each component actually consumes.
 

--- a/.mise/tasks/kotlin/check-android-api-floor
+++ b/.mise/tasks/kotlin/check-android-api-floor
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # [MISE] description="Verify compiled androidMain bytecode stays on the android-minSdk floor."
-# [MISE] shell="python3"
+# [MISE] shell="python"
 
 """Reject Android platform APIs introduced above the ``android-minSdk`` floor.
 

--- a/.mise/tasks/kotlin/verify-staging
+++ b/.mise/tasks/kotlin/verify-staging
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # [MISE] description="Verify staged Kotlin Maven payloads."
-# [MISE] shell="python3"
+# [MISE] shell="python"
 
 import json
 import pathlib

--- a/.mise/tasks/verify-native-package
+++ b/.mise/tasks/verify-native-package
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # [MISE] description="Reject build-host paths in a packaged native artifact."
-# [MISE] shell="python3"
+# [MISE] shell="python"
 # USAGE arg "<preset>" help="Native CMake preset"
 
 """Check that a packaged shared library only names portable dependencies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,11 @@ interop or the popular MapLibre Android/iOS SDKs.
 
 ```bash
 # Install/refresh system packages, shared tools, and repository hooks.
-# On Linux this uses sudo; --yes accepts package-manager prompts.
+# On Linux this uses sudo; --yes accepts package-manager prompts. Use this on
+# Linux and macOS:
 mise bootstrap --yes
+# On Windows, skip mise's unused Unix-only managed-files phase.
+mise bootstrap --yes --skip files
 
 # Project-specific tools install automatically with namespaced tasks.
 

--- a/docs/src/content/docs/development/overview.md
+++ b/docs/src/content/docs/development/overview.md
@@ -58,6 +58,12 @@ mise trust
 mise bootstrap --yes
 ```
 
+On Windows, skip mise's unused Unix-only managed-files phase:
+
+```powershell
+mise bootstrap --yes --skip files
+```
+
 Language-specific tools are declared by their binding, example, or docs project.
 Mise installs them automatically when a namespaced project task runs, so the
 initial bootstrap stays focused on tools used across the repository. The

--- a/mise.toml
+++ b/mise.toml
@@ -146,7 +146,7 @@ swiftformat = { version = "{{vars.swiftformat_version}}", backend = "github:nick
 #
 # The Android SDK tool installs the command-line tools alone, so the packages the
 # builds need are installed once the SDK is in place.
-android-sdk = { version = "{{vars.android_cmdline_tools_version}}", postinstall = ".mise/bin/sync-android-packages {{vars.java_version}} {{vars.android_ndk_version}} {{vars.android_cmake_version}}" }
+android-sdk = { version = "{{vars.android_cmdline_tools_version}}", postinstall = "bash .mise/bin/sync-android-packages {{vars.java_version}} {{vars.android_ndk_version}} {{vars.android_cmake_version}}" }
 # The vfox plugin runs the current emsdk launcher before emsdk installs its bundled
 # Python. Use the project Python because Apple's version can be older than the
 # launcher's minimum; `depends` installs it before the environment below resolves it.

--- a/mise.windows.toml
+++ b/mise.windows.toml
@@ -6,16 +6,24 @@ shell = '"C:/Program Files/Git/bin/bash.exe" -e -lc'
 [vars]
 host_native_preset = "windows-{{ arch() }}-vulkan"
 
+[tools]
+# Tool post-install commands use cmd.exe instead of the task shell. Name Git
+# Bash directly so Windows does not resolve its WSL launcher.
+android-sdk = { version = "{{vars.android_cmdline_tools_version}}", postinstall = '"C:/Program Files/Git/bin/bash.exe" .mise/bin/sync-android-packages {{vars.java_version}} {{vars.android_ndk_version}} {{vars.android_cmake_version}}' }
+
 [env]
 # Mise tasks use non-interactive Git Bash on Windows. Source VsDevCmd before each
 # task because mise cannot activate Visual Studio's batch environment directly.
 # The script caches the resolved environment so only the first shell pays for it.
 MLN_FFI_WINDOWS_HOST_ARCHITECTURE = "{{ arch() }}"
 BASH_ENV = "{{config_root}}/.mise/bin/windows-msvc-env.sh"
+# Emscripten publishes x64 Windows binaries. Windows ARM64 runs them through
+# emulation, so make emsdk select that supported release architecture.
+EMSDK_ARCH = "x86_64"
 # Git's installer puts its `cmd` directory on `PATH` and leaves out the `bin`
 # directory holding `bash.exe`. File tasks and dprint plugins name `bash`
 # directly, so put the same Git Bash the task shell uses within their reach.
-_.path = ["C:/Program Files/Git/bin"]
+_.path = ["{{config_root}}/.mise/bin/windows", "C:/Program Files/Git/bin"]
 
 [deps.submodules]
 # Dependency providers run through the platform shell rather than


### PR DESCRIPTION
## Summary

Fix Windows SDK and file-task setup by selecting Emscripten's x64 releases on ARM64, resolving the pinned Python during emsdk setup, invoking Git Bash explicitly for Android setup, isolating the nested Java command from workspace dependency preparation, and naming the cross-platform Python executable for mise file tasks.

## Test plan

Forced clean installs of `emsdk@4.0.10` and `android-sdk@22.0`, ran `emcc --version`, verified the Android SDK packages and Python 3.14.4 resolution, ran the snapshot-scope file task directly, and completed the real pre-commit hook with dprint and snapshot-scope checks.

## AI assistance

- **Tools:** Codex
- **Context:** Codex helped diagnose the Windows ARM64 install and file-task failures, implement the mise configuration changes, and run the validation commands; I reviewed the complete diff and test results before publishing.