### PR TITLE
Fix Windows local file loading

### DIFF
--- a/.mise/bin/sync-submodules
+++ b/.mise/bin/sync-submodules
@@ -56,6 +56,7 @@ mlt_vendor_paths=(
 # pointing at maplibre/maplibre-native. See patches/maplibre-native/README.md.
 mln_patches=(
   "$repo_root/patches/maplibre-native/0001-configurable-emdawnwebgpu-suspension.patch"
+  "$repo_root/patches/maplibre-native/0002-windows-local-file-urls.patch"
 )
 
 # A patch counts as applied when it reverses cleanly, which is also what makes

--- a/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandleTest.kt
+++ b/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandleTest.kt
@@ -1,5 +1,6 @@
 package org.maplibre.nativeffi.runtime
 
+import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
@@ -197,6 +198,36 @@ class RuntimeHandleTest {
       } finally {
         map.close()
       }
+    }
+  }
+
+  @Test
+  fun localFileStyleLoadsFromCanonicalEncodedUri() {
+    val tempDirectory = Files.createTempDirectory("maplibre resources ké地図")
+    try {
+      val styleFile =
+        Files.createDirectories(tempDirectory.resolve("style sheets").resolve("スタイル"))
+          .resolve("style.json")
+      Files.writeString(styleFile, STYLE_JSON)
+
+      RuntimeHandle.create(RuntimeOptions()).use { runtime ->
+        val map =
+          MapHandle.create(
+            runtime,
+            MapOptions().apply {
+              width = 64
+              height = 64
+            },
+          )
+        try {
+          map.setStyleUrl(styleFile.toUri().toASCIIString())
+          assertTrue(waitForMapEvent(runtime, map, RuntimeEventType.MAP_STYLE_LOADED))
+        } finally {
+          map.close()
+        }
+      }
+    } finally {
+      tempDirectory.toFile().deleteRecursively()
     }
   }
 

--- a/patches/maplibre-native/0002-windows-local-file-urls.patch
+++ b/patches/maplibre-native/0002-windows-local-file-urls.patch
@@ -1,0 +1,106 @@
+diff --git a/platform/default/src/mbgl/storage/local_file_request.cpp b/platform/default/src/mbgl/storage/local_file_request.cpp
+index 8c6cf43..325e1aa 100644
+--- a/platform/default/src/mbgl/storage/local_file_request.cpp
++++ b/platform/default/src/mbgl/storage/local_file_request.cpp
+@@ -5,6 +5,10 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ 
++#if defined(_WIN32)
++#include <filesystem>
++#endif
++
+ #if defined(_WIN32) && !defined(S_ISDIR)
+ #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+ #endif
+@@ -15,8 +19,14 @@ void requestLocalFile(const std::string& path,
+                       const ActorRef<FileSourceRequest>& req,
+                       const std::optional<std::pair<uint64_t, uint64_t>>& dataRange) {
+     Response response;
++#if defined(_WIN32)
++    const auto nativePath = std::filesystem::u8path(path);
++    struct _stat64 buf;
++    int result = _wstat64(nativePath.c_str(), &buf);
++#else
+     struct stat buf;
+     int result = stat(path.c_str(), &buf);
++#endif
+ 
+     if (result == 0 && (S_IFDIR & buf.st_mode)) {
+         response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
+diff --git a/platform/default/src/mbgl/storage/local_file_source.cpp b/platform/default/src/mbgl/storage/local_file_source.cpp
+index e855e06..26f9c84 100644
+--- a/platform/default/src/mbgl/storage/local_file_source.cpp
++++ b/platform/default/src/mbgl/storage/local_file_source.cpp
+@@ -34,8 +34,16 @@ public:
+         }
+ 
+         // Cut off the protocol and prefix with path.
+-        const auto path = mbgl::util::percentDecode(
++        auto path = mbgl::util::percentDecode(
+             resource.url.substr(std::char_traits<char>::length(util::FILE_PROTOCOL)));
++#if defined(_WIN32)
++        // A canonical Windows file URI is file:///C:/path. Removing file://
++        // leaves /C:/path, but the Windows filesystem APIs expect C:/path.
++        if (path.size() >= 3 && path[0] == '/' && path[2] == ':' &&
++            ((path[1] >= 'A' && path[1] <= 'Z') || (path[1] >= 'a' && path[1] <= 'z'))) {
++            path.erase(0, 1);
++        }
++#endif
+         requestLocalFile(path, req, resource.dataRange);
+     }
+ 
+diff --git a/src/mbgl/util/io.cpp b/src/mbgl/util/io.cpp
+index af44566..e705eea 100644
+--- a/src/mbgl/util/io.cpp
++++ b/src/mbgl/util/io.cpp
+@@ -8,6 +8,10 @@
+ #include <sstream>
+ #include <fstream>
+ 
++#if defined(_WIN32)
++#include <filesystem>
++#endif
++
+ #if defined(__GNUC__) && !defined(WIN32)
+ #define MBGL_FOPEN_MODE_WBE "wbe"
+ #else
+@@ -17,6 +21,14 @@
+ namespace mbgl {
+ namespace util {
+ 
++#if defined(_WIN32)
++namespace {
++std::filesystem::path pathFromUTF8(const std::string& path) {
++    return std::filesystem::u8path(path);
++}
++} // namespace
++#endif
++
+ IOException::IOException(int err, const std::string &msg)
+     : std::runtime_error(msg + ": " + std::strerror(errno)),
+       code(err) {}
+@@ -36,7 +48,11 @@ void write_file(const std::string &filename, const std::string &data) {
+ std::string read_file(const std::string &filename) {
+     MLN_TRACE_FUNC();
+ 
++#if defined(_WIN32)
++    std::ifstream file(pathFromUTF8(filename), std::ios::binary);
++#else
+     std::ifstream file(filename, std::ios::binary);
++#endif
+     if (file.good()) {
+         std::stringstream data;
+         data << file.rdbuf();
+@@ -50,7 +66,11 @@ std::optional<std::string> readFile(const std::string &filename,
+                                     const std::optional<std::pair<uint64_t, uint64_t>> &dataRange) {
+     MLN_TRACE_FUNC();
+ 
++#if defined(_WIN32)
++    std::ifstream file(pathFromUTF8(filename), std::ios::binary);
++#else
+     std::ifstream file(filename, std::ios::binary);
++#endif
+     if (file.good()) {
+         if (dataRange) {
+             size_t size = static_cast<size_t>(dataRange->second - dataRange->first + 1);

--- a/patches/maplibre-native/README.md
+++ b/patches/maplibre-native/README.md
@@ -13,6 +13,11 @@ the browser WebGPU build needs `-sJSPI` instead. See
 `cmake/mln_ffi_emscripten.cmake` for why that matters. Upstream:
 [maplibre-native#4451](https://github.com/maplibre/maplibre-native/pull/4451).
 
+`0002-windows-local-file-urls.patch` removes the URI-only leading slash from
+canonical Windows drive paths and opens UTF-8 filenames through wide filesystem
+APIs. This lets the local file source load percent-encoded `file:///C:/...`
+resources whose paths contain spaces or non-ASCII characters.
+
 Drop a patch once the pin moves to a commit that carries it. Applying is
 idempotent, and the sync restores the files a patch touches before moving the
 submodule, so a pin bump and an edit to a patch both take effect on a worktree


### PR DESCRIPTION
## Description

Fix Windows local file loading by carrying a MapLibre Native patch that normalizes canonical drive URIs and uses wide filesystem paths for percent-decoded UTF-8 filenames.

TODO: send this patch upstream

## Test plan

Built Windows ARM64 Vulkan, ran the C API and Kotlin JVM suites, and ran maplibre-compose's `DesktopPackagedStyleTest` against the packaged local runtime.