### PR TITLE
Enable Swift binding tests on the tvOS simulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,6 +874,9 @@ jobs:
           mise run install-native-package
           tvos-arm64-metal
           build/packages/native/dist/maplibre-native-c-tvos-arm64-metal.tar.gz
+      - run: mise run //bindings/swift:build tvos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -908,6 +911,9 @@ jobs:
           mise run install-native-package
           tvos-simulator-arm64-metal
           build/packages/native/dist/maplibre-native-c-tvos-simulator-arm64-metal.tar.gz
+      - run: mise run //bindings/swift:test tvos-simulator-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
       - run: mise run //bindings/zig:test tvos-simulator-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"

--- a/Package.swift
+++ b/Package.swift
@@ -52,18 +52,18 @@ let targets: [Target] = [
     dependencies: ["CMaplibreNativeC"],
     path: "bindings/swift/Sources/MaplibreNativeFFI",
     linkerSettings: [
-      .linkedLibrary("c++", .when(platforms: [.iOS])),
-      .linkedLibrary("objc", .when(platforms: [.iOS])),
-      .linkedLibrary("sqlite3", .when(platforms: [.iOS])),
-      .linkedLibrary("z", .when(platforms: [.iOS])),
-      .linkedFramework("CoreFoundation", .when(platforms: [.iOS])),
-      .linkedFramework("CoreGraphics", .when(platforms: [.iOS])),
-      .linkedFramework("CoreText", .when(platforms: [.iOS])),
-      .linkedFramework("Foundation", .when(platforms: [.iOS])),
-      .linkedFramework("ImageIO", .when(platforms: [.iOS])),
-      .linkedFramework("Metal", .when(platforms: [.iOS])),
-      .linkedFramework("MetalKit", .when(platforms: [.iOS])),
-      .linkedFramework("QuartzCore", .when(platforms: [.iOS])),
+      .linkedLibrary("c++", .when(platforms: [.iOS, .tvOS])),
+      .linkedLibrary("objc", .when(platforms: [.iOS, .tvOS])),
+      .linkedLibrary("sqlite3", .when(platforms: [.iOS, .tvOS])),
+      .linkedLibrary("z", .when(platforms: [.iOS, .tvOS])),
+      .linkedFramework("CoreFoundation", .when(platforms: [.iOS, .tvOS])),
+      .linkedFramework("CoreGraphics", .when(platforms: [.iOS, .tvOS])),
+      .linkedFramework("CoreText", .when(platforms: [.iOS, .tvOS])),
+      .linkedFramework("Foundation", .when(platforms: [.iOS, .tvOS])),
+      .linkedFramework("ImageIO", .when(platforms: [.iOS, .tvOS])),
+      .linkedFramework("Metal", .when(platforms: [.iOS, .tvOS])),
+      .linkedFramework("MetalKit", .when(platforms: [.iOS, .tvOS])),
+      .linkedFramework("QuartzCore", .when(platforms: [.iOS, .tvOS])),
     ]
   ),
   .target(
@@ -90,7 +90,7 @@ let targets: [Target] = [
 
 let package = Package(
   name: "maplibre-native-ffi",
-  platforms: [.macOS("14.3"), .iOS("14.3")],
+  platforms: [.macOS("14.3"), .iOS("14.3"), .tvOS("14.3")],
   products: products,
   dependencies: [
     .package(

--- a/bindings/swift/Sources/MaplibreNativeFFI/Support/NativeString.swift
+++ b/bindings/swift/Sources/MaplibreNativeFFI/Support/NativeString.swift
@@ -15,21 +15,6 @@ enum NativeString {
   }
 
   static func copyUTF8(data: UnsafeRawPointer?, size: Int) throws -> String {
-    try copyUTF8(
-      data: data?.assumingMemoryBound(to: CChar.self),
-      size: size
-    )
-  }
-
-  static func copyUTF8(data: UnsafePointer<CChar>?,
-                       size: UInt) throws -> String
-  {
-    try copyUTF8(data: data, size: Int(size))
-  }
-
-  static func copyUTF8(data: UnsafePointer<CChar>?,
-                       size: Int) throws -> String
-  {
     guard size > 0 else { return "" }
     guard let data else {
       throw NativeStringError(
@@ -37,7 +22,7 @@ enum NativeString {
       )
     }
     let bytes = UnsafeBufferPointer(
-      start: UnsafeRawPointer(data).assumingMemoryBound(to: UInt8.self),
+      start: data.assumingMemoryBound(to: UInt8.self),
       count: size
     )
     guard let text = String(bytes: bytes, encoding: .utf8) else {

--- a/bindings/swift/Tests/MaplibreNativeFFIIOSSimulatorTests/Runner.swift
+++ b/bindings/swift/Tests/MaplibreNativeFFIIOSSimulatorTests/Runner.swift
@@ -4,7 +4,7 @@ import Testing
 @main
 struct MaplibreNativeFFIIOSSimulatorTestRunner {
   static func main() async {
-    // swift test does not run iOS simulator bundles, so the simulator
+    // swift test does not run iOS or tvOS simulator bundles, so the simulator
     // executable delegates to SwiftPM's test entry point.
     await Testing.__swiftPMEntryPoint() as Never
   }

--- a/bindings/swift/mise.toml
+++ b/bindings/swift/mise.toml
@@ -40,8 +40,19 @@ case "$usage_preset" in
       --sdk "$(xcrun --sdk iphoneos --show-sdk-path)" \
       --triple arm64-apple-ios14.3
     ;;
+  tvos-arm64-metal)
+    exec swift build \
+      --product MaplibreNativeFFI \
+      --scratch-path .build/tvos \
+      --sdk "$(xcrun --sdk appletvos --show-sdk-path)" \
+      --triple arm64-apple-tvos14.3
+    ;;
   ios-*)
     echo "The Swift binding builds for an iOS device with ios-arm64-metal; simulator coverage comes from //bindings/swift:test." >&2
+    exit 2
+    ;;
+  tvos-*)
+    echo "The Swift binding builds for a tvOS device with tvos-arm64-metal; simulator coverage comes from //bindings/swift:test." >&2
     exit 2
     ;;
 esac
@@ -53,8 +64,8 @@ swift build --target MaplibreNativeFFI "${swift_args[@]}"
 [tasks.test]
 dir = "../.."
 extends = "ffi:preset"
-# The preset selects the runner: an iOS simulator preset builds the test bundle
-# and spawns it on a simulator, and host presets run in process.
+# The preset selects the runner: an iOS or tvOS simulator preset builds the test
+# bundle and spawns it on a simulator, and host presets run in process.
 run = '''
 native_install_dir="$MISE_MONOREPO_ROOT/build/$usage_preset/install"
 export PKG_CONFIG_PATH="$native_install_dir/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
@@ -76,8 +87,25 @@ case "$usage_preset" in
       .build/ios-simulator/arm64-apple-ios-simulator/debug/MaplibreNativeFFIIOSSimulatorTests \
       120
     ;;
-  ios-*)
-    echo "The Swift binding tests need a runnable target; test an ios-simulator preset instead of $usage_preset." >&2
+  tvos-simulator-*)
+    swift build \
+      --product MaplibreNativeFFIIOSSimulatorTests \
+      --scratch-path .build/tvos-simulator \
+      --sdk "$(xcrun --sdk appletvsimulator --show-sdk-path)" \
+      --triple arm64-apple-tvos14.3-simulator \
+      -Xswiftc -enable-testing \
+      -Xlinker -rpath \
+      -Xlinker "$native_install_dir/lib" \
+      -Xlinker -rpath \
+      -Xlinker "$(xcode-select -p)/Platforms/AppleTVSimulator.platform/Developer/Library/Frameworks"
+    mise run //:tvos-simulator:boot
+    export MLN_FFI_SIMULATOR_RUNTIME=tvOS
+    exec "$MISE_MONOREPO_ROOT/scripts/run-ios-simulator-test.sh" \
+      .build/tvos-simulator/arm64-apple-tvos-simulator/debug/MaplibreNativeFFIIOSSimulatorTests \
+      120
+    ;;
+  ios-* | tvos-*)
+    echo "The Swift binding tests need a runnable target; test an ios-simulator or tvos-simulator preset instead of $usage_preset." >&2
     exit 2
     ;;
 esac

--- a/ci/workflow.py
+++ b/ci/workflow.py
@@ -169,9 +169,16 @@ def consumer_commands(source: dict[str, object], preset: str) -> list[str]:
                 f"mise run //bindings/dart:build:mobile {preset}",
             ]
         )
+    elif target_platform == "tvos":
+        commands.extend(
+            [
+                f"mise run //bindings/swift:build {preset}",
+            ]
+        )
     elif target_platform == "tvos-simulator":
         commands.extend(
             [
+                f"mise run //bindings/swift:test {preset}",
                 f"mise run //bindings/zig:test {preset}",
             ]
         )


### PR DESCRIPTION
## Summary
Build the Swift binding for tvOS and run its suite on the tvOS simulator the same way iOS does.

## Test plan
`MISE_TASK_SKIP="//:build" mise run //bindings/swift:test tvos-simulator-arm64-metal` — 102 passed; `mise run //bindings/swift:build tvos-arm64-metal` succeeded.

## AI assistance
- **Tools:** Cursor
- **Context:** stacked on the Zig tvOS binding PR; Swift is next because iOS already tests it on the simulator.