### PR TITLE
Give OpenGL surface sessions their exclusive context mode

### DIFF
--- a/bindings/zig/tests/render.zig
+++ b/bindings/zig/tests/render.zig
@@ -2132,7 +2132,10 @@ test "OpenGL surface renders through public bindings" {
     defer testing.allocator.free(pixels);
     @memset(pixels, 0);
     try context.readSurfaceRGBA8(128, 128, pixels);
-    try testing.expect(hasNonZeroByte(pixels));
+    // The style's background color reaches the surface through the clear the
+    // session's exclusive context allows, so a corner away from the circle
+    // layer carries it exactly.
+    try testing.expectEqualSlices(u8, &.{ 0xd8, 0xf1, 0xff, 0xff }, pixels[0..4]);
 
     try testing.expectError(error.Unsupported, session.acquireOpenGLOwnedTextureFrame());
     var readback_buffer: [128 * 128 * 4]u8 = undefined;

--- a/src/render/opengl/context_mode.hpp
+++ b/src/render/opengl/context_mode.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+// The context mode every OpenGL session runs its renderer in, whether it draws
+// into a surface or a texture.
+
+#include <mbgl/gfx/renderer_backend.hpp>
+
+namespace mln::core::opengl {
+
+// A browser session renders into the host's own context, so MapLibre must treat
+// its cached GL state as stale each frame. Every other provider gets a session
+// context of its own inside the host's share group, and nothing else makes that
+// context current, so MapLibre keeps its cached state across frames and clears
+// each frame to the style's background color.
+#if defined(MLN_FFI_OPENGL_PROVIDER_WEBGL)
+constexpr auto session_context_mode = mbgl::gfx::ContextMode::Shared;
+#else
+constexpr auto session_context_mode = mbgl::gfx::ContextMode::Unique;
+#endif
+
+}  // namespace mln::core::opengl

--- a/src/render/opengl/opengl_surface_session.cpp
+++ b/src/render/opengl/opengl_surface_session.cpp
@@ -24,6 +24,7 @@
 
 #include "diagnostics/diagnostics.hpp"
 #include "map/map.hpp"
+#include "render/opengl/context_mode.hpp"
 #if defined(MLN_FFI_OPENGL_PROVIDER_EGL)
 #include "render/opengl/egl_context.hpp"
 #endif
@@ -58,7 +59,7 @@ class OpenGLSurfaceBackend final : public mbgl::gl::RendererBackend,
   OpenGLSurfaceBackend(
     const mln_opengl_surface_descriptor& descriptor, mbgl::Size size
   )
-      : mbgl::gl::RendererBackend(mbgl::gfx::ContextMode::Shared),
+      : mbgl::gl::RendererBackend(mln::core::opengl::session_context_mode),
         mbgl::gfx::Renderable(
           size, std::make_unique<OpenGLSurfaceRenderableResource>(*this)
         ),

--- a/src/render/opengl/opengl_texture_session.cpp
+++ b/src/render/opengl/opengl_texture_session.cpp
@@ -34,6 +34,7 @@
 #include "diagnostics/diagnostics.hpp"
 #include "map/map.hpp"
 #include "maplibre_native_c/base.h"
+#include "render/opengl/context_mode.hpp"
 #if defined(MLN_FFI_OPENGL_PROVIDER_EGL)
 #include "render/opengl/egl_context.hpp"
 #endif
@@ -190,29 +191,20 @@ class OpenGLTextureRenderableResource final
   std::optional<mbgl::gl::Framebuffer> framebuffer_;
 };
 
-// A browser session renders into the host's own context, so MapLibre must treat
-// its cached GL state as stale each frame. Every other provider gets a session
-// context of its own inside the host's share group.
-#if defined(MLN_FFI_OPENGL_PROVIDER_WEBGL)
-constexpr auto session_context_mode = mbgl::gfx::ContextMode::Shared;
-#else
-constexpr auto session_context_mode = mbgl::gfx::ContextMode::Unique;
-#endif
-
 class OpenGLTextureBackend final : public mbgl::gl::RendererBackend,
                                    public mbgl::gfx::HeadlessBackend {
  public:
   OpenGLTextureBackend(
     const mln_opengl_owned_texture_descriptor& descriptor, mbgl::Size size
   )
-      : mbgl::gl::RendererBackend(session_context_mode),
+      : mbgl::gl::RendererBackend(mln::core::opengl::session_context_mode),
         mbgl::gfx::HeadlessBackend(size),
         context_(descriptor.context) {}
 
   OpenGLTextureBackend(
     const mln_opengl_borrowed_texture_descriptor& descriptor, mbgl::Size size
   )
-      : mbgl::gl::RendererBackend(session_context_mode),
+      : mbgl::gl::RendererBackend(mln::core::opengl::session_context_mode),
         mbgl::gfx::HeadlessBackend(size),
         context_(descriptor.context),
         borrowed_texture_(descriptor.texture) {}


### PR DESCRIPTION
## Summary

An OpenGL surface session owns the context it renders through for every provider but WebGL, so it now runs in `ContextMode::Unique` like the texture path already does, sharing one constant between them.

## Test plan

`mise run test linux-x64-egl` and `mise run //bindings/zig:test linux-x64-egl`, whose OpenGL surface render test now asserts the style's background color reaches the surface.

## AI assistance

- **Tools:** Claude Code
- **Context:** Found while scoping #587; the surface path was left on the shared mode when #490 drew the distinction for textures.