### PR TITLE
Fix Zig device builds on iOS and tvOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -786,6 +786,9 @@ jobs:
       - run: mise run //bindings/swift:build ios-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:build ios-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
       - run: mise run //examples/swift-map:build:ios
         env:
           MISE_TASK_SKIP: "//:build"
@@ -877,6 +880,9 @@ jobs:
         env:
           MISE_TASK_SKIP: "//:build"
       - run: mise run //bindings/swift:build tvos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:build tvos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact

--- a/bindings/zig/mise.toml
+++ b/bindings/zig/mise.toml
@@ -45,25 +45,21 @@ case "$usage_preset" in
     exit 2
     ;;
   ios-simulator-*)
-    native_install_dir="$MISE_MONOREPO_ROOT/build/$usage_preset/install"
+    source "$MISE_MONOREPO_ROOT/scripts/zig-cross-env.sh" "$usage_preset"
     mise run //:ios-simulator:boot
     exec zig build test --build-file ../../build.zig \
-      -Dtarget=aarch64-ios-simulator \
-      -Dnative-install-dir="$native_install_dir" \
+      -Dnative-install-dir="$MISE_MONOREPO_ROOT/build/$usage_preset/install" \
       -Ddependency-include-dir="$MISE_MONOREPO_ROOT/third_party/maplibre-native/vendor/Vulkan-Headers/include" \
-      -Dsystem-root="$(xcrun --sdk iphonesimulator --show-sdk-path)" \
-      --libc "$native_install_dir/share/maplibre-native-c/zig-libc" \
+      ${zig_cross_args[@]+"${zig_cross_args[@]}"} \
       --test-timeout 120s --summary all --verbose
     ;;
   tvos-simulator-*)
-    native_install_dir="$MISE_MONOREPO_ROOT/build/$usage_preset/install"
+    source "$MISE_MONOREPO_ROOT/scripts/zig-cross-env.sh" "$usage_preset"
     mise run //:tvos-simulator:boot
     exec zig build test --build-file ../../build.zig \
-      -Dtarget=aarch64-tvos-simulator \
-      -Dnative-install-dir="$native_install_dir" \
+      -Dnative-install-dir="$MISE_MONOREPO_ROOT/build/$usage_preset/install" \
       -Ddependency-include-dir="$MISE_MONOREPO_ROOT/third_party/maplibre-native/vendor/Vulkan-Headers/include" \
-      -Dsystem-root="$(xcrun --sdk appletvsimulator --show-sdk-path)" \
-      --libc "$native_install_dir/share/maplibre-native-c/zig-libc" \
+      ${zig_cross_args[@]+"${zig_cross_args[@]}"} \
       --test-timeout 120s --summary all --verbose
     ;;
   ios-* | tvos-*)

--- a/ci/workflow.py
+++ b/ci/workflow.py
@@ -155,6 +155,7 @@ def consumer_commands(source: dict[str, object], preset: str) -> list[str]:
             [
                 f"mise run //bindings/kotlin:ios-build {preset}",
                 f"mise run //bindings/swift:build {preset}",
+                f"mise run //bindings/zig:build {preset}",
                 "mise run //examples/swift-map:build:ios",
                 f"mise run //bindings/dart:build:mobile {preset}",
             ]
@@ -174,6 +175,7 @@ def consumer_commands(source: dict[str, object], preset: str) -> list[str]:
             [
                 f"mise run //bindings/kotlin:ios-build {preset}",
                 f"mise run //bindings/swift:build {preset}",
+                f"mise run //bindings/zig:build {preset}",
             ]
         )
     elif target_platform == "tvos-simulator":

--- a/scripts/zig-cross-env.sh
+++ b/scripts/zig-cross-env.sh
@@ -1,10 +1,54 @@
 #!/usr/bin/env bash
 # Sourced by Zig binding tasks with a native preset as $1. Android presets add
-# the NDK sysroot and the installed libc metadata. Host presets need no extra
+# the NDK sysroot and the installed libc metadata. Apple mobile presets add the
+# Xcode SDK root and the installed libc metadata. Host presets need no extra
 # arguments.
 # shellcheck shell=bash
 
 zig_cross_args=()
+
+apple_sdk=
+case "$1" in
+  ios-simulator-*) apple_sdk=iphonesimulator ;;
+  ios-*) apple_sdk=iphoneos ;;
+  tvos-simulator-*) apple_sdk=appletvsimulator ;;
+  tvos-*) apple_sdk=appletvos ;;
+esac
+
+# The SDK root supplies system headers and libc++.tbd. The installed zig-libc
+# file points Zig at that SDK's include layout.
+if [[ -n "$apple_sdk" ]]; then
+  native_install_dir="$MISE_MONOREPO_ROOT/build/$1/install"
+  descriptor="$native_install_dir/share/maplibre-native-c/artifact.json"
+  zig_libc="$native_install_dir/share/maplibre-native-c/zig-libc"
+  if ! command -v xcrun >/dev/null; then
+    echo "Apple mobile Zig builds need xcrun from Xcode." >&2
+    exit 2
+  fi
+  sdk_path=$(xcrun --sdk "$apple_sdk" --show-sdk-path) || exit 2
+  if [[ ! -d "$sdk_path" ]]; then
+    echo "The $apple_sdk SDK does not exist: $sdk_path" >&2
+    exit 2
+  fi
+  if [[ ! -f "$descriptor" ]]; then
+    echo "The Apple native artifact has no descriptor: $descriptor" >&2
+    exit 2
+  fi
+  if [[ ! -f "$zig_libc" ]]; then
+    echo "The Apple native artifact has no Zig libc file: $zig_libc" >&2
+    exit 2
+  fi
+  zig_target=$(sed -n 's/^[[:space:]]*"zigTarget":[[:space:]]*"\([^"]*\)".*/\1/p' "$descriptor")
+  if [[ -z "$zig_target" ]]; then
+    echo "The Apple native artifact has no Zig target: $descriptor" >&2
+    exit 2
+  fi
+  zig_cross_args=(
+    -Dtarget="$zig_target"
+    -Dsystem-root="$sdk_path"
+    --libc "$zig_libc"
+  )
+fi
 
 case "$1" in
   android-*)


### PR DESCRIPTION
## Summary
Pass the Apple SDK root and CMake zig-libc file through `zig-cross-env.sh` so `//bindings/zig:build` compiles for iOS and tvOS device presets.

## Test plan
`mise run //bindings/zig:build ios-arm64-metal` and `tvos-arm64-metal` succeed; device `//bindings/zig:test` still refuses and points at a simulator.

## AI assistance

- **Tools:** Cursor
- **Context:** Implemented and verified the #621 fix in this session.

Fixes #621