### PR TITLE
Force the submodule checkout in sync-submodules

### DIFF
--- a/.mise/bin/sync-submodules
+++ b/.mise/bin/sync-submodules
@@ -81,28 +81,23 @@ apply_mln_patches() {
   done
 }
 
-# `submodule update --checkout` refuses to move a worktree carrying local
-# changes, and leaves one alone entirely when the submodule already sits at the
-# pinned commit, so the files a patch touches are restored before the checkout
-# and the patch goes on again after.
+# The submodule worktrees below are managed rather than edited, so the update
+# runs with --force: it throws away local changes and checks out even when a
+# submodule already sits at its pinned commit. That is what puts a worktree
+# carrying an applied patch back on the pinned files before the patch goes on
+# again, whether the patch was since edited or dropped from the list entirely.
 #
-# Restoring those paths rather than reversing the patch is what handles an
-# edited patch: an earlier version of it is still applied, no longer reverses,
-# and would leave a stale hunk for the new version to fail against. Files that
-# no patch names are left where they are, so an unrelated local edit still fails
-# the checkout as it would have anyway.
-restore_mln_patch_paths() {
-  local patch path
+# Report what that discards, because a local edit made by hand goes with it.
+report_discarded_mln_changes() {
+  local changes
   if [[ ! -e "$mln_path/.git" ]]; then
     return 0
   fi
-  for patch in "${mln_patches[@]}"; do
-    # --numstat reads the patch alone, so it names the paths whatever state the
-    # worktree is in. Its columns are added, removed, path.
-    while IFS=$'\t' read -r _ _ path; do
-      git -C "$mln_path" checkout -- "$path"
-    done < <(git -C "$mln_path" apply --numstat "$patch")
-  done
+  changes="$(git -C "$mln_path" status --porcelain --untracked-files=no || true)"
+  if [[ -n "$changes" ]]; then
+    printf 'sync-submodules: discarding local changes in %s\n%s\n' \
+      "$mln_path" "$changes" >&2
+  fi
 }
 
 # Skipped by design (full MapLibre tree only): googletest, benchmark, cpp-httplib, args,
@@ -125,18 +120,18 @@ if [[ "$top_status" == " "* ]]; then
   fi
 fi
 
-restore_mln_patch_paths
+report_discarded_mln_changes
 
 git -c submodule.recurse=false submodule sync "$mln_path"
 # .gitmodules marks this submodule `update = none` so that Cargo and SwiftPM
 # skip it when resolving a git dependency on this repository. --checkout is the
 # opt back in for the builds that do need the source.
-git -c submodule.recurse=false submodule update --init --checkout --depth 1 "$mln_path"
+git -c submodule.recurse=false submodule update --init --checkout --force --depth 1 "$mln_path"
 
 apply_mln_patches
 
 git -C "$mln_path" -c submodule.recurse=false submodule sync "${vendor_paths[@]}"
-git -C "$mln_path" -c submodule.recurse=false submodule update --init --depth 1 "${vendor_paths[@]}"
+git -C "$mln_path" -c submodule.recurse=false submodule update --init --force --depth 1 "${vendor_paths[@]}"
 
 git -C "$mlt_path" -c submodule.recurse=false submodule sync "${mlt_vendor_paths[@]}"
-git -C "$mlt_path" -c submodule.recurse=false submodule update --init --depth 1 "${mlt_vendor_paths[@]}"
+git -C "$mlt_path" -c submodule.recurse=false submodule update --init --force --depth 1 "${mlt_vendor_paths[@]}"

--- a/.mise/bin/sync-submodules
+++ b/.mise/bin/sync-submodules
@@ -81,19 +81,41 @@ apply_mln_patches() {
   done
 }
 
+# A synced worktree is modified in exactly the paths that the listed patches
+# touch, so a tracked change anywhere else is an edit made by hand or a
+# leftover from a patch that has since left the list. A nested submodule
+# carrying tracked edits reports as modified too; untracked content inside
+# one is build noise, and stays ignored.
+mln_unexplained_paths() {
+  local patch patched path
+  patched="$(
+    for patch in "${mln_patches[@]}"; do
+      # --numstat reads the patch alone; its columns are added, removed, path.
+      git -C "$mln_path" apply --numstat "$patch" | cut -f3
+    done
+  )"
+  git -C "$mln_path" status --porcelain --untracked-files=no \
+    --ignore-submodules=untracked | cut -c4- |
+    while read -r path; do
+      grep -qxF "$path" <<<"$patched" || printf '%s\n' "$path"
+    done
+}
+
 # The submodule worktrees below are managed rather than edited, so the update
 # runs with --force: it throws away local changes and checks out even when a
 # submodule already sits at its pinned commit. That is what puts a worktree
 # carrying an applied patch back on the pinned files before the patch goes on
 # again, whether the patch was since edited or dropped from the list entirely.
 #
-# Report what that discards, because a local edit made by hand goes with it.
+# Report the paths that no listed patch accounts for, because an edit made by
+# hand goes with them. Paths that a patch does account for are routine: the
+# checkout resets them and the patch goes back on.
 report_discarded_mln_changes() {
   local changes
   if [[ ! -e "$mln_path/.git" ]]; then
     return 0
   fi
-  changes="$(git -C "$mln_path" status --porcelain --untracked-files=no || true)"
+  changes="$(mln_unexplained_paths)"
   if [[ -n "$changes" ]]; then
     printf 'sync-submodules: discarding local changes in %s\n%s\n' \
       "$mln_path" "$changes" >&2
@@ -114,7 +136,8 @@ if [[ "$top_status" == " "* ]]; then
     mlt_count="$(printf '%s\n' "$mlt_status" | sed '/^$/d' | wc -l | tr -d ' ')"
     if [[ "$mlt_count" == "${#mlt_vendor_paths[@]}" ]] &&
       ! grep -qE '^[+-U]' <<<"$mlt_status" &&
-      mln_patches_applied; then
+      mln_patches_applied &&
+      [[ -z "$(mln_unexplained_paths)" ]]; then
       exit 0
     fi
   fi

--- a/patches/maplibre-native/README.md
+++ b/patches/maplibre-native/README.md
@@ -15,9 +15,11 @@ resources whose paths contain spaces or non-ASCII characters.
 uses it to bound one pump's drain; the budget logic stays on the C API side, and
 an unset gate keeps upstream behavior.
 
-Drop a patch once the pin moves to a commit that carries it. Applying is
-idempotent, and the sync restores the files a patch touches before moving the
-submodule, so a pin bump and an edit to a patch both take effect on a worktree
-that already carries the old version. A patch that no longer applies fails the
-sync rather than being skipped. Each patch changes files that the pinned commit
-already has, because restoring a path is how the sync clears what it applied.
+Drop a patch once the pin moves to a commit that carries it. The sync checks out
+the pinned commit with `--force`, so it discards whatever the last sync applied
+before applying the list again. A pin bump, an edit to a patch, and a dropped
+patch all take effect on a worktree that still carries the old version. A patch
+that no longer applies fails the sync rather than being skipped.
+
+Local edits to the submodule worktree are discarded by the same checkout. The
+sync prints them first.

--- a/patches/maplibre-native/README.md
+++ b/patches/maplibre-native/README.md
@@ -21,5 +21,8 @@ before applying the list again. A pin bump, an edit to a patch, and a dropped
 patch all take effect on a worktree that still carries the old version. A patch
 that no longer applies fails the sync rather than being skipped.
 
-Local edits to the submodule worktree are discarded by the same checkout. The
-sync prints them first.
+Local edits to the submodule worktree, including edits inside a nested vendor
+submodule, are discarded by the same checkout, and a sync runs it whenever the
+worktree carries a tracked change that no listed patch accounts for. The sync
+prints those paths first. A forced checkout also removes an untracked file that
+sits where a new pin adds a tracked one.


### PR DESCRIPTION
## Summary

`sync-submodules` restored only the paths named by patches currently in the
list, so `vendor/dawn.cmake` — left modified by `0001`, dropped in #604 — blocked
the checkout on every later pin bump, and `mise deps` failed on any checkout
last synced before that. The update now runs with `--force`, which discards
local changes and checks out even when the pin already matches, and prints what
it discards.

## Test plan

Recreated the failure (submodule at the old `c8dad00b` pin with the retired
`0001` patch applied) and confirmed the sync repairs it to the pinned commit
with `0002` and `0003` reapplied, then exits on the fast path when run again.

## AI assistance

- **Tools:** Claude Code
- **Context:** diagnosed the failing `mise deps` and drafted the change and its
  comments.