### PR TITLE
Document location-indicator accuracy radius in meters

### DIFF
--- a/bindings/dart/lib/src/runtime/runtime.dart
+++ b/bindings/dart/lib/src/runtime/runtime.dart
@@ -3357,7 +3357,7 @@ final class MapHandle {
     });
   }
 
-  /// Sets a location indicator layer accuracy radius in logical pixels.
+  /// Sets a location indicator layer accuracy radius in meters.
   void setLocationIndicatorAccuracyRadius(String layerId, double radius) {
     withNativeArena((arena) {
       final nativeLayerId = nativeStringView(layerId, arena);

--- a/bindings/dotnet/src/Maplibre.NativeFfi/Map/MapHandle.cs
+++ b/bindings/dotnet/src/Maplibre.NativeFfi/Map/MapHandle.cs
@@ -1655,7 +1655,7 @@ public sealed unsafe class MapHandle : IDisposable
         );
     }
 
-    /// <summary>Sets a location indicator layer accuracy radius in logical pixels.</summary>
+    /// <summary>Sets a location indicator layer accuracy radius in meters.</summary>
     public void SetLocationIndicatorAccuracyRadius(string layerId, double radius)
     {
         using var nativeLayerId = NativeStringView.From(layerId, nameof(layerId));

--- a/bindings/go/style.go
+++ b/bindings/go/style.go
@@ -1898,7 +1898,7 @@ func (m *MapHandle) SetLocationIndicatorBearing(layerID string, bearing float64)
 	})
 }
 
-// SetLocationIndicatorAccuracyRadius sets a location indicator layer accuracy radius.
+// SetLocationIndicatorAccuracyRadius sets a location indicator layer accuracy radius in meters.
 func (m *MapHandle) SetLocationIndicatorAccuracyRadius(layerID string, radius float64) error {
 	ptr, release, err := m.ptr()
 	if err != nil {

--- a/bindings/python/python/maplibre_native_ffi/map.py
+++ b/bindings/python/python/maplibre_native_ffi/map.py
@@ -871,7 +871,7 @@ class MapHandle(NativeHandleMixin):
         layer_id: str,
         radius: float,
     ) -> None:
-        """Set a location indicator layer accuracy radius in logical pixels."""
+        """Set a location indicator layer accuracy radius in meters."""
         self._native.set_location_indicator_accuracy_radius(layer_id, radius)
 
     def set_location_indicator_image_name(

--- a/bindings/rust/crates/maplibre-native-ffi/src/map/style.rs
+++ b/bindings/rust/crates/maplibre-native-ffi/src/map/style.rs
@@ -1123,7 +1123,7 @@ impl super::MapHandle {
         })
     }
 
-    /// Sets a location indicator layer accuracy radius in logical pixels.
+    /// Sets a location indicator layer accuracy radius in meters.
     pub fn set_location_indicator_accuracy_radius(
         &self,
         layer_id: &str,

--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -1644,7 +1644,7 @@ MLN_API mln_status mln_map_set_location_indicator_bearing(
 ) MLN_NOEXCEPT;
 
 /**
- * Sets a location indicator layer accuracy radius in logical pixels.
+ * Sets a location indicator layer accuracy radius in meters.
  *
  * Returns:
  * - MLN_STATUS_OK on success.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Correct the location-indicator accuracy radius unit from logical pixels to meters, matching MapLibre Native.

## Test plan

Confirmed MapLibre Native stores `accuracy-radius` as meters and grepped that no remaining accuracy-radius docs still say logical pixels.

## Sources

Issue [#649](https://github.com/maplibre/maplibre-native-ffi/issues/649). Vendored MapLibre Native is [`550f64be2232e09934ffc660a9acdbacff8b164a`](https://github.com/maplibre/maplibre-native/commit/550f64be2232e09934ffc660a9acdbacff8b164a).

- Style spec: `"units": "meters"` and “The accuracy, in meters, of the position source…” in [`scripts/style-spec.mjs`](https://github.com/maplibre/maplibre-native/blob/550f64be2232e09934ffc660a9acdbacff8b164a/scripts/style-spec.mjs#L109-L120) and the Android override in [`platform/android/scripts/android-style-spec-overrides.mjs`](https://github.com/maplibre/maplibre-native/blob/550f64be2232e09934ffc660a9acdbacff8b164a/platform/android/scripts/android-style-spec-overrides.mjs#L95-L111).
- Android SDK: [`LocationPropertyFactory.accuracyRadius`](https://github.com/maplibre/maplibre-native/blob/550f64be2232e09934ffc660a9acdbacff8b164a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationPropertyFactory.java#L112-L120) documents the same meter unit.
- Renderer: `style::AccuracyRadius` is stored as `parameters.errorRadiusMeters` in [`render_location_indicator_layer.cpp`](https://github.com/maplibre/maplibre-native/blob/550f64be2232e09934ffc660a9acdbacff8b164a/src/mbgl/renderer/layers/render_location_indicator_layer.cpp#L959-L961). The circle is built with `CheapRuler(..., Meters)` and `ruler.destination(centerPoint, params.errorRadiusMeters, …)` ([constructor](https://github.com/maplibre/maplibre-native/blob/550f64be2232e09934ffc660a9acdbacff8b164a/src/mbgl/renderer/layers/render_location_indicator_layer.cpp#L508-L509), [destination](https://github.com/maplibre/maplibre-native/blob/550f64be2232e09934ffc660a9acdbacff8b164a/src/mbgl/renderer/layers/render_location_indicator_layer.cpp#L604-L612)).
- This C API writes the value through as the `accuracy-radius` style property with no unit conversion (`src/map/map.cpp`).

Generated C API docs come from the header; Kotlin, Swift, and Zig had no unit wording to correct.

## AI assistance

- **Tools:** Cursor
- **Context:** Verified [#649](https://github.com/maplibre/maplibre-native-ffi/issues/649) against MapLibre Native sources and updated the C header plus handwritten binding docs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20619072-8a34-4541-aab6-8f65da83cebf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20619072-8a34-4541-aab6-8f65da83cebf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

