### PR TITLE
Fix clangd compilation database sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,9 @@ Native targets and render backends are defined in `CMakePresets.json`. Gradle
 selects the Android presets when building platform packages; OpenHarmony and
 host workflows use the presets directly.
 
-Clangd uses the compilation database from the last preset built through
-`mise run build`; rebuild the matching preset before trusting target-specific
-diagnostics.
+Clangd uses the compilation database selected by the last
+`mise run build <preset>` invocation; select the matching preset before trusting
+target-specific diagnostics.
 
 The Android, Emscripten, and OpenHarmony SDKs are opt-in, each behind the mise
 configuration environment named after its presets. A build for one of those

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,10 @@ Native targets and render backends are defined in `CMakePresets.json`. Gradle
 selects the Android presets when building platform packages; OpenHarmony and
 host workflows use the presets directly.
 
+Clangd uses the compilation database from the last preset built through
+`mise run build`; rebuild the matching preset before trusting target-specific
+diagnostics.
+
 The Android, Emscripten, and OpenHarmony SDKs are opt-in, each behind the mise
 configuration environment named after its presets. A build for one of those
 targets reads `ANDROID_HOME`, `EMSDK`, or `OHOS_SDK_NATIVE` from the

--- a/mise.toml
+++ b/mise.toml
@@ -211,6 +211,14 @@ depends = [{ task = ":build", args = ["{{usage.preset}}"] }]
 [tasks.build]
 description = "Configure, build, and install a native CMake preset."
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
+run = [
+  { task = "//:build-preset", args = ["{{usage.preset}}"] },
+  { task = "//:select-clangd-preset", args = ["{{usage.preset}}"] },
+]
+
+[tasks.build-preset]
+hide = true
+usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 sources = [
   ".mise/bin/sync-rustls-platform-verifier",
   "CMakeLists.txt",
@@ -237,17 +245,21 @@ outputs = { auto = true }
 run = [
   { task = "//:check-cross-sdk", args = ["{{usage.preset}}"] },
   '.mise/bin/with-sccache-basedirs cmake --workflow --preset "$usage_preset"',
-  '''
-  compile_commands_dir="$MISE_MONOREPO_ROOT/build/clangd"
-  compile_commands="$compile_commands_dir/compile_commands.json"
-  compile_commands_tmp="$compile_commands.tmp"
-  cmake -E make_directory "$compile_commands_dir"
-  cmake -E copy "$MISE_MONOREPO_ROOT/build/$usage_preset/compile_commands.json" "$compile_commands_tmp"
-  cmake -E rm -f "$compile_commands"
-  cmake -E rename "$compile_commands_tmp" "$compile_commands"
-  ''',
   'cmake --install "$MISE_MONOREPO_ROOT/build/$usage_preset" --component loader',
 ]
+
+[tasks.select-clangd-preset]
+hide = true
+usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
+run = '''
+compile_commands_dir="$MISE_MONOREPO_ROOT/build/clangd"
+compile_commands="$compile_commands_dir/compile_commands.json"
+cmake -E make_directory "$compile_commands_dir"
+compile_commands_tmp="$(mktemp "$compile_commands.XXXXXX")"
+trap 'rm -f "$compile_commands_tmp"' EXIT
+cmake -E copy "$MISE_MONOREPO_ROOT/build/$usage_preset/compile_commands.json" "$compile_commands_tmp"
+mv -f "$compile_commands_tmp" "$compile_commands"
+'''
 
 [tasks.check-cross-sdk]
 description = "Verify the SDK a cross-compilation preset builds against is available."

--- a/mise.toml
+++ b/mise.toml
@@ -237,6 +237,15 @@ outputs = { auto = true }
 run = [
   { task = "//:check-cross-sdk", args = ["{{usage.preset}}"] },
   '.mise/bin/with-sccache-basedirs cmake --workflow --preset "$usage_preset"',
+  '''
+  compile_commands_dir="$MISE_MONOREPO_ROOT/build/clangd"
+  compile_commands="$compile_commands_dir/compile_commands.json"
+  compile_commands_tmp="$compile_commands.tmp"
+  cmake -E make_directory "$compile_commands_dir"
+  cmake -E copy "$MISE_MONOREPO_ROOT/build/$usage_preset/compile_commands.json" "$compile_commands_tmp"
+  cmake -E rm -f "$compile_commands"
+  cmake -E rename "$compile_commands_tmp" "$compile_commands"
+  ''',
   'cmake --install "$MISE_MONOREPO_ROOT/build/$usage_preset" --component loader',
 ]
 


### PR DESCRIPTION
## Summary

Restore synchronization of the selected CMake preset's compilation database for clangd and document the last-preset behavior.

## Test plan

Ran `mise run build`, clangd diagnostics and definition queries, and `hk fix` on the changed files.

## AI assistance

- **Tools:** OpenAI Codex (GPT-5.6)
- **Context:** Used to inspect the clangd setup and history, implement compilation-database synchronization, update `AGENTS.md`, and run verification.