### PR TITLE
Document latLngBoundsForCamera two-corner vs four-corner hulls

### DIFF
--- a/bindings/dart/lib/src/runtime/runtime.dart
+++ b/bindings/dart/lib/src/runtime/runtime.dart
@@ -2195,11 +2195,21 @@ final class MapHandle {
     });
   }
 
-  /// Computes wrapped geographic bounds for a camera.
+  /// Computes geographic bounds for a camera from two viewport corners.
+  ///
+  /// The box is the hull of the top-left and bottom-right screen corners for
+  /// that camera in the current viewport. When bearing and pitch are zero, the
+  /// box equals the visible area. Those corners are the northwest and southeast
+  /// of the viewport. Longitudes stay in -180 to 180.
   LatLngBounds latLngBoundsForCamera(CameraOptions camera) =>
       _latLngBoundsForCamera(camera, unwrapped: false);
 
-  /// Computes unwrapped geographic bounds for a camera.
+  /// Computes geographic bounds for a camera from the four viewport corners.
+  ///
+  /// The axis-aligned hull of all four screen corners and the center encompasses
+  /// the projected viewport. Longitudes unwrap onto the shortest path through
+  /// the center. A viewport that crosses the antimeridian reports values outside
+  /// -180 to 180.
   LatLngBounds latLngBoundsForCameraUnwrapped(CameraOptions camera) =>
       _latLngBoundsForCamera(camera, unwrapped: true);
 

--- a/bindings/dotnet/src/Maplibre.NativeFfi/Map/MapHandle.cs
+++ b/bindings/dotnet/src/Maplibre.NativeFfi/Map/MapHandle.cs
@@ -416,7 +416,12 @@ public sealed unsafe class MapHandle : IDisposable
         return MapStructs.CameraOptionsFromNative(camera);
     }
 
-    /// <summary>Calculates geographic bounds for a camera.</summary>
+    /// <summary>Computes geographic bounds for a camera from two viewport corners.</summary>
+    /// <remarks>
+    /// The box is the hull of the top-left and bottom-right screen corners for that camera in the
+    /// current viewport. When bearing and pitch are zero, the box equals the visible area. Those
+    /// corners are the northwest and southeast of the viewport. Longitudes stay in -180 to 180.
+    /// </remarks>
     public LatLngBounds LatLngBoundsForCamera(CameraOptions camera)
     {
         var nativeCamera = MapStructs.ToNative(camera);
@@ -427,7 +432,12 @@ public sealed unsafe class MapHandle : IDisposable
         return MapStructs.FromNative(bounds);
     }
 
-    /// <summary>Calculates unwrapped geographic bounds for a camera.</summary>
+    /// <summary>Computes geographic bounds for a camera from the four viewport corners.</summary>
+    /// <remarks>
+    /// The axis-aligned hull of all four screen corners and the center encompasses the projected
+    /// viewport. Longitudes unwrap onto the shortest path through the center. A viewport that
+    /// crosses the antimeridian reports values outside -180 to 180.
+    /// </remarks>
     public LatLngBounds LatLngBoundsForCameraUnwrapped(CameraOptions camera)
     {
         var nativeCamera = MapStructs.ToNative(camera);

--- a/bindings/go/map.go
+++ b/bindings/go/map.go
@@ -710,8 +710,13 @@ func (m *MapHandle) CameraForGeometry(geometry []byte, fitOptions *CameraFitOpti
 	return goCameraOptions(raw), nil
 }
 
-// LatLngBoundsForCamera computes wrapped geographic bounds for a camera in the
-// current viewport.
+// LatLngBoundsForCamera computes geographic bounds for a camera from two
+// viewport corners.
+//
+// The box is the hull of the top-left and bottom-right screen corners for that
+// camera in the current viewport. When bearing and pitch are zero, the box
+// equals the visible area. Those corners are the northwest and southeast of
+// the viewport. Longitudes stay in -180 to 180.
 func (m *MapHandle) LatLngBoundsForCamera(camera CameraOptions) (LatLngBounds, error) {
 	ptr, release, err := m.ptr()
 	if err != nil {
@@ -729,8 +734,13 @@ func (m *MapHandle) LatLngBoundsForCamera(camera CameraOptions) (LatLngBounds, e
 	return goLatLngBounds(raw), nil
 }
 
-// LatLngBoundsForCameraUnwrapped computes unwrapped geographic bounds for a
-// camera in the current viewport.
+// LatLngBoundsForCameraUnwrapped computes geographic bounds for a camera from
+// the four viewport corners.
+//
+// The axis-aligned hull of all four screen corners and the center encompasses
+// the projected viewport. Longitudes unwrap onto the shortest path through the
+// center. A viewport that crosses the antimeridian reports values outside -180
+// to 180.
 func (m *MapHandle) LatLngBoundsForCameraUnwrapped(camera CameraOptions) (LatLngBounds, error) {
 	ptr, release, err := m.ptr()
 	if err != nil {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -367,8 +367,22 @@ public expect class MapHandle : AutoCloseable {
 
   public fun cameraForGeometry(geometry: ByteArray, fitOptions: CameraFitOptions?): CameraOptions
 
+  /**
+   * Computes geographic bounds for a camera from two viewport corners.
+   *
+   * The box is the hull of the top-left and bottom-right screen corners for that camera in the
+   * current viewport. When bearing and pitch are zero, the box equals the visible area. Those
+   * corners are the northwest and southeast of the viewport. Longitudes stay in -180 to 180.
+   */
   public fun latLngBoundsForCamera(camera: CameraOptions): LatLngBounds
 
+  /**
+   * Computes geographic bounds for a camera from the four viewport corners.
+   *
+   * The axis-aligned hull of all four screen corners and the center encompasses the projected
+   * viewport. Longitudes unwrap onto the shortest path through the center. A viewport that crosses
+   * the antimeridian reports values outside -180 to 180.
+   */
   public fun latLngBoundsForCameraUnwrapped(camera: CameraOptions): LatLngBounds
 
   public var bounds: BoundOptions

--- a/bindings/python/python/maplibre_native_ffi/map.py
+++ b/bindings/python/python/maplibre_native_ffi/map.py
@@ -1282,7 +1282,19 @@ class MapHandle(NativeHandleMixin):
         *,
         unwrapped: bool = False,
     ) -> LatLngBounds:
-        """Compute geographic bounds for a camera in the current viewport."""
+        """Compute geographic bounds for a camera from two viewport corners.
+
+        The box is the hull of the top-left and bottom-right screen corners
+        for that camera in the current viewport. When bearing and pitch are
+        zero, the box equals the visible area. Those corners are the northwest
+        and southeast of the viewport. Longitudes stay in -180 to 180.
+
+        Pass `unwrapped=True` for the axis-aligned hull of all four screen
+        corners and the center. That hull encompasses the projected viewport.
+        Longitudes unwrap onto the shortest path through the center. A
+        viewport that crosses the antimeridian reports values outside -180
+        to 180.
+        """
         from .geo import LatLng, LatLngBounds
 
         raw = self._native.lat_lng_bounds_for_camera(*_camera_parts(camera), unwrapped)

--- a/bindings/rust/crates/maplibre-native-ffi/src/map.rs
+++ b/bindings/rust/crates/maplibre-native-ffi/src/map.rs
@@ -573,7 +573,12 @@ impl MapHandle {
         Ok(CameraOptions::from_native(raw_camera))
     }
 
-    /// Computes wrapped geographic bounds for a camera in the current viewport.
+    /// Computes geographic bounds for a camera from two viewport corners.
+    ///
+    /// The box is the hull of the top-left and bottom-right screen corners for
+    /// that camera in the current viewport. When bearing and pitch are zero, the
+    /// box equals the visible area. Those corners are the northwest and
+    /// southeast of the viewport. Longitudes stay in -180 to 180.
     pub fn lat_lng_bounds_for_camera(&self, camera: &CameraOptions) -> Result<LatLngBounds> {
         let map = self.inner.native()?;
         let raw_camera = camera.to_native();
@@ -586,7 +591,12 @@ impl MapHandle {
         Ok(LatLngBounds::from_native(raw_bounds))
     }
 
-    /// Computes unwrapped geographic bounds for a camera in the current viewport.
+    /// Computes geographic bounds for a camera from the four viewport corners.
+    ///
+    /// The axis-aligned hull of all four screen corners and the center
+    /// encompasses the projected viewport. Longitudes unwrap onto the shortest
+    /// path through the center. A viewport that crosses the antimeridian reports
+    /// values outside -180 to 180.
     pub fn lat_lng_bounds_for_camera_unwrapped(
         &self,
         camera: &CameraOptions,

--- a/bindings/swift/Sources/MaplibreNativeFFI/CameraAdvanced.swift
+++ b/bindings/swift/Sources/MaplibreNativeFFI/CameraAdvanced.swift
@@ -512,6 +512,18 @@ public extension MapHandle {
     }
   }
 
+  /// Returns geographic bounds for a camera from two viewport corners.
+  ///
+  /// The box is the hull of the top-left and bottom-right screen corners for
+  /// that camera in the current viewport. When bearing and pitch are zero, the
+  /// box equals the visible area. Those corners are the northwest and southeast
+  /// of the viewport. Longitudes stay in -180 to 180.
+  ///
+  /// Pass `unwrapped: true` for the axis-aligned hull of all four screen
+  /// corners
+  /// and the center. That hull encompasses the projected viewport. Longitudes
+  /// unwrap onto the shortest path through the center. A viewport that crosses
+  /// the antimeridian reports values outside -180 to 180.
   func latLngBounds(for camera: CameraOptions,
                     unwrapped: Bool = false) throws -> LatLngBounds
   {

--- a/bindings/zig/src/map.zig
+++ b/bindings/zig/src/map.zig
@@ -1822,6 +1822,12 @@ pub const MapHandle = enum(c.mln_map) {
         return values.cameraOptionsFromNative(camera);
     }
 
+    /// Computes geographic bounds for a camera from two viewport corners.
+    ///
+    /// The box is the hull of the top-left and bottom-right screen corners for
+    /// that camera in the current viewport. When bearing and pitch are zero, the
+    /// box equals the visible area. Those corners are the northwest and
+    /// southeast of the viewport. Longitudes stay in -180 to 180.
     pub fn latLngBoundsForCamera(self: *MapHandle, camera: values.CameraOptions) status.Error!values.LatLngBounds {
         var raw_camera = values.cameraOptionsToNative(camera);
         var bounds: c.mln_lat_lng_bounds = undefined;
@@ -1829,6 +1835,12 @@ pub const MapHandle = enum(c.mln_map) {
         return values.latLngBoundsFromNative(bounds);
     }
 
+    /// Computes geographic bounds for a camera from the four viewport corners.
+    ///
+    /// The axis-aligned hull of all four screen corners and the center
+    /// encompasses the projected viewport. Longitudes unwrap onto the shortest
+    /// path through the center. A viewport that crosses the antimeridian reports
+    /// values outside -180 to 180.
     pub fn latLngBoundsForCameraUnwrapped(self: *MapHandle, camera: values.CameraOptions) status.Error!values.LatLngBounds {
         var raw_camera = values.cameraOptionsToNative(camera);
         var bounds: c.mln_lat_lng_bounds = undefined;

--- a/include/maplibre_native_c/camera.h
+++ b/include/maplibre_native_c/camera.h
@@ -571,7 +571,13 @@ MLN_API mln_status mln_map_camera_for_geometry(
 ) MLN_NOEXCEPT;
 
 /**
- * Computes wrapped geographic bounds for a camera in the current viewport.
+ * Computes geographic bounds for a camera from two viewport corners.
+ *
+ * The box is the hull of the top-left and bottom-right screen corners for that
+ * camera in the current viewport. When bearing and pitch are zero, the box
+ * equals the visible area. Those corners are the northwest and southeast of
+ * the viewport. Longitudes stay in -180 to 180. On success, *out_bounds is
+ * overwritten.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -586,7 +592,12 @@ MLN_API mln_status mln_map_lat_lng_bounds_for_camera(
 ) MLN_NOEXCEPT;
 
 /**
- * Computes unwrapped geographic bounds for a camera in the current viewport.
+ * Computes geographic bounds for a camera from the four viewport corners.
+ *
+ * The axis-aligned hull of all four screen corners and the center encompasses
+ * the projected viewport. Longitudes unwrap onto the shortest path through the
+ * center. A viewport that crosses the antimeridian reports values outside -180
+ * to 180. On success, *out_bounds is overwritten.
  *
  * Returns:
  * - MLN_STATUS_OK on success.


### PR DESCRIPTION
Resolve #622 

## Summary
Document that the wrapped camera-bounds call hulls two viewport corners (visible only at zero bearing and pitch) and the unwrapped call encompasses the projected viewport.

## Test plan
Read the C and binding comments against `Map::latLngBoundsForCamera` and `Map::latLngBoundsForCameraUnwrapped`.

## AI assistance

- **Tools:** Cursor
- **Context:** Investigated https://github.com/maplibre/maplibre-native-ffi/issues/622 and updated the C and binding comments to describe the actual hulls.