### PR TITLE
Publish Linux ARM64 Kotlin/Native runtimes

### DIFF
--- a/.github/workflows/_kotlin-maven.yml
+++ b/.github/workflows/_kotlin-maven.yml
@@ -64,14 +64,14 @@ jobs:
           run-id: ${{ inputs.run_id }}
           pattern: ${{ matrix.native_pattern }}-${{ env.PACKAGE_SHA }}
           path: build/packages/native/maven-input
-      # The Linux partition also publishes the linuxX64 KLIBs, which embed the
+      # The Linux partition also publishes the Linux KLIBs, which embed the
       # Linux static archives rather than the Android ones.
       - if: ${{ matrix.partition == 'linux' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
-          pattern: native-package-linux-x64-*-${{ env.PACKAGE_SHA }}
+          pattern: native-package-linux-*-*-${{ env.PACKAGE_SHA }}
           path: build/packages/native/maven-input
       - run: >-
           mise run //:kotlin:publish stage

--- a/.mise/tasks/kotlin/publish
+++ b/.mise/tasks/kotlin/publish
@@ -39,6 +39,8 @@ prepare_native_inputs() {
         android-arm64-vulkan
         android-x64-egl
         android-x64-vulkan
+        linux-arm64-egl
+        linux-arm64-vulkan
         linux-x64-egl
         linux-x64-vulkan
       )
@@ -125,6 +127,14 @@ publish_linux_leaves() {
     "$@"
 
   publish_tasks \
+    :bindings:kotlin \
+    "$repository" \
+    LinuxArm64 -- \
+    "$@" \
+    -Pkotlin.native.enableKlibsCrossCompilation=true \
+    -PmaplibreNativeCInstallDir="$install_root/linux-arm64-egl"
+
+  publish_tasks \
     :bindings:kotlin:runtimes:opengl \
     "$repository" \
     LinuxX64 -- \
@@ -132,11 +142,32 @@ publish_linux_leaves() {
     -Pmaplibre.runtime.opengl.linuxX64.installDir="$install_root/linux-x64-egl"
 
   publish_tasks \
+    :bindings:kotlin:runtimes:opengl \
+    "$repository" \
+    LinuxArm64 -- \
+    "$@" \
+    -Pkotlin.native.enableKlibsCrossCompilation=true \
+    -Pmaplibre.runtime.opengl.linuxArm64.installDir="$install_root/linux-arm64-egl"
+
+  publish_tasks \
     :bindings:kotlin:runtimes:vulkan \
     "$repository" \
     LinuxX64 -- \
     "$@" \
     -Pmaplibre.runtime.vulkan.linuxX64.installDir="$install_root/linux-x64-vulkan"
+
+  publish_tasks \
+    :bindings:kotlin:runtimes:vulkan \
+    "$repository" \
+    LinuxArm64 -- \
+    "$@" \
+    -Pkotlin.native.enableKlibsCrossCompilation=true \
+    -Pmaplibre.runtime.vulkan.linuxArm64.installDir="$install_root/linux-arm64-vulkan"
+
+  ./gradlew \
+    -Pkotlin.native.enableKlibsCrossCompilation=true \
+    -PmaplibreNativeCInstallDir="$install_root/linux-arm64-egl" \
+    :bindings:kotlin:linkDebugTestLinuxArm64
 }
 
 publish_apple_leaves() {

--- a/.mise/tasks/kotlin/verify-staging
+++ b/.mise/tasks/kotlin/verify-staging
@@ -26,6 +26,7 @@ API_BEARING_MODULES = {
     "maplibre-native-ffi-iosarm64",
     "maplibre-native-ffi-iossimulatorarm64",
     "maplibre-native-ffi-jvm",
+    "maplibre-native-ffi-linuxarm64",
     "maplibre-native-ffi-linuxx64",
     "maplibre-native-ffi-macosarm64",
 }
@@ -36,17 +37,20 @@ ROOT_TARGET_MODULES = {
         "iosArm64": "maplibre-native-ffi-iosarm64",
         "iosSimulatorArm64": "maplibre-native-ffi-iossimulatorarm64",
         "jvm": "maplibre-native-ffi-jvm",
+        "linuxArm64": "maplibre-native-ffi-linuxarm64",
         "linuxX64": "maplibre-native-ffi-linuxx64",
         "macosArm64": "maplibre-native-ffi-macosarm64",
     },
     "maplibre-native-ffi-runtime-opengl": {
         "android": "maplibre-native-ffi-runtime-opengl-android",
         "jvm": "maplibre-native-ffi-runtime-opengl-jvm",
+        "linuxArm64": "maplibre-native-ffi-runtime-opengl-linuxarm64",
         "linuxX64": "maplibre-native-ffi-runtime-opengl-linuxx64",
     },
     "maplibre-native-ffi-runtime-vulkan": {
         "android": "maplibre-native-ffi-runtime-vulkan-android",
         "jvm": "maplibre-native-ffi-runtime-vulkan-jvm",
+        "linuxArm64": "maplibre-native-ffi-runtime-vulkan-linuxarm64",
         "linuxX64": "maplibre-native-ffi-runtime-vulkan-linuxx64",
     },
     "maplibre-native-ffi-runtime-metal": {
@@ -405,7 +409,9 @@ def verify_jvm(root: pathlib.Path) -> None:
 
 def verify_native(root: pathlib.Path) -> None:
     modules = {
+        "maplibre-native-ffi-runtime-opengl-linuxarm64",
         "maplibre-native-ffi-runtime-opengl-linuxx64",
+        "maplibre-native-ffi-runtime-vulkan-linuxarm64",
         "maplibre-native-ffi-runtime-vulkan-linuxx64",
         "maplibre-native-ffi-runtime-metal-macosarm64",
         "maplibre-native-ffi-runtime-metal-iosarm64",
@@ -427,6 +433,10 @@ def verify_native(root: pathlib.Path) -> None:
                 for name in names
             ):
                 raise SystemExit(f"{interop} does not embed libmaplibre-native-c.a")
+            if "-linux" in module and not any(
+                name.endswith("/included/libmln_ffi_platform.a") for name in names
+            ):
+                raise SystemExit(f"{interop} does not embed libmln_ffi_platform.a")
             for license_name in COMMON_NATIVE_LICENSES:
                 expected = f"resources/licenses/maplibre-native-c/{license_name}"
                 if expected not in names:

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -39,6 +39,7 @@ val mavenArtifact = "maplibre-native-ffi"
 kotlin {
   iosArm64()
   iosSimulatorArm64()
+  linuxArm64()
   linuxX64()
   macosArm64()
 
@@ -130,6 +131,7 @@ canonicalizeKmpRootMetadata(
       "iosArm64" to "$mavenArtifact-iosarm64",
       "iosSimulatorArm64" to "$mavenArtifact-iossimulatorarm64",
       "jvm" to "$mavenArtifact-jvm",
+      "linuxArm64" to "$mavenArtifact-linuxarm64",
       "linuxX64" to "$mavenArtifact-linuxx64",
       "macosArm64" to "$mavenArtifact-macosarm64",
     ),

--- a/bindings/kotlin/mise.toml
+++ b/bindings/kotlin/mise.toml
@@ -41,14 +41,25 @@ runtime_backend=
 case "$usage_preset" in
   linux-x64-egl) kotlin_target=linuxX64; runtime_backend=opengl ;;
   linux-x64-vulkan) kotlin_target=linuxX64; runtime_backend=vulkan ;;
+  linux-arm64-egl) kotlin_target=linuxArm64; runtime_backend=opengl ;;
+  linux-arm64-vulkan) kotlin_target=linuxArm64; runtime_backend=vulkan ;;
   macos-arm64-*) kotlin_target=macosArm64 ;;
-  linux-arm64-*|windows-*) kotlin_target= ;;
+  windows-*) kotlin_target= ;;
   *)
     echo "Unsupported Kotlin build preset: $usage_preset" >&2
     exit 2
     ;;
 esac
 gradle_args=(-PmaplibreNativeCInstallDir="build/$usage_preset/install")
+# Kotlin/Native has no Linux arm64 host toolchain, so this target only builds
+# through KLIB cross-compilation from a Linux x64 host.
+if [[ "$kotlin_target" == "linuxArm64" ]]; then
+  if [[ "$(uname -s)" != Linux || "$(uname -m)" != x86_64 ]]; then
+    echo "Linux ARM64 Kotlin/Native KLIBs cross-compile from a Linux x64 host only." >&2
+    exit 2
+  fi
+  gradle_args+=(-Pkotlin.native.enableKlibsCrossCompilation=true)
+fi
 tasks=(:bindings:kotlin:jvmJar)
 if [[ -n "$kotlin_target" ]]; then
   tasks+=(":bindings:kotlin:${kotlin_target}Klib")

--- a/bindings/kotlin/runtimes/opengl/build.gradle.kts
+++ b/bindings/kotlin/runtimes/opengl/build.gradle.kts
@@ -20,6 +20,7 @@ val packagedAndroidRuntimeLibs =
 kotlin {
   jvm { compilerOptions { jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.release.get())) } }
 
+  linuxArm64()
   linuxX64()
 
   android {

--- a/bindings/kotlin/runtimes/vulkan/build.gradle.kts
+++ b/bindings/kotlin/runtimes/vulkan/build.gradle.kts
@@ -20,6 +20,7 @@ val packagedAndroidRuntimeLibs =
 kotlin {
   jvm { compilerOptions { jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.release.get())) } }
 
+  linuxArm64()
   linuxX64()
 
   android {

--- a/ci/kotlin_maven_modules.json
+++ b/ci/kotlin_maven_modules.json
@@ -4,6 +4,7 @@
   "maplibre-native-ffi-iosarm64",
   "maplibre-native-ffi-iossimulatorarm64",
   "maplibre-native-ffi-jvm",
+  "maplibre-native-ffi-linuxarm64",
   "maplibre-native-ffi-linuxx64",
   "maplibre-native-ffi-macosarm64",
   "maplibre-native-ffi-runtime-metal",
@@ -14,9 +15,11 @@
   "maplibre-native-ffi-runtime-opengl",
   "maplibre-native-ffi-runtime-opengl-android",
   "maplibre-native-ffi-runtime-opengl-jvm",
+  "maplibre-native-ffi-runtime-opengl-linuxarm64",
   "maplibre-native-ffi-runtime-opengl-linuxx64",
   "maplibre-native-ffi-runtime-vulkan",
   "maplibre-native-ffi-runtime-vulkan-android",
   "maplibre-native-ffi-runtime-vulkan-jvm",
+  "maplibre-native-ffi-runtime-vulkan-linuxarm64",
   "maplibre-native-ffi-runtime-vulkan-linuxx64"
 ]

--- a/docs/src/content/docs/development/kotlin-publishing.md
+++ b/docs/src/content/docs/development/kotlin-publishing.md
@@ -74,11 +74,12 @@ link requirements for that target and backend. The final application links the
 archive without acquiring a separate MapLibre Native FFI shared library or
 framework.
 
-The native runtime publications are OpenGL and Vulkan for Linux x64, plus Metal
-for macOS arm64, iOS arm64, and the iOS arm64 simulator. Each published
-Kotlin/Native target has a matching runtime variant. Linux arm64 is absent
-because Kotlin/Native has no arm64 Linux host, so that target would have to be
-cross-compiled.
+The native runtime publications are OpenGL and Vulkan for Linux x64 and arm64,
+plus Metal for macOS arm64, iOS arm64, and the iOS arm64 simulator. Each
+published Kotlin/Native target has a matching runtime variant. A Linux x64 host
+cross-compiles the Linux arm64 publications because Kotlin/Native does not run
+on Linux arm64 hosts. Publication compiles and links the arm64 test binary
+without executing it.
 
 The Kotlin/Native Linux toolchain is the tightest consumer of the Linux archive.
 Its sysroot supplies glibc 2.19 and GCC 8.3, and it statically links its own
@@ -166,10 +167,10 @@ Explicit native-library path configuration remains available as an override.
 ## Snapshot publication
 
 Snapshot versions end in `-SNAPSHOT` and publish from the exact commit that
-passed the main CI workflow. A Linux x64 runner builds the Android publications,
-reusing the matrix's CMake install archives to build only the JNI bridge and
-final AARs, while macOS runners build the JVM, macOS, and iOS publications. Each
-consumes native build artifacts produced by the platform and backend CI matrix.
+passed the main CI workflow. A Linux x64 runner builds the Android and Linux
+publications, cross-compiling and linking the Linux arm64 Kotlin suite. A macOS
+runner builds the JVM, macOS, and iOS publications. Each consumes native build
+artifacts produced by the platform and backend CI matrix.
 
 A daily schedule drives publication rather than each push to `main`: the Publish
 snapshots workflow picks the latest successful CI run on `main` and publishes

--- a/gradle/kotlin-runtime.gradle.kts
+++ b/gradle/kotlin-runtime.gradle.kts
@@ -55,19 +55,23 @@ fun nativeTargets(
   targetFamily: MaplibreRuntimeTargetFamily,
 ): Map<String, NativeTargetConfiguration> =
   when (targetFamily) {
-    // Linux arm64 is absent because Kotlin/Native has no arm64 Linux host, so
-    // that target would have to be cross-compiled from x64.
     MaplibreRuntimeTargetFamily.LINUX -> {
       require(backend != MaplibreRuntimeBackend.METAL) {
         "Metal does not support the Linux runtime target family"
       }
       mapOf(
+        "linuxArm64" to
+          NativeTargetConfiguration(
+            "linux-${backend.id}.def",
+            "linux-arm64",
+            listOf("libmaplibre-native-c.a", "libmln_ffi_platform.a"),
+          ),
         "linuxX64" to
           NativeTargetConfiguration(
             "linux-${backend.id}.def",
             "linux-x64",
             listOf("libmaplibre-native-c.a", "libmln_ffi_platform.a"),
-          )
+          ),
       )
     }
     MaplibreRuntimeTargetFamily.APPLE -> {
@@ -431,6 +435,7 @@ canonicalizeKmpRootMetadata(
         mapOf(
           "android" to "$mavenArtifact-android",
           "jvm" to "$mavenArtifact-jvm",
+          "linuxArm64" to "$mavenArtifact-linuxarm64",
           "linuxX64" to "$mavenArtifact-linuxx64",
         )
       MaplibreRuntimeTargetFamily.APPLE ->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Publish Linux ARM64 Kotlin/Native binding and OpenGL/Vulkan runtime variants by cross-compiling their KLIBs on the Linux x64 Maven staging host, rebased onto main after the macOS runtime publications, and wire `//bindings/kotlin:build` for linux-arm64 presets with KLIB cross-compilation.

## Test plan

Installed CI `linux-arm64-egl`/`linux-arm64-vulkan` packages and cross-compiled the binding plus OpenGL/Vulkan `linuxArm64` KLIBs on Linux x64; merge conflicts with #593 resolved and the Codex `build` wiring addressed.

## AI assistance

- **Tools:** Codex, Cursor
- **Context:** Continues #594 after merge conflicts with #593; Codex flagged the missing linux-arm64 `build` task wiring, which this branch addresses.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55fe6797-32cd-4636-8a02-df945f8beaaa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55fe6797-32cd-4636-8a02-df945f8beaaa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

