### PR TITLE
Bound Linux CI apt downloads against a crawling Azure archive

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -112,6 +112,16 @@ runs:
     - name: Install sccache
       uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
+    # GitHub-hosted x64 runners prefer azure.archive.ubuntu.com. When that
+    # mirror crawls, apt keeps the connection instead of failing over, and
+    # `mise bootstrap`'s libclang-dev download sits in this action for tens
+    # of minutes. Bound idle fetches and wrap apt-get so a crawl demotes the
+    # Azure mirror and retries. ARM runners use ports.ubuntu.com instead.
+    - name: Bound apt downloads on Linux
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      run: bash "${GITHUB_ACTION_PATH}/bound-apt.sh"
+
     - name: Use Linux software graphics drivers
       if: ${{ runner.os == 'Linux' && startsWith(inputs.target, 'linux-') }}
       shell: bash

--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -115,8 +115,8 @@ runs:
     # GitHub-hosted x64 runners prefer azure.archive.ubuntu.com. When that
     # mirror crawls, apt keeps the connection instead of failing over, and
     # `mise bootstrap`'s libclang-dev download sits in this action for tens
-    # of minutes. Bound idle fetches and wrap apt-get so a crawl demotes the
-    # Azure mirror and retries. ARM runners use ports.ubuntu.com instead.
+    # of minutes. Demote Azure and bound idle fetches before any apt-get.
+    # ARM runners use ports.ubuntu.com instead.
     - name: Bound apt downloads on Linux
       if: ${{ runner.os == 'Linux' }}
       shell: bash

--- a/.github/actions/setup-ci-deps/bound-apt.sh
+++ b/.github/actions/setup-ci-deps/bound-apt.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# GitHub-hosted x64 runners list azure.archive.ubuntu.com at priority 1.
+# That mirror periodically serves at tens of kB/s without erroring, so apt
+# never fails over. mise bootstrap then spends tens of minutes on
+# libclang-dev (~29 MB) while ARM jobs (ports.ubuntu.com) finish the same
+# install in a second.
+#
+# Bound idle HTTP fetches, and wrap apt-get so a crawl is cut off, the Azure
+# mirror is demoted, and the call is retried against archive.ubuntu.com.
+# The wrapper sits on sudo's PATH ahead of /usr/bin/apt-get, so the explicit
+# installs below and `mise bootstrap` both pick it up.
+set -euo pipefail
+
+sudo tee /etc/apt/apt.conf.d/99ci-acquire >/dev/null <<'EOF'
+Acquire::Retries "5";
+Acquire::http::Timeout "20";
+Acquire::https::Timeout "20";
+Acquire::ForceIPv4 "true";
+DPkg::Lock::Timeout "60";
+Dpkg::Use-Pty "0";
+EOF
+
+wrapper="$(mktemp)"
+trap 'rm -f "${wrapper}"' EXIT
+cat >"${wrapper}" <<'EOF'
+#!/bin/bash
+set -u
+real=/usr/bin/apt-get
+timeout_sec="${MAPLIBRE_APT_GET_TIMEOUT:-120}"
+
+/usr/bin/timeout --foreground --signal=TERM --kill-after=15 "${timeout_sec}" "${real}" "$@"
+status=$?
+if [[ "${status}" -eq 0 ]]; then
+  exit 0
+fi
+if [[ "${status}" -ne 124 && "${status}" -ne 137 ]]; then
+  exit "${status}"
+fi
+
+echo "apt-get exceeded ${timeout_sec}s; demoting azure.archive.ubuntu.com and retrying" >&2
+if [[ -f /etc/apt/apt-mirrors.txt ]] && grep -q 'azure.archive.ubuntu.com' /etc/apt/apt-mirrors.txt; then
+  sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt
+  echo "apt mirrors after demote:" >&2
+  cat /etc/apt/apt-mirrors.txt >&2
+fi
+
+/usr/bin/timeout --foreground --signal=TERM --kill-after=15 180 "${real}" "$@"
+exit $?
+EOF
+
+sudo install -m0755 "${wrapper}" /usr/local/bin/apt-get
+
+echo "Wrote /etc/apt/apt.conf.d/99ci-acquire and /usr/local/bin/apt-get wrapper"
+if [[ -f /etc/apt/apt-mirrors.txt ]]; then
+  echo "Current apt mirrors:"
+  cat /etc/apt/apt-mirrors.txt
+fi

--- a/.github/actions/setup-ci-deps/bound-apt.sh
+++ b/.github/actions/setup-ci-deps/bound-apt.sh
@@ -5,10 +5,10 @@
 # libclang-dev (~29 MB) while ARM jobs (ports.ubuntu.com) finish the same
 # install in a second.
 #
-# Bound idle HTTP fetches, and wrap apt-get so a crawl is cut off, the Azure
-# mirror is demoted, and the call is retried against archive.ubuntu.com.
-# The wrapper sits on sudo's PATH ahead of /usr/bin/apt-get, so the explicit
-# installs below and `mise bootstrap` both pick it up.
+# Demote Azure before any apt-get so archive.ubuntu.com is tried first, and
+# bound idle HTTP fetches so a hung connection fails over instead of sitting
+# until the job timeout. Do not SIGTERM apt-get: interrupting dpkg mid-unpack
+# leaves the package database unusable.
 set -euo pipefail
 
 sudo tee /etc/apt/apt.conf.d/99ci-acquire >/dev/null <<'EOF'
@@ -20,37 +20,11 @@ DPkg::Lock::Timeout "60";
 Dpkg::Use-Pty "0";
 EOF
 
-wrapper="$(mktemp)"
-trap 'rm -f "${wrapper}"' EXIT
-cat >"${wrapper}" <<'EOF'
-#!/bin/bash
-set -u
-real=/usr/bin/apt-get
-timeout_sec="${MAPLIBRE_APT_GET_TIMEOUT:-120}"
-
-/usr/bin/timeout --foreground --signal=TERM --kill-after=15 "${timeout_sec}" "${real}" "$@"
-status=$?
-if [[ "${status}" -eq 0 ]]; then
-  exit 0
-fi
-if [[ "${status}" -ne 124 && "${status}" -ne 137 ]]; then
-  exit "${status}"
-fi
-
-echo "apt-get exceeded ${timeout_sec}s; demoting azure.archive.ubuntu.com and retrying" >&2
 if [[ -f /etc/apt/apt-mirrors.txt ]] && grep -q 'azure.archive.ubuntu.com' /etc/apt/apt-mirrors.txt; then
-  sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt
-  echo "apt mirrors after demote:" >&2
-  cat /etc/apt/apt-mirrors.txt >&2
+  sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt
 fi
 
-/usr/bin/timeout --foreground --signal=TERM --kill-after=15 180 "${real}" "$@"
-exit $?
-EOF
-
-sudo install -m0755 "${wrapper}" /usr/local/bin/apt-get
-
-echo "Wrote /etc/apt/apt.conf.d/99ci-acquire and /usr/local/bin/apt-get wrapper"
+echo "Wrote /etc/apt/apt.conf.d/99ci-acquire"
 if [[ -f /etc/apt/apt-mirrors.txt ]]; then
   echo "Current apt mirrors:"
   cat /etc/apt/apt-mirrors.txt

--- a/.mise/tasks/kotlin/publish
+++ b/.mise/tasks/kotlin/publish
@@ -191,10 +191,15 @@ publish_linux_leaves() {
     -Pkotlin.native.enableKlibsCrossCompilation=true \
     "${vulkan[@]}"
 
-  ./gradlew \
-    -Pkotlin.native.enableKlibsCrossCompilation=true \
-    -PmaplibreNativeCInstallDir="$install_root/linux-arm64-egl" \
-    :bindings:kotlin:linkDebugTestLinuxArm64
+  # linuxTest links libEGL from the host. The x64 Maven staging job
+  # cross-compiles linuxArm64 KLIBs above; ARM CI links and runs the tests
+  # natively on ubuntu-24.04-arm.
+  if [[ "$(uname -s)" == Linux && "$(uname -m)" == aarch64 ]]; then
+    ./gradlew \
+      -Pkotlin.native.enableKlibsCrossCompilation=true \
+      -PmaplibreNativeCInstallDir="$install_root/linux-arm64-egl" \
+      :bindings:kotlin:linkDebugTestLinuxArm64
+  fi
 }
 
 publish_apple_leaves() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bound Linux CI apt so a crawling Azure archive is demoted before install, after a 120s wrapper SIGTERM'd dpkg mid-unpack, and skip linuxArm64 Kotlin test linking on x64 Maven hosts that have no aarch64 libEGL.

## Test plan

Simulated the Azure priority demote locally; Linux `setup-ci-deps` and Kotlin Maven staging on this PR will exercise both fixes.

## AI assistance

- **Tools:** Cursor
- **Context:** Diagnosed from CI run 32169791957. `emscripten-wasm32-webgl` hit `dpkg was interrupted` after the apt-get wrapper timed out during libclang-18-dev unpack. `Kotlin Maven staging / linux` failed `linkDebugTestLinuxArm64` with `-lEGL`, also red on main after #636.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74acff4e-b1bf-4e5b-97d6-b0a25dd918d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74acff4e-b1bf-4e5b-97d6-b0a25dd918d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

