### PR TITLE
Wake render sessions for queued worker results

### DIFF
--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -884,17 +884,17 @@ auto register_render_session(std::shared_ptr<mln_render_session_object> session)
 }
 
 void RenderSessionScheduler::schedule(std::function<void()>&& task) {
-  auto wake = std::function<void()>{};
+  auto request_repaint = std::function<void()>{};
   {
     const auto lock = std::scoped_lock{mutex_};
     const auto was_empty = queue_.empty();
     queue_.push_back(std::move(task));
     if (was_empty && !draining_) {
-      wake = wake_;
+      request_repaint = repaint_request_;
     }
   }
-  if (wake) {
-    wake();
+  if (request_repaint) {
+    request_repaint();
   }
 }
 
@@ -934,18 +934,18 @@ auto RenderSessionScheduler::drain() -> void {
 }
 
 RenderSessionScheduler::DrainGuard::~DrainGuard() {
-  auto wake = std::function<void()>{};
+  auto request_repaint = std::function<void()>{};
   {
     const auto lock = std::scoped_lock{scheduler_.mutex_};
     if (scheduler_.draining_) {
       scheduler_.draining_ = false;
       if (!scheduler_.queue_.empty()) {
-        wake = scheduler_.wake_;
+        request_repaint = scheduler_.repaint_request_;
       }
     }
   }
-  if (wake) {
-    wake();
+  if (request_repaint) {
+    request_repaint();
   }
 }
 
@@ -955,9 +955,11 @@ auto RenderSessionScheduler::discard() -> void {
   batch.swap(queue_);
 }
 
-auto RenderSessionScheduler::set_wake(std::function<void()> wake) -> void {
+auto RenderSessionScheduler::set_repaint_request(
+  std::function<void()> repaint_request
+) -> void {
   const auto lock = std::scoped_lock{mutex_};
-  wake_ = std::move(wake);
+  repaint_request_ = std::move(repaint_request);
 }
 
 // Only the attaching thread destroys a session, so the borrowed object stays
@@ -1023,10 +1025,10 @@ auto attach_render_session(
   if (attach_status != MLN_STATUS_OK) {
     return attach_status;
   }
-  session->scheduler.set_wake([map]() {
-    static_cast<void>(map_post_trigger_repaint(map));
-  });
   try {
+    session->scheduler.set_repaint_request([map]() {
+      static_cast<void>(map_post_trigger_repaint(map));
+    });
     // Set before priming: renderer_backend() dispatches on kind.
     session->kind = kind;
     // Create the backend's graphics context on the thread that will drive the
@@ -1042,7 +1044,7 @@ auto attach_render_session(
     const auto size_status =
       map_post_set_size(map, session->width, session->height);
     if (size_status != MLN_STATUS_OK) {
-      session->scheduler.set_wake({});
+      session->scheduler.set_repaint_request({});
       static_cast<void>(map_detach_render_target_session(map, handle));
       return size_status;
     }
@@ -1050,7 +1052,7 @@ auto attach_render_session(
 
     *out_session = register_render_session(std::move(session));
   } catch (...) {
-    session->scheduler.set_wake({});
+    session->scheduler.set_repaint_request({});
     static_cast<void>(map_detach_render_target_session(map, handle));
     throw;
   }
@@ -1372,7 +1374,7 @@ auto render_session_detach(mln_render_session session) -> mln_status {
     return MLN_STATUS_INVALID_STATE;
   }
 
-  live->scheduler.set_wake({});
+  live->scheduler.set_repaint_request({});
 
   // Tear the renderer down before releasing the map's slot. The renderer holds
   // the map's forwarding observer, which the map's frontend owns; releasing the

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -884,8 +884,18 @@ auto register_render_session(std::shared_ptr<mln_render_session_object> session)
 }
 
 void RenderSessionScheduler::schedule(std::function<void()>&& task) {
-  const auto lock = std::scoped_lock{mutex_};
-  queue_.push_back(std::move(task));
+  auto wake = std::function<void()>{};
+  {
+    const auto lock = std::scoped_lock{mutex_};
+    const auto was_empty = queue_.empty();
+    queue_.push_back(std::move(task));
+    if (was_empty && !draining_) {
+      wake = wake_;
+    }
+  }
+  if (wake) {
+    wake();
+  }
 }
 
 void RenderSessionScheduler::schedule(
@@ -909,6 +919,7 @@ auto RenderSessionScheduler::drain() -> void {
     {
       const auto lock = std::scoped_lock{mutex_};
       if (queue_.empty()) {
+        draining_ = false;
         return;
       }
       batch.swap(queue_);
@@ -923,14 +934,30 @@ auto RenderSessionScheduler::drain() -> void {
 }
 
 RenderSessionScheduler::DrainGuard::~DrainGuard() {
-  const auto lock = std::scoped_lock{scheduler_.mutex_};
-  scheduler_.draining_ = false;
+  auto wake = std::function<void()>{};
+  {
+    const auto lock = std::scoped_lock{scheduler_.mutex_};
+    if (scheduler_.draining_) {
+      scheduler_.draining_ = false;
+      if (!scheduler_.queue_.empty()) {
+        wake = scheduler_.wake_;
+      }
+    }
+  }
+  if (wake) {
+    wake();
+  }
 }
 
 auto RenderSessionScheduler::discard() -> void {
   auto batch = std::vector<std::function<void()>>{};
   const auto lock = std::scoped_lock{mutex_};
   batch.swap(queue_);
+}
+
+auto RenderSessionScheduler::set_wake(std::function<void()> wake) -> void {
+  const auto lock = std::scoped_lock{mutex_};
+  wake_ = std::move(wake);
 }
 
 // Only the attaching thread destroys a session, so the borrowed object stays
@@ -996,6 +1023,9 @@ auto attach_render_session(
   if (attach_status != MLN_STATUS_OK) {
     return attach_status;
   }
+  session->scheduler.set_wake([map]() {
+    static_cast<void>(map_post_trigger_repaint(map));
+  });
   try {
     // Set before priming: renderer_backend() dispatches on kind.
     session->kind = kind;
@@ -1012,6 +1042,7 @@ auto attach_render_session(
     const auto size_status =
       map_post_set_size(map, session->width, session->height);
     if (size_status != MLN_STATUS_OK) {
+      session->scheduler.set_wake({});
       static_cast<void>(map_detach_render_target_session(map, handle));
       return size_status;
     }
@@ -1019,6 +1050,7 @@ auto attach_render_session(
 
     *out_session = register_render_session(std::move(session));
   } catch (...) {
+    session->scheduler.set_wake({});
     static_cast<void>(map_detach_render_target_session(map, handle));
     throw;
   }
@@ -1339,6 +1371,8 @@ auto render_session_detach(mln_render_session session) -> mln_status {
     set_thread_error("cannot detach while a texture frame is acquired");
     return MLN_STATUS_INVALID_STATE;
   }
+
+  live->scheduler.set_wake({});
 
   // Tear the renderer down before releasing the map's slot. The renderer holds
   // the map's forwarding observer, which the map's frontend owns; releasing the

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -239,9 +239,13 @@ class RenderSessionScheduler final : public mbgl::Scheduler {
   // Drops queued work without running it, for detach.
   auto discard() -> void;
 
+  // Requests a host frame when foreign-thread work makes an idle queue
+  // nonempty. Cleared before detach so late worker results are discarded.
+  auto set_wake(std::function<void()> wake) -> void;
+
  private:
-  // Clears `draining_` however drain() leaves, so a throwing task cannot wedge
-  // the queue closed.
+  // Reopens the queue and wakes pending work if drain() exits through an
+  // exception.
   class DrainGuard {
    public:
     explicit DrainGuard(RenderSessionScheduler& scheduler)
@@ -258,6 +262,7 @@ class RenderSessionScheduler final : public mbgl::Scheduler {
 
   std::mutex mutex_;
   std::vector<std::function<void()>> queue_;
+  std::function<void()> wake_;
   bool draining_ = false;
   mapbox::base::WeakPtrFactory<mbgl::Scheduler> weak_factory_{this};
   // Do not add members here, see `WeakPtrFactory`

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -239,9 +239,9 @@ class RenderSessionScheduler final : public mbgl::Scheduler {
   // Drops queued work without running it, for detach.
   auto discard() -> void;
 
-  // Requests a host frame when foreign-thread work makes an idle queue
-  // nonempty. Cleared before detach so late worker results are discarded.
-  auto set_wake(std::function<void()> wake) -> void;
+  // Requests a host frame when work makes an idle queue nonempty. Cleared
+  // before detach so late worker results are discarded.
+  auto set_repaint_request(std::function<void()> repaint_request) -> void;
 
  private:
   // Reopens the queue and wakes pending work if drain() exits through an
@@ -262,7 +262,7 @@ class RenderSessionScheduler final : public mbgl::Scheduler {
 
   std::mutex mutex_;
   std::vector<std::function<void()>> queue_;
-  std::function<void()> wake_;
+  std::function<void()> repaint_request_;
   bool draining_ = false;
   mapbox::base::WeakPtrFactory<mbgl::Scheduler> weak_factory_{this};
   // Do not add members here, see `WeakPtrFactory`


### PR DESCRIPTION
## Summary

Wake a render session when asynchronous worker results enter its idle scheduler queue so delayed tiles render without user input, fixing maplibre/maplibre-native-ffi#615.

## Test plan

Ran `mise run //:test macos-arm64-metal` and confirmed that the MapLibre Compose delayed-tile repro fills without a click.

An automated regression test was difficult to assemble for this scenario; decided against it.

## AI assistance

- **Tools:** Codex
- **Context:** Codex assisted with tracing, implementation, and validation.