### PR TITLE
Fix Kotlin snapshot root inputs

### DIFF
--- a/.mise/tasks/kotlin/publish
+++ b/.mise/tasks/kotlin/publish
@@ -228,9 +228,13 @@ publish_apple_roots() {
   local repository="$1"
   shift
   local opengl=(
+    -Pmaplibre.runtime.opengl.linuxArm64.installDir="$install_root/linux-arm64-egl"
+    -Pmaplibre.runtime.opengl.linuxX64.installDir="$install_root/linux-x64-egl"
     -Pmaplibre.runtime.opengl.macosArm64.installDir="$install_root/macos-arm64-egl"
   )
   local vulkan=(
+    -Pmaplibre.runtime.vulkan.linuxArm64.installDir="$install_root/linux-arm64-vulkan"
+    -Pmaplibre.runtime.vulkan.linuxX64.installDir="$install_root/linux-x64-vulkan"
     -Pmaplibre.runtime.vulkan.macosArm64.installDir="$install_root/macos-arm64-vulkan"
   )
   local metal=(


### PR DESCRIPTION
## Summary

Pass the Linux runtime install directories to the Apple Kotlin root publications so KMP cinterop commonization uses the packaged native inputs.

## Test plan

Run `mise run //:kotlin:publish stage apple 0.1.0-SNAPSHOT`, `HK_FIX=0 mise exec -- hk check --no-stage .mise/tasks/kotlin/publish`, `bash -n .mise/tasks/kotlin/publish`, and `git diff --check`.