### PR TITLE
Add tvOS Metal targets for the native C library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -847,6 +847,74 @@ jobs:
           path: build/packages/native/dist/maplibre-native-c-ios-simulator-arm64-metal.tar.gz
           if-no-files-found: error
 
+  target-tvos-arm64-metal:
+    name: target / tvos-arm64-metal
+    runs-on: macos-26
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    if: >-
+      github.event_name != 'pull_request'
+      || github.base_ref == 'main'
+      || github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: tvos-arm64-metal
+          gradle: false
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run build tvos-arm64-metal
+      - name: Archive native artifact
+        run: mise run archive-native tvos-arm64-metal
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          tvos-arm64-metal
+          build/packages/native/dist/maplibre-native-c-tvos-arm64-metal.tar.gz
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-tvos-arm64-metal-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-tvos-arm64-metal.tar.gz
+          if-no-files-found: error
+
+  target-tvos-simulator-arm64-metal:
+    name: target / tvos-simulator-arm64-metal
+    runs-on: macos-26
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    if: >-
+      github.event_name != 'pull_request'
+      || github.base_ref == 'main'
+      || github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: tvos-simulator-arm64-metal
+          gradle: false
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test tvos-simulator-arm64-metal
+      - name: Archive native artifact
+        run: mise run archive-native tvos-simulator-arm64-metal
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          tvos-simulator-arm64-metal
+          build/packages/native/dist/maplibre-native-c-tvos-simulator-arm64-metal.tar.gz
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-tvos-simulator-arm64-metal-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-tvos-simulator-arm64-metal.tar.gz
+          if-no-files-found: error
+
   target-android-arm64-egl:
     name: target / android-arm64-egl
     runs-on: ubuntu-latest
@@ -1547,6 +1615,8 @@ jobs:
       - target-macos-arm64-egl
       - target-ios-arm64-metal
       - target-ios-simulator-arm64-metal
+      - target-tvos-arm64-metal
+      - target-tvos-simulator-arm64-metal
       - target-android-arm64-egl
       - target-android-arm64-vulkan
       - target-android-x64-egl

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -57,6 +57,17 @@
       }
     },
     {
+      "name": "_tvos-arm64",
+      "hidden": true,
+      "inherits": "_single-config",
+      "toolchainFile": "${sourceDir}/cmake/toolchains/apple.cmake",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "tvOS",
+        "CMAKE_OSX_ARCHITECTURES": "arm64",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14.3"
+      }
+    },
+    {
       "name": "_android",
       "hidden": true,
       "inherits": "_single-config",
@@ -236,6 +247,18 @@
       "cacheVariables": { "CMAKE_OSX_SYSROOT": "iphonesimulator" }
     },
     {
+      "name": "tvos-arm64-metal",
+      "displayName": "tvOS ARM64 Metal",
+      "inherits": ["_tvos-arm64", "_metal"],
+      "cacheVariables": { "CMAKE_OSX_SYSROOT": "appletvos" }
+    },
+    {
+      "name": "tvos-simulator-arm64-metal",
+      "displayName": "tvOS Simulator ARM64 Metal",
+      "inherits": ["_tvos-arm64", "_metal"],
+      "cacheVariables": { "CMAKE_OSX_SYSROOT": "appletvsimulator" }
+    },
+    {
       "name": "android-arm64-egl",
       "displayName": "Android ARM64 EGL",
       "inherits": ["_android-arm64", "_egl"]
@@ -361,6 +384,20 @@
     {
       "name": "ios-simulator-arm64-metal",
       "configurePreset": "ios-simulator-arm64-metal",
+      "targets": ["install"],
+      "configuration": "Release",
+      "jobs": 0
+    },
+    {
+      "name": "tvos-arm64-metal",
+      "configurePreset": "tvos-arm64-metal",
+      "targets": ["install"],
+      "configuration": "Release",
+      "jobs": 0
+    },
+    {
+      "name": "tvos-simulator-arm64-metal",
+      "configurePreset": "tvos-simulator-arm64-metal",
       "targets": ["install"],
       "configuration": "Release",
       "jobs": 0
@@ -501,6 +538,11 @@
       "inherits": "_test-base"
     },
     {
+      "name": "tvos-simulator-arm64-metal",
+      "configurePreset": "tvos-simulator-arm64-metal",
+      "inherits": "_test-base"
+    },
+    {
       "name": "windows-x64-wgl",
       "configurePreset": "windows-x64-wgl",
       "configuration": "Release",
@@ -589,6 +631,18 @@
     {
       "name": "ios-simulator-arm64-metal",
       "configurePreset": "ios-simulator-arm64-metal",
+      "generators": ["TGZ"],
+      "configurations": ["Release"]
+    },
+    {
+      "name": "tvos-arm64-metal",
+      "configurePreset": "tvos-arm64-metal",
+      "generators": ["TGZ"],
+      "configurations": ["Release"]
+    },
+    {
+      "name": "tvos-simulator-arm64-metal",
+      "configurePreset": "tvos-simulator-arm64-metal",
       "generators": ["TGZ"],
       "configurations": ["Release"]
     },
@@ -741,6 +795,20 @@
       "steps": [
         { "type": "configure", "name": "ios-simulator-arm64-metal" },
         { "type": "build", "name": "ios-simulator-arm64-metal" }
+      ]
+    },
+    {
+      "name": "tvos-arm64-metal",
+      "steps": [
+        { "type": "configure", "name": "tvos-arm64-metal" },
+        { "type": "build", "name": "tvos-arm64-metal" }
+      ]
+    },
+    {
+      "name": "tvos-simulator-arm64-metal",
+      "steps": [
+        { "type": "configure", "name": "tvos-simulator-arm64-metal" },
+        { "type": "build", "name": "tvos-simulator-arm64-metal" }
       ]
     },
     {

--- a/ci/workflow.py
+++ b/ci/workflow.py
@@ -32,6 +32,8 @@ def load_configuration(
 def platform(preset: str) -> str:
     if preset.startswith("ios-simulator-"):
         return "ios-simulator"
+    if preset.startswith("tvos-simulator-"):
+        return "tvos-simulator"
     return preset.split("-", 1)[0]
 
 
@@ -57,7 +59,7 @@ def runner(preset: str) -> str:
         # The zig toolchain sets the glibc floor. These images stay pinned so
         # the graphics loaders and drivers the tests use stay reproducible.
         return "ubuntu-24.04-arm" if target_architecture == "arm64" else "ubuntu-24.04"
-    if target_platform in {"macos", "ios", "ios-simulator"}:
+    if target_platform in {"macos", "ios", "ios-simulator", "tvos", "tvos-simulator"}:
         return "macos-26"
     if target_platform == "windows":
         return "windows-11-arm" if target_architecture == "arm64" else "windows-2022"

--- a/cmake/mln_ffi_maplibre_native.cmake
+++ b/cmake/mln_ffi_maplibre_native.cmake
@@ -50,7 +50,9 @@ function(mln_ffi_add_maplibre_native)
     endforeach()
   endif()
 
-  if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+  if(CMAKE_SYSTEM_NAME MATCHES "^(iOS|tvOS)$")
+    # action_journal_impl.cpp selects ghc::filesystem whenever TARGET_OS_IPHONE
+    # is set, and that macro is true on tvOS as well as iOS.
     target_link_libraries(mbgl-core PRIVATE mbgl-vendor-filesystem)
   endif()
 

--- a/cmake/mln_ffi_tests.cmake
+++ b/cmake/mln_ffi_tests.cmake
@@ -231,7 +231,7 @@ function(mln_ffi_add_c_api_test)
     return()
   endif()
 
-  if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+  if(CMAKE_SYSTEM_NAME MATCHES "^(iOS|tvOS)$")
     add_test(
       NAME c-api
       COMMAND
@@ -263,6 +263,11 @@ function(mln_ffi_add_c_api_test)
   # fixtures out of the tree that happened to compile it first.
   set(test_environment
       "MLN_FFI_TEST_FIXTURE_DIR=${PROJECT_SOURCE_DIR}/third_party/maplibre-native/test/fixtures")
+  if(CMAKE_SYSTEM_NAME STREQUAL "tvOS")
+    list(APPEND test_environment "MLN_FFI_SIMULATOR_RUNTIME=tvOS")
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    list(APPEND test_environment "MLN_FFI_SIMULATOR_RUNTIME=iOS")
+  endif()
   get_target_property(vulkan_icd_file mln_ffi_render_dependencies
                       MLN_FFI_VULKAN_ICD_FILE)
   if(vulkan_icd_file)

--- a/cmake/platform/apple.cmake
+++ b/cmake/platform/apple.cmake
@@ -10,15 +10,24 @@ function(mln_ffi_configure_apple_toolchain_defaults)
   endif()
 
   if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
-    if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    if(CMAKE_SYSTEM_NAME MATCHES "^(iOS|tvOS)$")
       # Match MapLibre Native's vendored CMake, which currently forces this
-      # value through maplibre-tile-spec even for iOS builds.
+      # value through maplibre-tile-spec even for iOS builds. tvOS shares the
+      # same numeric floor.
       set(CMAKE_OSX_DEPLOYMENT_TARGET "14.3"
-          CACHE STRING "Minimum iOS deployment target" FORCE)
+          CACHE STRING "Minimum ${CMAKE_SYSTEM_NAME} deployment target" FORCE)
     elseif(NOT DEFINED ENV{MACOSX_DEPLOYMENT_TARGET})
       set(CMAKE_OSX_DEPLOYMENT_TARGET "14.3"
           CACHE STRING "Minimum macOS deployment target" FORCE)
     endif()
+  endif()
+endfunction()
+
+function(mln_ffi_apple_is_simulator out_var)
+  if(CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
+    set(${out_var} TRUE PARENT_SCOPE)
+  else()
+    set(${out_var} FALSE PARENT_SCOPE)
   endif()
 endfunction()
 
@@ -40,28 +49,58 @@ function(mln_ffi_configure_platform_dependencies target)
     PROPERTIES
       MLN_FFI_DEFAULT_LOGGING_STDERR TRUE MLN_FFI_DEFAULT_THREAD_LOCAL TRUE
       MLN_FFI_SHARED_SUPPORTED TRUE)
-  if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+
+  mln_ffi_apple_is_simulator(MLN_FFI_APPLE_SIMULATOR)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set_target_properties(
       ${target}
       PROPERTIES
-        MLN_FFI_TARGET_PLATFORM ios-arm64 MLN_FFI_ZIG_TARGET aarch64-ios)
-    if(CMAKE_OSX_SYSROOT MATCHES "[iI][pP]hone[Ss]imulator")
+        MLN_FFI_TARGET_PLATFORM macos-arm64 MLN_FFI_ZIG_TARGET aarch64-macos
+        MLN_FFI_TEST_SUPPORTED TRUE)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    if(MLN_FFI_APPLE_SIMULATOR)
       set_target_properties(
         ${target}
         PROPERTIES
           MLN_FFI_TARGET_PLATFORM ios-simulator-arm64 MLN_FFI_ZIG_TARGET
           aarch64-ios-simulator MLN_FFI_TEST_SUPPORTED TRUE)
     else()
-      set_target_properties(${target} PROPERTIES MLN_FFI_TEST_SUPPORTED FALSE)
+      set_target_properties(
+        ${target}
+        PROPERTIES
+          MLN_FFI_TARGET_PLATFORM ios-arm64 MLN_FFI_ZIG_TARGET aarch64-ios
+          MLN_FFI_TEST_SUPPORTED FALSE)
+    endif()
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "tvOS")
+    if(MLN_FFI_APPLE_SIMULATOR)
+      set_target_properties(
+        ${target}
+        PROPERTIES
+          MLN_FFI_TARGET_PLATFORM tvos-simulator-arm64 MLN_FFI_ZIG_TARGET
+          aarch64-tvos-simulator MLN_FFI_TEST_SUPPORTED TRUE)
+    else()
+      set_target_properties(
+        ${target}
+        PROPERTIES
+          MLN_FFI_TARGET_PLATFORM tvos-arm64 MLN_FFI_ZIG_TARGET aarch64-tvos
+          MLN_FFI_TEST_SUPPORTED FALSE)
     endif()
   else()
-    set_target_properties(
-      ${target}
-      PROPERTIES
-        MLN_FFI_TARGET_PLATFORM macos-arm64 MLN_FFI_ZIG_TARGET aarch64-macos
-        MLN_FFI_TEST_SUPPORTED TRUE)
+    message(FATAL_ERROR "Unsupported Apple platform: ${CMAKE_SYSTEM_NAME}")
   endif()
-  if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(MLN_FFI_APPLE_SDK "${CMAKE_OSX_SYSROOT}")
+    if(NOT MLN_FFI_APPLE_SDK)
+      set(MLN_FFI_APPLE_SDK macosx)
+    endif()
+    if(NOT IS_ABSOLUTE "${MLN_FFI_APPLE_SDK}")
+      execute_process(
+        COMMAND xcrun --sdk "${MLN_FFI_APPLE_SDK}" --show-sdk-path
+        OUTPUT_VARIABLE MLN_FFI_APPLE_SDK OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY)
+    endif()
+  else()
     set(MLN_FFI_ZIG_LIBC_SYSROOT "${CMAKE_OSX_SYSROOT}")
     if(NOT IS_ABSOLUTE "${MLN_FFI_ZIG_LIBC_SYSROOT}")
       execute_process(
@@ -77,17 +116,6 @@ function(mln_ffi_configure_platform_dependencies target)
         MLN_FFI_ZIG_LIBC_INCLUDE_DIR "${MLN_FFI_ZIG_LIBC_SYSROOT}/usr/include"
         MLN_FFI_ZIG_LIBC_CRT_DIR "")
     set(MLN_FFI_APPLE_SDK "${MLN_FFI_ZIG_LIBC_SYSROOT}")
-  else()
-    set(MLN_FFI_APPLE_SDK "${CMAKE_OSX_SYSROOT}")
-    if(NOT MLN_FFI_APPLE_SDK)
-      set(MLN_FFI_APPLE_SDK macosx)
-    endif()
-    if(NOT IS_ABSOLUTE "${MLN_FFI_APPLE_SDK}")
-      execute_process(
-        COMMAND xcrun --sdk "${MLN_FFI_APPLE_SDK}" --show-sdk-path
-        OUTPUT_VARIABLE MLN_FFI_APPLE_SDK OUTPUT_STRIP_TRAILING_WHITESPACE
-        COMMAND_ERROR_IS_FATAL ANY)
-    endif()
   endif()
 
   find_program(MLN_FFI_LIBTOOL NAMES libtool REQUIRED)
@@ -127,7 +155,7 @@ function(mln_ffi_configure_platform target)
     ${target}
     PRIVATE mbgl-vendor-metal-cpp MLN_FFI::PlatformDependencies)
 
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set_target_properties(
       ${target}
       PROPERTIES

--- a/cmake/render/metal.cmake
+++ b/cmake/render/metal.cmake
@@ -14,8 +14,7 @@ function(mln_ffi_configure_renderer target)
       ${PROJECT_SOURCE_DIR}/src/render/metal/metal_texture_backend.mm
       ${PROJECT_SOURCE_DIR}/src/render/metal/metal_surface_session.mm)
 
-  if(CMAKE_SYSTEM_NAME STREQUAL "iOS"
-     AND CMAKE_OSX_SYSROOT MATCHES "[iI][pP]hone[Ss]imulator")
+  if(CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
     list(APPEND MLN_FFI_METAL_SOURCES
          ${PROJECT_SOURCE_DIR}/src/render/metal/ios_simulator_metal_symbols.m)
   endif()

--- a/cmake/toolchains/apple.cmake
+++ b/cmake/toolchains/apple.cmake
@@ -25,6 +25,17 @@ elseif(MLN_FFI_XTOOL_SYSROOT_NAME MATCHES "iphoneos")
   set(MLN_FFI_XTOOL_TRIPLE "arm64-apple-ios${CMAKE_OSX_DEPLOYMENT_TARGET}")
   set(MLN_FFI_XTOOL_SYSROOT
       "${MLN_FFI_XTOOL_SDK_BUNDLE}/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk")
+elseif(MLN_FFI_XTOOL_SYSROOT_NAME MATCHES "appletvsimulator")
+  set(CMAKE_SYSTEM_NAME tvOS)
+  set(MLN_FFI_XTOOL_TRIPLE
+      "arm64-apple-tvos${CMAKE_OSX_DEPLOYMENT_TARGET}-simulator")
+  set(MLN_FFI_XTOOL_SYSROOT
+      "${MLN_FFI_XTOOL_SDK_BUNDLE}/Developer/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk")
+elseif(MLN_FFI_XTOOL_SYSROOT_NAME MATCHES "appletvos")
+  set(CMAKE_SYSTEM_NAME tvOS)
+  set(MLN_FFI_XTOOL_TRIPLE "arm64-apple-tvos${CMAKE_OSX_DEPLOYMENT_TARGET}")
+  set(MLN_FFI_XTOOL_SYSROOT
+      "${MLN_FFI_XTOOL_SDK_BUNDLE}/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk")
 elseif(MLN_FFI_XTOOL_SYSROOT_NAME MATCHES "macosx")
   set(CMAKE_SYSTEM_NAME Darwin)
   set(MLN_FFI_XTOOL_TRIPLE "arm64-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}")

--- a/docs/scripts/generate-support-matrix.py
+++ b/docs/scripts/generate-support-matrix.py
@@ -30,6 +30,7 @@ PLATFORM_LABELS = {
     "linux": "Linux",
     "macos": "macOS",
     "ohos": "OpenHarmony",
+    "tvos": "tvOS",
     "windows": "Windows",
 }
 BACKEND_LABELS = {
@@ -50,6 +51,8 @@ ENVIRONMENT_ORDER = [
     "android-x64",
     "ios-arm64",
     "ios-simulator-arm64",
+    "tvos-arm64",
+    "tvos-simulator-arm64",
     "ohos-arm64",
     "ohos-x64",
 ]
@@ -73,20 +76,24 @@ class Coverage:
     @property
     def environment(self) -> str:
         if self.simulator:
-            return f"ios-simulator-{self.arch}"
+            return f"{self.platform}-simulator-{self.arch}"
         return f"{self.platform}-{self.arch}"
 
 
 def coverage_from_preset(preset: str, status: str) -> Coverage:
     target_platform = platform(preset)
+    simulator = target_platform.endswith("-simulator")
+    base_platform = (
+        target_platform.removesuffix("-simulator") if simulator else target_platform
+    )
     return Coverage(
-        platform="ios" if target_platform == "ios-simulator" else target_platform,
+        platform=base_platform,
         arch=architecture(preset),
         backend={"egl": "opengl", "wgl": "opengl", "webgl": "opengl"}.get(
             backend(preset), backend(preset)
         ),
         status=status,
-        simulator=target_platform == "ios-simulator",
+        simulator=simulator,
     )
 
 
@@ -144,9 +151,9 @@ def backend_sort_key(value: str) -> tuple[int, str]:
 
 def environment_label(entry: Coverage) -> str:
     if entry.simulator:
-        return f"iOS Simulator {entry.arch}"
-    if entry.platform == "ios":
-        return f"iOS device {entry.arch}"
+        return f"{PLATFORM_LABELS[entry.platform]} Simulator {entry.arch}"
+    if entry.platform in {"ios", "tvos"}:
+        return f"{PLATFORM_LABELS[entry.platform]} device {entry.arch}"
     return f"{PLATFORM_LABELS[entry.platform]} {entry.arch}"
 
 

--- a/mise.macos.toml
+++ b/mise.macos.toml
@@ -14,44 +14,15 @@ JDK_JAVA_OPTIONS = "-Djava.library.path=/opt/homebrew/opt/vulkan-loader/lib -Dor
 MLN_FFI_VULKAN_LOADER_DIR = "/opt/homebrew/opt/vulkan-loader/lib"
 VK_DRIVER_FILES = "/opt/homebrew/opt/molten-vk/etc/vulkan/icd.d/MoltenVK_icd.json"
 
+[tasks."apple-simulator:boot"]
+description = "Boot an available Apple simulator and wait until it is ready."
+usage = 'arg "<runtime>"'
+run = 'bash "$MISE_MONOREPO_ROOT/scripts/apple-simulator.sh" boot "$usage_runtime"'
+
 [tasks."ios-simulator:boot"]
 description = "Boot an available iPhone simulator and wait until it is ready."
-run = '''
-device=$(xcrun simctl list devices available iOS | awk -F '[()]' '/ iPhone / && /Shutdown|Booted/ { print $2; exit }')
-[[ -n "$device" ]] || { echo "No available iOS simulator device found." >&2; exit 2; }
-state=$(xcrun simctl list devices "$device" | awk -F '[()]' -v id="$device" '$0 ~ id { print $4; exit }')
-if [[ "$state" != "Booted" ]]; then
-  xcrun simctl boot "$device"
-  xcrun simctl bootstatus "$device" -b
-fi
-'''
+run = [{ task = "//:apple-simulator:boot", args = ["iOS"] }]
 
 [tasks."tvos-simulator:boot"]
 description = "Boot an available Apple TV simulator and wait until it is ready."
-run = '''
-device=$(
-  xcrun simctl list devices available tvOS |
-    awk '
-      /Apple TV/ && /Shutdown|Booted/ {
-        if (match($0, /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/)) {
-          print substr($0, RSTART, RLENGTH)
-          exit
-        }
-      }
-    '
-)
-[[ -n "$device" ]] || { echo "No available tvOS simulator device found." >&2; exit 2; }
-state=$(
-  xcrun simctl list devices "$device" |
-    awk -v id="$device" '
-      index($0, id) {
-        if ($0 ~ /Booted/) { print "Booted"; exit }
-        if ($0 ~ /Shutdown/) { print "Shutdown"; exit }
-      }
-    '
-)
-if [[ "$state" != "Booted" ]]; then
-  xcrun simctl boot "$device"
-  xcrun simctl bootstatus "$device" -b
-fi
-'''
+run = [{ task = "//:apple-simulator:boot", args = ["tvOS"] }]

--- a/mise.macos.toml
+++ b/mise.macos.toml
@@ -25,3 +25,33 @@ if [[ "$state" != "Booted" ]]; then
   xcrun simctl bootstatus "$device" -b
 fi
 '''
+
+[tasks."tvos-simulator:boot"]
+description = "Boot an available Apple TV simulator and wait until it is ready."
+run = '''
+device=$(
+  xcrun simctl list devices available tvOS |
+    awk '
+      /Apple TV/ && /Shutdown|Booted/ {
+        if (match($0, /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/)) {
+          print substr($0, RSTART, RLENGTH)
+          exit
+        }
+      }
+    '
+)
+[[ -n "$device" ]] || { echo "No available tvOS simulator device found." >&2; exit 2; }
+state=$(
+  xcrun simctl list devices "$device" |
+    awk -v id="$device" '
+      index($0, id) {
+        if ($0 ~ /Booted/) { print "Booted"; exit }
+        if ($0 ~ /Shutdown/) { print "Shutdown"; exit }
+      }
+    '
+)
+if [[ "$state" != "Booted" ]]; then
+  xcrun simctl boot "$device"
+  xcrun simctl bootstatus "$device" -b
+fi
+'''

--- a/mise.toml
+++ b/mise.toml
@@ -311,6 +311,8 @@ depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 run = '''
 if [[ "$usage_preset" == ios-simulator-* ]]; then
   mise run //:ios-simulator:boot
+elif [[ "$usage_preset" == tvos-simulator-* ]]; then
+  mise run //:tvos-simulator:boot
 elif [[ "$usage_preset" == ohos-x64-egl || "$usage_preset" == android-x64-* ]]; then
   # An emulator target runs the suite through a device shell rather than ctest,
   # so the tile fixtures ctest would name by absolute source path are staged

--- a/mise.toml
+++ b/mise.toml
@@ -310,9 +310,9 @@ depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 # scripts/run-browser-test.mjs for how a browser is located.
 run = '''
 if [[ "$usage_preset" == ios-simulator-* ]]; then
-  mise run //:ios-simulator:boot
+  mise run //:apple-simulator:boot iOS
 elif [[ "$usage_preset" == tvos-simulator-* ]]; then
-  mise run //:tvos-simulator:boot
+  mise run //:apple-simulator:boot tvOS
 elif [[ "$usage_preset" == ohos-x64-egl || "$usage_preset" == android-x64-* ]]; then
   # An emulator target runs the suite through a device shell rather than ctest,
   # so the tile fixtures ctest would name by absolute source path are staged

--- a/scripts/apple-simulator.sh
+++ b/scripts/apple-simulator.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Resolves Apple simulator devices by UUID. Device names can contain
+# parentheses, so field-splitting on '(' is not a stable id.
+set -euo pipefail
+
+uuid_re='[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
+
+usage() {
+  echo "usage: $0 boot <iOS|tvOS>" >&2
+  echo "       $0 find-booted <iOS|tvOS>" >&2
+  exit 2
+}
+
+device_filter() {
+  case "$1" in
+    iOS) printf '%s\n' ' iPhone ' ;;
+    tvOS) printf '%s\n' 'Apple TV' ;;
+    *)
+      echo "Unknown simulator runtime: $1" >&2
+      usage
+      ;;
+  esac
+}
+
+find_device() {
+  local runtime=$1
+  local state_re=$2
+  local filter
+  filter=$(device_filter "$runtime")
+  xcrun simctl list devices available "$runtime" |
+    awk -v filter="$filter" -v state_re="$state_re" -v uuid_re="$uuid_re" '
+      index($0, filter) && $0 ~ state_re {
+        if (match($0, uuid_re)) {
+          print substr($0, RSTART, RLENGTH)
+          exit
+        }
+      }
+    '
+}
+
+device_state() {
+  xcrun simctl list devices "$1" |
+    awk -v id="$1" '
+      index($0, id) {
+        if ($0 ~ /Booted/) { print "Booted"; exit }
+        if ($0 ~ /Shutdown/) { print "Shutdown"; exit }
+      }
+    '
+}
+
+boot_runtime() {
+  local runtime=$1
+  local device
+  device=$(find_device "$runtime" 'Shutdown|Booted')
+  if [[ -z "$device" ]]; then
+    echo "No available $runtime simulator device found." >&2
+    exit 2
+  fi
+  if [[ "$(device_state "$device")" != "Booted" ]]; then
+    xcrun simctl boot "$device"
+    xcrun simctl bootstatus "$device" -b
+  fi
+}
+
+find_booted() {
+  local runtime=$1
+  local device
+  device=$(find_device "$runtime" 'Booted')
+  if [[ -z "$device" ]]; then
+    echo "No booted $runtime simulator device found. Run 'mise run //:apple-simulator:boot $runtime' first." >&2
+    exit 2
+  fi
+  printf '%s\n' "$device"
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+fi
+
+case "$1" in
+  boot) boot_runtime "$2" ;;
+  find-booted) find_booted "$2" ;;
+  *) usage ;;
+esac

--- a/scripts/run-ios-simulator-test.sh
+++ b/scripts/run-ios-simulator-test.sh
@@ -9,16 +9,39 @@ fi
 test_executable=$1
 timeout_seconds=${2:-120}
 if [[ ! -x "$test_executable" ]]; then
-  echo "iOS simulator test executable is not executable: $test_executable" >&2
+  echo "Simulator test executable is not executable: $test_executable" >&2
   exit 2
 fi
 
+runtime=${MLN_FFI_SIMULATOR_RUNTIME:-iOS}
+case "$runtime" in
+  iOS)
+    device_filter=' iPhone '
+    boot_task=ios-simulator:boot
+    ;;
+  tvOS)
+    device_filter='Apple TV'
+    boot_task=tvos-simulator:boot
+    ;;
+  *)
+    echo "Unknown simulator runtime: $runtime" >&2
+    exit 2
+    ;;
+esac
+
 device=$(
-  xcrun simctl list devices available iOS |
-    awk -F '[()]' '/ iPhone / && /Booted/ { print $2; exit }'
+  xcrun simctl list devices available "$runtime" |
+    awk -v filter="$device_filter" '
+      index($0, filter) && /Booted/ {
+        if (match($0, /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/)) {
+          print substr($0, RSTART, RLENGTH)
+          exit
+        }
+      }
+    '
 )
 if [[ -z "$device" ]]; then
-  echo "No booted iOS simulator device found. Run 'mise run //:ios-simulator:boot' first." >&2
+  echo "No booted $runtime simulator device found. Run 'mise run //:$boot_task' first." >&2
   exit 2
 fi
 

--- a/scripts/run-ios-simulator-test.sh
+++ b/scripts/run-ios-simulator-test.sh
@@ -13,42 +13,14 @@ if [[ ! -x "$test_executable" ]]; then
   exit 2
 fi
 
-runtime=${MLN_FFI_SIMULATOR_RUNTIME:-iOS}
-case "$runtime" in
-  iOS)
-    device_filter=' iPhone '
-    boot_task=ios-simulator:boot
-    ;;
-  tvOS)
-    device_filter='Apple TV'
-    boot_task=tvos-simulator:boot
-    ;;
-  *)
-    echo "Unknown simulator runtime: $runtime" >&2
-    exit 2
-    ;;
-esac
-
-device=$(
-  xcrun simctl list devices available "$runtime" |
-    awk -v filter="$device_filter" '
-      index($0, filter) && /Booted/ {
-        if (match($0, /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/)) {
-          print substr($0, RSTART, RLENGTH)
-          exit
-        }
-      }
-    '
-)
-if [[ -z "$device" ]]; then
-  echo "No booted $runtime simulator device found. Run 'mise run //:$boot_task' first." >&2
-  exit 2
-fi
-
 if [[ ! "$timeout_seconds" =~ ^[0-9]+$ ]]; then
   echo "Invalid timeout: $timeout_seconds" >&2
   exit 2
 fi
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+runtime=${MLN_FFI_SIMULATOR_RUNTIME:-iOS}
+device=$("$script_dir/apple-simulator.sh" find-booted "$runtime")
 
 # simctl hands the spawned process the variables named SIMCTL_CHILD_<NAME>, with
 # the prefix removed, so the fixture directory travels under that spelling. The

--- a/src/platform/apple/http_file_source.mm
+++ b/src/platform/apple/http_file_source.mm
@@ -271,14 +271,14 @@ NSString* HTTPFileSource::Impl::getUserAgent() const {
                                          @(mbgl::version::revision)]];
 
   NSString* systemName = @"Darwin";
-#if TARGET_OS_IPHONE
+#if TARGET_OS_TV
+  systemName = @"tvOS";
+#elif TARGET_OS_IPHONE
   systemName = @"iOS";
 #elif TARGET_OS_MAC
   systemName = @"macOS";
 #elif TARGET_OS_WATCH
   systemName = @"watchOS";
-#elif TARGET_OS_TV
-  systemName = @"tvOS";
 #endif
 #if TARGET_OS_SIMULATOR
   systemName = [systemName stringByAppendingString:@" Simulator"];


### PR DESCRIPTION
## Summary
Ship Metal native C archives for tvOS device and simulator, following the iOS path so Apple TV hosts can link the same C API.

## Test plan
`mise run build tvos-arm64-metal` and `mise run test tvos-simulator-arm64-metal` on macOS; CI archives both presets.

## AI assistance

- **Tools:** Cursor
- **Context:** Explored the iOS native-core wiring, then implemented tvOS presets, Apple platform detection, simulator tests, and CI/publish packaging. No MapLibre Native patch.