### PR TITLE
Bump compose-map to Compose Multiplatform 1.12.0

### DIFF
--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/ComposeNativeSurface.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/ComposeNativeSurface.kt
@@ -11,12 +11,15 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.LocalAwtWindow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import javax.swing.SwingUtilities
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 public fun ComposeNativeSurface(
   renderer: NativeSurfaceRenderer,
@@ -26,6 +29,8 @@ public fun ComposeNativeSurface(
   val internalController = rememberNativeSurfaceController()
   val activeController = controller ?: internalController
   val density = LocalDensity.current
+  val awtWindow =
+    checkNotNull(LocalAwtWindow.current) { "ComposeNativeSurface requires a parent AWT window" }
   val drawState = remember { NativeSurfaceDrawState() }
   var extent by remember { mutableStateOf(SurfaceExtent.Empty) }
   var frameRequest by remember { mutableLongStateOf(0L) }
@@ -39,6 +44,11 @@ public fun ComposeNativeSurface(
     }
   val nativeSurfaceState by activeController.state.collectAsState()
   val surfaceReady = nativeSurfaceState is NativeSurfaceState.Ready
+
+  DisposableEffect(awtWindow) {
+    SkikoHost.attachWindow(awtWindow)
+    onDispose { SkikoHost.detachWindow(awtWindow) }
+  }
 
   DisposableEffect(renderer) {
     val participant = DesktopNativeRenderingLifecycle.register { renderer.close() }

--- a/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/SkikoHost.kt
+++ b/examples/compose-map/src/main/kotlin/org/maplibre/nativeffi/examples/composemap/surface/SkikoHost.kt
@@ -34,7 +34,6 @@ import org.lwjgl.opengl.GL30.glGetInteger
 
 internal object SkikoHost {
   private const val SKIA_LAYER_CLASS = "org.jetbrains.skiko.SkiaLayer"
-  private const val COMPOSE_WINDOW_CLASS = "androidx.compose.ui.awt.ComposeWindow"
   private const val METAL_REDRAWER_CLASS = "org.jetbrains.skiko.redrawer.MetalRedrawer"
   private const val DIRECT3D_REDRAWER_CLASS = "org.jetbrains.skiko.redrawer.Direct3DRedrawer"
   private const val LINUX_OPENGL_REDRAWER_CLASS = "org.jetbrains.skiko.redrawer.LinuxOpenGLRedrawer"
@@ -48,12 +47,25 @@ internal object SkikoHost {
   private val direct3DPresenters = mutableMapOf<Long, Direct3DTexturePresenter>()
   private val openGlPresenters = mutableMapOf<Int, OpenGlTexturePresenter>()
   private var cachedSkiaLayer: Component? = null
+  private var boundWindow = WeakReference<Window>(null)
+
+  fun attachWindow(window: Window) {
+    boundWindow = WeakReference(window)
+    cachedSkiaLayer = null
+  }
+
+  fun detachWindow(window: Window) {
+    if (boundWindow.get() === window) {
+      boundWindow = WeakReference(null)
+      cachedSkiaLayer = null
+    }
+  }
 
   fun requireMetalDevice(): SkikoMetalDevice = onEdt {
     val layer =
       findSkiaLayer()
         ?: throw NativeSurfaceBridgeException(
-          "SkikoHost could not find a live $SKIA_LAYER_CLASS. ${describeWindows()}"
+          "SkikoHost could not find a live $SKIA_LAYER_CLASS. ${describeBoundWindow()}"
         )
     val contextHandler = requireMetalContextHandler(layer)
     val device =
@@ -81,7 +93,7 @@ internal object SkikoHost {
     val layer =
       findSkiaLayer()
         ?: throw NativeSurfaceBridgeException(
-          "SkikoHost could not find a live $SKIA_LAYER_CLASS. ${describeWindows()}"
+          "SkikoHost could not find a live $SKIA_LAYER_CLASS. ${describeBoundWindow()}"
         )
     val redrawer = requireDirect3DRedrawer(layer)
     val ptr =
@@ -167,7 +179,7 @@ internal object SkikoHost {
     val layer =
       findSkiaLayer()
         ?: throw NativeSurfaceBridgeException(
-          "SkikoHost could not find a live $SKIA_LAYER_CLASS. ${describeWindows()}"
+          "SkikoHost could not find a live $SKIA_LAYER_CLASS. ${describeBoundWindow()}"
         )
     readLinuxOpenGlContext(requireLinuxOpenGlRedrawer(layer))
   }
@@ -207,6 +219,7 @@ internal object SkikoHost {
     openGlPresenters.clear()
     glPresenters.forEach { it.close() }
     cachedSkiaLayer = null
+    boundWindow = WeakReference(null)
   }
 
   private fun findMetalContext(): DirectContext? = onEdt {
@@ -304,65 +317,44 @@ internal object SkikoHost {
     return redrawer
   }
 
-  // Walking every window's component tree is too expensive to repeat per frame, so the layer is
-  // remembered until AWT takes its peer away.
+  // The layer is remembered until AWT takes its peer away, so a bound window is not walked again
+  // on every frame.
   private fun findSkiaLayer(): Any? {
     cachedSkiaLayer?.let { cached ->
       if (cached.isDisplayable) {
         return cached
       }
     }
-    val layer = (findSkiaLayerComponent() ?: findComposeWindowSkiaLayer()) as Component?
+    val window = boundWindow.get()?.takeIf { it.isDisplayable } ?: return null
+    val layer = window.walkComponents().firstOrNull { isSkiaLayer(it) }
     cachedSkiaLayer = layer
     return layer
   }
 
-  private fun findSkiaLayerComponent(): Any? =
-    Window.getWindows()
-      .asSequence()
-      .filter { it.isDisplayable }
-      .flatMap { it.walkComponents() }
-      .firstOrNull { isSkiaLayer(it) }
-
-  private fun findComposeWindowSkiaLayer(): Any? =
-    Window.getWindows()
-      .asSequence()
-      .filter { it.isDisplayable && it.javaClass.name == COMPOSE_WINDOW_CLASS }
-      .mapNotNull { window ->
-        runCatching {
-            val composePanel = window.getField("composePanel") ?: return@mapNotNull null
-            val contentComponent =
-              composePanel.invokeDeclaredNoArg("getContentComponent") ?: return@mapNotNull null
-            if (isSkiaLayer(contentComponent)) {
-              contentComponent
-            } else {
-              (contentComponent as? Component)?.walkComponents()?.firstOrNull { isSkiaLayer(it) }
-            }
-          }
-          .getOrNull()
-      }
-      .firstOrNull()
-
   private fun isSkiaLayer(value: Any): Boolean = Class.forName(SKIA_LAYER_CLASS).isInstance(value)
 
-  private fun describeWindows(): String =
-    Window.getWindows().joinToString(prefix = "Windows: ", separator = " | ") { window ->
-      buildString {
-        append(window.javaClass.name)
-        append("(displayable=")
-        append(window.isDisplayable)
-        append(", showing=")
-        append(window.isShowing)
-        append(")")
-        append(" children=[")
-        append(
-          window.walkComponents().drop(1).take(12).joinToString { component ->
-            component.javaClass.name
-          }
-        )
-        append("]")
-      }
+  private fun describeBoundWindow(): String {
+    val window = boundWindow.get()
+    if (window == null) {
+      return "Bound AWT window: none"
     }
+    return buildString {
+      append("Bound AWT window: ")
+      append(window.javaClass.name)
+      append("(displayable=")
+      append(window.isDisplayable)
+      append(", showing=")
+      append(window.isShowing)
+      append(")")
+      append(" children=[")
+      append(
+        window.walkComponents().drop(1).take(12).joinToString { component ->
+          component.javaClass.name
+        }
+      )
+      append("]")
+    }
+  }
 
   private fun Component.walkComponents(): Sequence<Component> = sequence {
     yield(this@walkComponents)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.4.10"
-compose = "1.11.1"
+compose = "1.12.0"
 agp = "9.1.1"
 dokka = "2.2.0"
 maven-publish = "0.37.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump Compose Multiplatform from 1.11.1 to 1.12.0 and find the Skiko layer through `LocalAwtWindow` instead of scanning every AWT window.

## Test plan

Compiled and assembled `:examples:compose-map` against 1.12.0, and probed the 1.12 / Skiko 0.150.1 jars for every remaining reflected field and method.

## AI assistance

- **Tools:** Cursor
- **Context:** Reviewed the Compose Multiplatform 1.12.0 changelog and inspected Skiko 0.150.1 / ComposeWindow internals against `SkikoHost` reflection.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-756f49e5-4cf8-4bc0-8691-aff13712931d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-756f49e5-4cf8-4bc0-8691-aff13712931d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

