### PR TITLE
Refresh the local OHOS plugin link after install

### DIFF
--- a/mise.ohos.toml
+++ b/mise.ohos.toml
@@ -3,19 +3,16 @@
 
 [tools]
 # mise has no registry entry for the OpenHarmony SDK, so this resolves through the
-# plugin the hook below registers. Its unpacking step needs a POSIX shell, which is
-# why Windows is left out.
+# plugin that the hook below registers. Its unpacking step needs a POSIX shell,
+# which is why Windows is left out.
 ohos-sdk = { version = "{{vars.ohos_sdk_version}}", os = ["linux", "macos"] }
 # Oniro publishes its emulator image against the corresponding OpenHarmony
 # release. Keep both tools on the same version so their system ABI stays aligned.
 "http:oniro-emulator" = { version = "{{vars.ohos_sdk_version}}", url = "https://github.com/eclipse-oniro4openharmony/device_board_oniro/releases/download/v{{ version }}/oniro_emulator.zip", checksum = "sha256:a30e01f1b161e0fdcd91263f30f29cc92bfa49c1776d5ee2c46caefef055b2da", size = "1449068188", bin_path = ".", os = ["linux", "macos"] }
 
 [hooks]
-# The OpenHarmony SDK plugin lives in the repository, and mise resolves a plugin
-# from its own directory, so registering the link is what makes `ohos-sdk` install.
-# Linking is a symlink, and re-linking is how a checkout that moves stops being
-# stale. Moving the plugin to its own repository later replaces this with a
-# `[plugins]` entry naming its URL.
+# Register the plugin before the first SDK installation resolves it. The root
+# postinstall hook refreshes the same symlink for ordinary installs.
 preinstall = [
   "mise plugins link --force ohos-sdk .mise/plugins/ohos-sdk",
 ]

--- a/mise.toml
+++ b/mise.toml
@@ -185,7 +185,11 @@ run = ".mise/bin/sync-rustls-platform-verifier"
 timeout = "2m"
 
 [hooks]
+# The OpenHarmony SDK plugin lives in the repository, and mise resolves a plugin
+# from its own directory. Refresh its checkout-dependent symlink before mise
+# inspects installed tool environments. The SDK remains opt-in through mise.ohos.toml.
 postinstall = [
+  "mise plugins link --force ohos-sdk .mise/plugins/ohos-sdk",
   "hk install --mise --quiet",
 ]
 


### PR DESCRIPTION
## Summary

Refresh the repository-local OpenHarmony SDK plugin link after ordinary mise installs so deleted worktree paths cannot leave a stale plugin registration.

## Test plan

Ran `mise install` twice, ran `mise -E ohos install`, verified the SDK toolchain and `hdc`, and checked both changed files with hk.

## AI assistance

- **Tools:** Codex
- **Context:** Codex diagnosed the stale plugin symlink, implemented the hook update, and ran the validation above.
