### PR TITLE
Give WebGPU sessions their exclusive context mode

### DIFF
--- a/src/render/webgpu/webgpu_texture_session.cpp
+++ b/src/render/webgpu/webgpu_texture_session.cpp
@@ -132,7 +132,7 @@ class WebGPUTextureBackend final : public mbgl::webgpu::RendererBackend,
   WebGPUTextureBackend(
     const mln_webgpu_owned_texture_descriptor& descriptor, mbgl::Size size
   )
-      : mbgl::webgpu::RendererBackend(mbgl::gfx::ContextMode::Shared),
+      : mbgl::webgpu::RendererBackend(mbgl::gfx::ContextMode::Unique),
         mbgl::gfx::HeadlessBackend(size),
         owns_color_texture_(true),
         color_format_(webgpu_owned_color_format) {
@@ -150,7 +150,7 @@ class WebGPUTextureBackend final : public mbgl::webgpu::RendererBackend,
   WebGPUTextureBackend(
     const mln_webgpu_borrowed_texture_descriptor& descriptor, mbgl::Size size
   )
-      : mbgl::webgpu::RendererBackend(mbgl::gfx::ContextMode::Shared),
+      : mbgl::webgpu::RendererBackend(mbgl::gfx::ContextMode::Unique),
         mbgl::gfx::HeadlessBackend(size),
         owns_color_texture_(false),
         texture_(static_cast<WGPUTexture>(descriptor.texture)),
@@ -628,7 +628,7 @@ class WebGPUSurfaceBackend final : public mbgl::webgpu::RendererBackend,
   WebGPUSurfaceBackend(
     const mln_webgpu_surface_descriptor& descriptor, mbgl::Size size
   )
-      : mbgl::webgpu::RendererBackend(mbgl::gfx::ContextMode::Shared),
+      : mbgl::webgpu::RendererBackend(mbgl::gfx::ContextMode::Unique),
         mbgl::gfx::Renderable(
           size, std::make_unique<RenderableResource>(*this)
         ),


### PR DESCRIPTION
## Summary

WebGPU's owned texture, borrowed texture, and surface sessions now run in `ContextMode::Unique` like every other backend, since a `WGPUDevice` carries no thread-current state a host could disturb.

## Test plan

`mise -E emscripten run test emscripten-wasm32-webgpu` and `mise -E emscripten run //bindings/rust:test emscripten-wasm32-webgpu` pass in headless Chromium, including the borrowed-texture test that reads the style's background color back out of the host's texture.

## AI assistance

- **Tools:** Claude Code
- **Context:** Found while scoping #587 alongside the OpenGL surface change in #589.