### PR TITLE
Clean up first Kotlin release packaging and docs

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -617,7 +617,7 @@ jobs:
     timeout-minutes: 120
     environment:
       name: maven-central
-      url: https://central.sonatype.com/publishing/deployments
+      url: https://central.sonatype.com/artifact/org.maplibre.nativeffi/maplibre-native-ffi/${{ needs.plan.outputs.kotlin_version }}
     permissions:
       actions: read
       contents: read

--- a/.mise/tasks/verify-native-package
+++ b/.mise/tasks/verify-native-package
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# [MISE] description="Reject build-host paths and vendored loaders in a packaged native artifact."
+# [MISE] description="Reject private exports, build-host paths, and vendored loaders in a native package."
 # [MISE] shell="python"
 # USAGE arg "<preset>" help="Native CMake preset"
 
@@ -56,6 +56,7 @@ MACHO_NAME = re.compile(r"^\s*name (?P<name>.+) \(offset \d+\)$")
 MACHO_PATH = re.compile(r"^\s*path (?P<path>.+) \(offset \d+\)$")
 MACHO_COMMAND = re.compile(r"^\s*cmd (?P<command>LC_\w+)$")
 ELF_ENTRY = re.compile(r"^\s*0x[0-9a-f]+\s+\((?P<tag>\w+)\)\s+.*\[(?P<value>[^\]]*)\]")
+PE_EXPORT = re.compile(r"^\s*Name: (?P<name>\S+)$")
 
 # The name a loader goes by, without the `lib` prefix, the version, and the
 # extension: `libGLESv2.so.2`, `libvulkan.1.dylib`, and `@rpath/libEGL.dylib`
@@ -82,6 +83,7 @@ PLATFORM_LOADER_PRESETS = ("android-", "ohos-")
 PACKAGED_LIBRARY_STEM = "maplibre-native-c"
 
 BUILD_HOST_PATH = "names a build-host path"
+PRIVATE_EXPORT = "exports a private symbol"
 LINKED_LOADER = "links a graphics loader"
 VENDORED_LOADER = "carries a library that is not the C API"
 REMEDIES = {
@@ -89,6 +91,10 @@ REMEDIES = {
         "The package only loads on hosts that reproduce the paths above. "
         "Resolve the dependency at runtime, or give it a relocatable install "
         "name and ship it in the package."
+    ),
+    PRIVATE_EXPORT: (
+        "Only the stable C API belongs in the dynamic symbol table. Hide the "
+        "dependency symbol above or add a public mln_* entry point instead."
     ),
     LINKED_LOADER: (
         "The package pulls a graphics loader along wherever it is repackaged, "
@@ -176,6 +182,16 @@ def elf_problems(binary: pathlib.Path, links_loader: bool) -> list[tuple[str, st
     return problems
 
 
+def pe_problems(binary: pathlib.Path) -> list[tuple[str, str]]:
+    """Exports from a Windows library's PE export directory."""
+    exports = (
+        match.group("name")
+        for line in run(["llvm-readobj", "--coff-exports", str(binary)]).splitlines()
+        if (match := PE_EXPORT.match(line))
+    )
+    return [(PRIVATE_EXPORT, name) for name in exports if not name.startswith("mln_")]
+
+
 def image_format(binary: pathlib.Path) -> str | None:
     """The executable format of a file, or None for one that does not load.
 
@@ -204,8 +220,9 @@ def binary_problems(
         return macho_problems(binary, links_loader)
     # Windows PE imports name a DLL without a directory, so there is no
     # build-host path for them to carry, and the one graphics library a WGL
-    # build imports is the system opengl32.dll.
-    return []
+    # build imports is the system opengl32.dll. Its exports still need to stay
+    # within the public C API.
+    return pe_problems(binary)
 
 
 def main() -> int:

--- a/cmake/mln_ffi_maplibre_native.cmake
+++ b/cmake/mln_ffi_maplibre_native.cmake
@@ -55,6 +55,11 @@ function(mln_ffi_add_maplibre_native)
   endif()
 
   include("${MLN_FFI_SOURCE_DIR}/vendor/nunicode.cmake")
+  if(WIN32)
+    # nunicode marks its public functions for DLL export on Windows even when
+    # built as a static library. It is an implementation detail of the C API.
+    target_compile_definitions(mbgl-vendor-nunicode PRIVATE NU_EXPORT=)
+  endif()
   include("${MLN_FFI_SOURCE_DIR}/vendor/sqlite.cmake")
 
   set(MLN_FFI_SOURCE_DIR "${MLN_FFI_SOURCE_DIR}" PARENT_SCOPE)

--- a/docs/src/content/docs/install.mdx
+++ b/docs/src/content/docs/install.mdx
@@ -5,21 +5,156 @@ description: Add a language binding and its native library to a project.
 
 import { Aside } from "@astrojs/starlight/components";
 
-<Aside type="caution" title="Prerelease only">
-  Tagged releases are not yet available. Each channel is a floating snapshot
-  that moves with `main`. Package names, coordinates, and the C ABI can change
-  between snapshots.
+<Aside type="caution" title="Pre-1.0">
+  Kotlin tagged releases are immutable, but the API can change between
+  releases. The native library and bleeding-edge bindings are floating
+  snapshots that move with `main`.
 </Aside>
 
 Choose a render backend first. Use Metal for Apple platforms, OpenGL for
-emulators and virtual machines, and Vulkan for other platforms. Then find your
-language below. Some bindings fetch the native library; the others use
-[Get the native library](#get-the-native-library).
+emulators and virtual machines, and Vulkan for other platforms. Then choose a
+published binding or a bleeding-edge binding below.
 
-## Kotlin
+## Native library
+
+Download `maplibre-native-c-<preset>.tar.gz` for the target from the
+[latest snapshot release](https://github.com/maplibre/maplibre-native-ffi/releases/tag/unstable-native-snapshot)
+and unpack it. The archive root is the install prefix.
+
+A preset is spelled `<platform>-<arch>-<backend>`, as in `macos-arm64-metal` or
+`linux-x64-vulkan`. OpenGL presets name their context provider in place of the
+backend: `wgl` on Windows and `egl` elsewhere.
+
+On Windows, add `<prefix>/bin` to `PATH` or copy `maplibre-native-c.dll` beside
+your executable, because a prefix carries no loader path there. Linux and macOS
+builds record an rpath into the prefix that they built against.
+
+To build a prefix yourself, install [mise](https://mise.jdx.dev/) and prepare
+the toolchain as the
+[development overview](/maplibre-native-ffi/development/overview/) describes:
+
+```bash frame="terminal"
+mise bootstrap
+mise run build macos-arm64-metal  # prefix at build/macos-arm64-metal/install
+```
+
+### Use the C API
+
+Export `PKG_CONFIG_PATH` and build against `maplibre-native-c`:
+
+```bash frame="terminal"
+export PKG_CONFIG_PATH=<prefix>/share/pkgconfig
+cc -std=c23 main.c $(pkg-config --cflags --libs maplibre-native-c) -o main
+```
+
+### Initialize Android
+
+Depend on a Kotlin runtime AAR. It contains the native library for every ABI and
+the platform TLS component that Android HTTPS requests require.
+
+```kotlin title="build.gradle.kts"
+implementation("org.maplibre.nativeffi:maplibre-native-ffi-runtime-vulkan:0.202608.0")
+```
+
+Then call `mln_android_init` once before creating a runtime, passing a `JNIEnv*`
+and an `android.content.Context`. Android HTTPS requests validate against the
+app's trust policy from that point on. Any thread attached to the JVM may make
+the call.
+
+## Published bindings
+
+### Kotlin
+
+Add Maven Central, the binding, and the runtime for your backend. The runtime
+carries the native library for every ABI.
+
+```kotlin title="build.gradle.kts"
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation("org.maplibre.nativeffi:maplibre-native-ffi:0.202608.0")
+  implementation("org.maplibre.nativeffi:maplibre-native-ffi-runtime-vulkan:0.202608.0")
+}
+```
+
+On Android, call `MaplibreAndroid.initialize(context)` before you create a
+runtime. The runtime AAR includes the platform TLS component. A Kotlin app needs
+no additional TLS package.
+
+The other runtimes are `maplibre-native-ffi-runtime-opengl` and
+`maplibre-native-ffi-runtime-metal`.
+
+## Bleeding-edge bindings
+
+These bindings follow `main`. Package names, coordinates, and the C ABI can
+change between snapshots.
+
+### .NET
+
+Add the snapshot feed, then the binding and the runtime for your backend.
+
+```xml title="nuget.config"
+<configuration>
+  <packageSources>
+    <add key="maplibre-snapshots" value="https://maplibre.github.io/maplibre-native-ffi/nuget/index.json" />
+  </packageSources>
+</configuration>
+```
+
+```xml title="MyApp.csproj"
+<ItemGroup>
+  <PackageReference Include="Maplibre.NativeFfi" />
+  <PackageReference Include="Maplibre.NativeFfi.Runtime.Vulkan" />
+</ItemGroup>
+```
+
+The other runtime packages are `Maplibre.NativeFfi.Runtime.OpenGL` and
+`Maplibre.NativeFfi.Runtime.Metal`.
+
+### Dart
+
+Depend on the package from Git. The build hook downloads a native artifact for
+your target when you build.
+
+```yaml title="pubspec.yaml"
+dependencies:
+  maplibre_native_ffi:
+    git:
+      url: https://github.com/maplibre/maplibre-native-ffi
+      path: bindings/dart
+```
+
+The hook chooses the default backend from the target. Name a different one in
+your application's pubspec to override that.
+
+```yaml title="pubspec.yaml"
+hooks:
+  user_defines:
+    maplibre_native_ffi:
+      backend: vulkan
+```
+
+Write an install prefix into `.dart_tool/maplibre_native_install_dir` to use
+your own build instead. A pinned Git revision keeps the Dart code fixed, and the
+hook still resolves the current snapshot for a build that has no artifact
+cached. Point the hook at your own prefix when you need a fixed native library.
+
+### Go
+
+```bash frame="terminal"
+go get github.com/maplibre/maplibre-native-ffi/bindings/go@main
+```
+
+Install the [native library](#native-library), then export `PKG_CONFIG_PATH`
+before you build. cgo reads it.
+
+### Kotlin
 
 Add the Maven snapshot repository, the binding, and the runtime for your
-backend. The runtime carries the native library for every ABI.
+backend. The runtime modules and Android initialization match the published
+binding.
 
 ```kotlin title="build.gradle.kts"
 repositories {
@@ -35,29 +170,7 @@ dependencies {
 }
 ```
 
-On Android, call `MaplibreAndroid.initialize(context)` before you create a
-runtime. The runtime AAR includes the platform TLS component. A Kotlin app needs
-no additional TLS package.
-
-The other runtimes are `maplibre-native-ffi-runtime-opengl` and
-`maplibre-native-ffi-runtime-metal`.
-
-## Rust
-
-Depend on the `maplibre-native-ffi` crate from Git and enable one backend feature.
-The build script downloads the matching native artifact.
-
-```toml title="Cargo.toml"
-[dependencies]
-maplibre-native-ffi = { git = "https://github.com/maplibre/maplibre-native-ffi", features = ["vulkan"] }
-```
-
-The other features are `opengl`, `metal`, and `webgpu`.
-
-Set `MAPLIBRE_NATIVE_C_INSTALL_DIR` to an install prefix to use your own build
-instead.
-
-## Python
+### Python
 
 Depend on the distribution for your backend and resolve it from the snapshot
 index. The wheels contain the native library.
@@ -81,57 +194,22 @@ to this package; all other dependencies continue to resolve from PyPI.
 The other distributions are `maplibre-native-ffi-opengl` and
 `maplibre-native-ffi-metal`.
 
-## .NET
+### Rust
 
-Add the snapshot feed, then the binding and the runtime for your backend.
+Depend on the `maplibre-native-ffi` crate from Git and enable one backend
+feature. The build script downloads the matching native artifact.
 
-```xml title="nuget.config"
-<configuration>
-  <packageSources>
-    <add key="maplibre-snapshots" value="https://maplibre.github.io/maplibre-native-ffi/nuget/index.json" />
-  </packageSources>
-</configuration>
+```toml title="Cargo.toml"
+[dependencies]
+maplibre-native-ffi = { git = "https://github.com/maplibre/maplibre-native-ffi", features = ["vulkan"] }
 ```
 
-```xml title="MyApp.csproj"
-<ItemGroup>
-  <PackageReference Include="Maplibre.NativeFfi" />
-  <PackageReference Include="Maplibre.NativeFfi.Runtime.Vulkan" />
-</ItemGroup>
-```
+The other features are `opengl`, `metal`, and `webgpu`.
 
-The other runtime packages are `Maplibre.NativeFfi.Runtime.OpenGL` and
-`Maplibre.NativeFfi.Runtime.Metal`.
+Set `MAPLIBRE_NATIVE_C_INSTALL_DIR` to an install prefix to use your own build
+instead.
 
-## Dart
-
-Depend on the package from Git. The build hook downloads a native artifact for
-your target when you build.
-
-```yaml title="pubspec.yaml"
-dependencies:
-  maplibre_native_ffi:
-    git:
-      url: https://github.com/maplibre/maplibre-native-ffi
-      path: bindings/dart
-```
-
-The hook chooses the default backend from the target. Name a different one
-in your application's pubspec to override that.
-
-```yaml title="pubspec.yaml"
-hooks:
-  user_defines:
-    maplibre_native_ffi:
-      backend: vulkan
-```
-
-Write an install prefix into `.dart_tool/maplibre_native_install_dir` to use
-your own build instead. A pinned Git revision keeps the Dart code fixed, and the
-hook still resolves the current snapshot for a build that has no artifact
-cached. Point the hook at your own prefix when you need a fixed native library.
-
-## Swift
+### Swift
 
 The package manifest at the repository root defines the Swift package.
 
@@ -147,70 +225,14 @@ the repository name rather than from the manifest, so name it as
 .product(name: "MaplibreNativeFFI", package: "maplibre-native-ffi")
 ```
 
-[Get the native library](#get-the-native-library), then export
-`PKG_CONFIG_PATH` before you build.
+Install the [native library](#native-library), then export `PKG_CONFIG_PATH`
+before you build.
 
-## Go
-
-```bash frame="terminal"
-go get github.com/maplibre/maplibre-native-ffi/bindings/go@main
-```
-
-[Get the native library](#get-the-native-library), then export
-`PKG_CONFIG_PATH` before you build. cgo reads it.
-
-## Zig
+### Zig
 
 ```bash frame="terminal"
 zig fetch --save git+https://github.com/maplibre/maplibre-native-ffi
 ```
 
-[Get the native library](#get-the-native-library), then pass
+Install the [native library](#native-library), then pass
 `-Dnative-install-dir=<prefix>` when you build.
-
-## C
-
-[Get the native library](#get-the-native-library), then export
-`PKG_CONFIG_PATH` and build against `maplibre-native-c`:
-
-```bash frame="terminal"
-export PKG_CONFIG_PATH=<prefix>/share/pkgconfig
-cc -std=c23 main.c $(pkg-config --cflags --libs maplibre-native-c) -o main
-```
-
-## Get the native library
-
-Download `maplibre-native-c-<preset>.tar.gz` for the target from the
-[latest snapshot release](https://github.com/maplibre/maplibre-native-ffi/releases/tag/unstable-native-snapshot)
-and unpack it. The directory you unpack to is the install prefix.
-
-A preset is spelled `<platform>-<arch>-<backend>`, as in `macos-arm64-metal` or
-`linux-x64-vulkan`. OpenGL presets name their context provider in place of the
-backend: `wgl` on Windows and `egl` elsewhere.
-
-On Windows, add `<prefix>/bin` to `PATH` or copy `maplibre-native-c.dll` beside
-your executable, because a prefix carries no loader path there. Linux and macOS
-builds record an rpath into the prefix that they built against.
-
-To build a prefix yourself, install [mise](https://mise.jdx.dev/) and prepare
-the toolchain as the
-[development overview](/maplibre-native-ffi/development/overview/) describes:
-
-```bash frame="terminal"
-mise bootstrap
-mise run build macos-arm64-metal  # prefix at build/macos-arm64-metal/install
-```
-
-### On Android
-
-Depend on the runtime AAR. It contains the native library for every ABI and the
-platform TLS component that Android HTTPS requests require.
-
-```kotlin title="build.gradle.kts"
-implementation("org.maplibre.nativeffi:maplibre-native-ffi-runtime-vulkan:0.1.0-SNAPSHOT")
-```
-
-Then call `mln_android_init` once before creating a runtime, passing a `JNIEnv*`
-and an `android.content.Context`. Android HTTPS requests validate against the
-app's trust policy from that point on. Any thread attached to the JVM may make
-the call.

--- a/docs/src/content/docs/install.mdx
+++ b/docs/src/content/docs/install.mdx
@@ -5,12 +5,6 @@ description: Add a language binding and its native library to a project.
 
 import { Aside } from "@astrojs/starlight/components";
 
-<Aside type="caution" title="Pre-1.0">
-  Kotlin tagged releases are immutable, but the API can change between
-  releases. The native library and bleeding-edge bindings are floating
-  snapshots that move with `main`.
-</Aside>
-
 Choose a render backend first. Use Metal for Apple platforms, OpenGL for
 emulators and virtual machines, and Vulkan for other platforms. Then choose a
 published binding or a bleeding-edge binding below.
@@ -88,8 +82,10 @@ The other runtimes are `maplibre-native-ffi-runtime-opengl` and
 
 ## Bleeding-edge bindings
 
-These bindings follow `main`. Package names, coordinates, and the C ABI can
-change between snapshots.
+<Aside type="caution" title="Prerelease only">
+  Each channel below is a floating snapshot that moves with `main`. Package
+  names, coordinates, and the C ABI can change between snapshots.
+</Aside>
 
 ### .NET
 


### PR DESCRIPTION
## Summary

Hide private nunicode symbols from Windows DLLs, enforce the public PE export surface during packaging, link releases to their Maven Central artifact, and put tagged Kotlin installation ahead of bleeding-edge channels.

## Test plan

Ran `mise run archive-native linux-x64-vulkan` and `pnpm --dir docs run build`, exercised the export verifier against the published Windows DLL, and left all target builds to PR CI.

## AI assistance

- **Tools:** Codex
- **Context:** Used to inspect the published artifacts, trace the leaked exports to nunicode, implement and validate the focused fix, and reorganize the installation page.