### PR TITLE
Enable Zig binding tests on the tvOS simulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -908,6 +908,9 @@ jobs:
           mise run install-native-package
           tvos-simulator-arm64-metal
           build/packages/native/dist/maplibre-native-c-tvos-simulator-arm64-metal.tar.gz
+      - run: mise run //bindings/zig:test tvos-simulator-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/bindings/zig/mise.toml
+++ b/bindings/zig/mise.toml
@@ -28,8 +28,8 @@ zig build --build-file ../../build.zig \
 
 [tasks.test]
 extends = "ffi:preset"
-# The preset selects the runner: an iOS simulator preset spawns the suite on a
-# simulator, and host presets run in process.
+# The preset selects the runner: an iOS or tvOS simulator preset spawns the
+# suite on a simulator, and host presets run in process.
 run = '''
 case "$usage_preset" in
   android-x64-*)
@@ -55,8 +55,19 @@ case "$usage_preset" in
       --libc "$native_install_dir/share/maplibre-native-c/zig-libc" \
       --test-timeout 120s --summary all --verbose
     ;;
-  ios-*)
-    echo "The Zig binding tests need a runnable target; test an ios-simulator preset instead of $usage_preset." >&2
+  tvos-simulator-*)
+    native_install_dir="$MISE_MONOREPO_ROOT/build/$usage_preset/install"
+    mise run //:tvos-simulator:boot
+    exec zig build test --build-file ../../build.zig \
+      -Dtarget=aarch64-tvos-simulator \
+      -Dnative-install-dir="$native_install_dir" \
+      -Ddependency-include-dir="$MISE_MONOREPO_ROOT/third_party/maplibre-native/vendor/Vulkan-Headers/include" \
+      -Dsystem-root="$(xcrun --sdk appletvsimulator --show-sdk-path)" \
+      --libc "$native_install_dir/share/maplibre-native-c/zig-libc" \
+      --test-timeout 120s --summary all --verbose
+    ;;
+  ios-* | tvos-*)
+    echo "The Zig binding tests need a runnable target; test an ios-simulator or tvos-simulator preset instead of $usage_preset." >&2
     exit 2
     ;;
 esac

--- a/build.zig
+++ b/build.zig
@@ -349,17 +349,20 @@ pub fn vulkanLibraryName(target: std.Build.ResolvedTarget) []const u8 {
     };
 }
 
-pub fn isIosSimulator(target: std.Build.ResolvedTarget) bool {
-    return target.result.os.tag == .ios and target.result.abi == .simulator;
+pub fn isAppleMobile(target: std.Build.ResolvedTarget) bool {
+    return switch (target.result.os.tag) {
+        .ios, .tvos => true,
+        else => false,
+    };
 }
 
-pub fn isIos(target: std.Build.ResolvedTarget) bool {
-    return target.result.os.tag == .ios;
+pub fn isAppleSimulator(target: std.Build.ResolvedTarget) bool {
+    return isAppleMobile(target) and target.result.abi == .simulator;
 }
 
 pub fn testOptimize(target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) std.builtin.OptimizeMode {
-    // Zig Debug iOS tests hit Mach-O/debug-info linker limits in this dependency graph.
-    if (isIos(target) and optimize == .Debug) return .ReleaseSafe;
+    // Zig Debug Apple-mobile tests hit Mach-O/debug-info linker limits in this dependency graph.
+    if (isAppleMobile(target) and optimize == .Debug) return .ReleaseSafe;
     return optimize;
 }
 
@@ -477,14 +480,12 @@ pub fn linkMaplibreNativeC(b: *std.Build, module_: *std.Build.Module, options: L
     });
     const link_dirs = &.{installPath(b, options.native_install_dir, "lib")};
     const runtime_library_dirs = &.{nativeRuntimeDir(b, options.native_install_dir, options.target)};
-    if (options.target.result.os.tag == .ios and !isIosSimulator(options.target)) {
+    if (isAppleMobile(options.target) and !isAppleSimulator(options.target)) {
         addLibraryPaths(module_, link_dirs);
         linkSystemLibraries(module_, staticIosLinkLibraries());
-        if (options.target.result.os.tag == .ios) {
-            const system_root = options.system_root orelse
-                @panic("iOS builds require -Dsystem-root=<path-to-iOS-SDK>");
-            module_.addObjectFile(.{ .cwd_relative = b.pathJoin(&.{ system_root.getPath(b), "usr", "lib", "libc++.tbd" }) });
-        }
+        const system_root = options.system_root orelse
+            @panic("iOS and tvOS device builds require -Dsystem-root=<path-to-SDK>");
+        module_.addObjectFile(.{ .cwd_relative = b.pathJoin(&.{ system_root.getPath(b), "usr", "lib", "libc++.tbd" }) });
         linkFrameworks(module_, staticIosFrameworks(options.render_backend));
     } else if (options.target.result.os.tag == .windows) {
         module_.addObjectFile(installPath(b, options.native_install_dir, "lib/maplibre-native-c.lib"));
@@ -552,9 +553,9 @@ fn addTestCompile(b: *std.Build, options: BuildOptions, root_source_file: std.Bu
             .target = options.target,
             .optimize = options.optimize,
         }),
-        .use_lld = if (isIos(options.target)) false else null,
+        .use_lld = if (isAppleMobile(options.target)) false else null,
     });
-    if (isIos(options.target)) {
+    if (isAppleMobile(options.target)) {
         tests.root_module.addCSourceFile(.{ .file = b.path("src/zig_test_support/ios_simulator_dyld_stub.m") });
     }
     linkMaplibreNativeC(b, tests.root_module, repoLinkOptions(options));
@@ -589,7 +590,7 @@ fn addBindingTests(b: *std.Build, options: BuildOptions, maplibre_native_ffi: *s
         }
     }
     if (options.render_backend == .metal) {
-        if (options.target.result.os.tag == .ios) {
+        if (isAppleMobile(options.target)) {
             tests.root_module.addCSourceFile(.{ .file = b.path("bindings/zig/tests/metal_support_ios.m") });
             tests.root_module.linkSystemLibrary("objc", .{});
             tests.root_module.linkFramework("Foundation", .{});
@@ -608,12 +609,16 @@ pub fn addTestRunStep(
     target: std.Build.ResolvedTarget,
     simulator_runner: std.Build.LazyPath,
 ) *std.Build.Step.Run {
-    if (isIosSimulator(target)) {
+    if (isAppleSimulator(target)) {
         const run_tests = b.addSystemCommand(&.{
             "bash",
             simulator_runner.getPath(b),
         });
         run_tests.addArtifactArg(tests);
+        run_tests.setEnvironmentVariable(
+            "MLN_FFI_SIMULATOR_RUNTIME",
+            if (target.result.os.tag == .tvos) "tvOS" else "iOS",
+        );
         return run_tests;
     }
 

--- a/ci/workflow.py
+++ b/ci/workflow.py
@@ -169,6 +169,12 @@ def consumer_commands(source: dict[str, object], preset: str) -> list[str]:
                 f"mise run //bindings/dart:build:mobile {preset}",
             ]
         )
+    elif target_platform == "tvos-simulator":
+        commands.extend(
+            [
+                f"mise run //bindings/zig:test {preset}",
+            ]
+        )
     elif target_platform in DESKTOP or target_platform == "emscripten":
         commands.extend(suite_commands(source, preset))
     return commands

--- a/docs/src/content/docs/development/binding-specification.md
+++ b/docs/src/content/docs/development/binding-specification.md
@@ -99,11 +99,12 @@ Requirements:
   process, runnable Android and OpenHarmony presets cross-compile and push to an
   emulator through the shared runners in `scripts/`
   (`run-android-emulator-test.sh`, `run-ohos-emulator-test.sh`, which boot the
-  emulator on demand), iOS simulator presets build a test bundle and spawn it on
-  a simulator, and Emscripten presets run in headless Chromium.
+  emulator on demand), iOS and tvOS simulator presets build a test bundle and
+  spawn it on a simulator, and Emscripten presets run in headless Chromium.
 - A preset that a binding cannot build or run MUST fail with a message that
   names what the binding supports. A device preset with no runner, such as
-  `ios-arm64-metal`, fails the same way and points at a simulator preset.
+  `ios-arm64-metal` or `tvos-arm64-metal`, fails the same way and points at a
+  simulator preset.
 - Colon-suffixed tasks cover the axes that a preset does not encode: one
   `test:<runtime>` task per runtime when a platform maps to more than one
   (`test:jvm` and `test:native` for Kotlin; a JavaScript binding adds its

--- a/src/zig_test_support/ios_simulator_dyld_stub.m
+++ b/src/zig_test_support/ios_simulator_dyld_stub.m
@@ -2,8 +2,8 @@
 
 struct mach_header;
 
-// Zig's test runtime references this dyld helper, which the iOS SDK link
-// environment does not provide. The tests never inspect image headers.
+// Zig's test runtime references this dyld helper, which the iOS and tvOS SDK
+// link environments do not provide. The tests never inspect image headers.
 const struct mach_header* _dyld_get_image_header_containing_address(
   const void* address
 ) {


### PR DESCRIPTION
## Summary
Run the Zig binding suite on the tvOS simulator the same way iOS does, and fail device presets with a pointer to the simulator.

## Test plan
`MISE_TASK_SKIP="//:build" mise run //bindings/zig:test tvos-simulator-arm64-metal` — 137 passed, 8 skipped.

## AI assistance
- **Tools:** Cursor
- **Context:** stacked tvOS binding PRs on top of the native-core PR; Zig first because iOS already tests it on the simulator.