### PR TITLE
Define offline database merge contract

### DIFF
--- a/bindings/rust/crates/maplibre-native-ffi/src/runtime.rs
+++ b/bindings/rust/crates/maplibre-native-ffi/src/runtime.rs
@@ -1453,7 +1453,7 @@ mod tests {
 
     #[test]
     // Spec coverage: BND-084.
-    fn offline_region_merge_database_uses_real_c_abi() {
+    fn offline_region_merge_database_accepts_read_only_source_through_real_c_abi() {
         let base = TempDir::new("maplibre-rust-offline-merge");
         let main_cache = base.path().join("main.db");
         let side_cache = base.path().join("side.db");
@@ -1476,6 +1476,16 @@ mod tests {
             create.take().unwrap();
             side_runtime.close().unwrap();
         }
+        let side_database_before = std::fs::read(&side_cache).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = std::fs::metadata(&side_cache).unwrap().permissions();
+            permissions.set_mode(0o444);
+            std::fs::set_permissions(&side_cache, permissions).unwrap();
+        }
 
         let mut main_options = RuntimeOptions::default();
         main_options.cache_path = Some(main_cache.to_string_lossy().into_owned());
@@ -1494,6 +1504,7 @@ mod tests {
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].definition, definition);
         assert_eq!(merged[0].metadata, b"merge");
+        assert_eq!(std::fs::read(&side_cache).unwrap(), side_database_before);
         main_runtime.close().unwrap();
     }
 

--- a/cmake/mln_ffi_tests.cmake
+++ b/cmake/mln_ffi_tests.cmake
@@ -13,13 +13,17 @@
 function(mln_ffi_configure_browser_c_api_test)
   set(fixture_dir
       "${PROJECT_SOURCE_DIR}/third_party/maplibre-native/test/fixtures")
-  # Only the tile fixtures the suite decodes travel into the module. Embedding
-  # the whole fixtures tree would carry 81MB of unrelated render-test images.
+  # Embed only the fixtures that the suite reads. Embedding the whole fixture
+  # tree would carry 81MB of unrelated render-test images.
   file(GLOB_RECURSE embedded_fixtures RELATIVE "${fixture_dir}"
        CONFIGURE_DEPENDS "${fixture_dir}/*.mlt")
   if(NOT embedded_fixtures)
     message(FATAL_ERROR "no MLT tile fixtures found under ${fixture_dir}")
   endif()
+  if(NOT EXISTS "${fixture_dir}/offline_database/corrupt-immediate.db")
+    message(FATAL_ERROR "offline database fixture is missing")
+  endif()
+  list(APPEND embedded_fixtures "offline_database/corrupt-immediate.db")
   # SHELL: keeps each flag with its value: CMake deduplicates repeated link
   # options, which would otherwise collapse the second --embed-file and leave
   # its path standing alone as an input file.

--- a/docs/src/content/docs/guides/work-offline.mdx
+++ b/docs/src/content/docs/guides/work-offline.mdx
@@ -77,6 +77,22 @@ continues. Drain both from the runtime that owns the region, as described in
 Set the download state to inactive to pause. Set it to active to resume from the
 resources that MapLibre has stored.
 
+## Import downloaded regions
+
+A host can download a MapLibre offline database that another runtime prepared,
+then merge its regions into the runtime database. Keep the downloaded file
+present and unchanged until the merge completes. The file may be read-only.
+
+The databases must use the same MapLibre offline schema version. MBTiles uses a
+different schema, so load an MBTiles file through an `mbtiles://` source
+instead.
+
+The start call opens the downloaded database read-only. A missing or unreadable
+file fails immediately. The merge then copies the tiles and resources assigned
+to each region, combines duplicate region definitions, and leaves the downloaded
+file unchanged. Format, schema, and later filesystem errors arrive in the
+operation-completed event.
+
 ## Read what the database holds
 
 List the regions in the database to learn what an earlier run of the host

--- a/include/maplibre_native_c/map.h
+++ b/include/maplibre_native_c/map.h
@@ -498,15 +498,26 @@ MLN_API mln_status mln_runtime_offline_regions_list_start(
 ) MLN_NOEXCEPT;
 
 /**
- * Starts merging offline regions from another database path.
+ * Starts merging offline regions from another MapLibre offline database.
  *
- * The side database may be upgraded in place by native code and must be
- * writable when native merge requires it.
+ * side_database_path must identify an existing, readable MapLibre offline
+ * database whose schema version matches this library. The runtime opens the
+ * database read-only and leaves its contents unchanged. Keep the file present
+ * and unchanged until the operation completes.
+ *
+ * The merge copies only tiles and resources assigned to a region. It does not
+ * accept an MBTiles database, which uses a different schema.
+ *
+ * This function validates that the database can be opened read-only and copies
+ * side_database_path before returning. It does not inspect the schema
+ * synchronously. Format, schema, and later filesystem errors appear in the
+ * operation-completed event's result status and message.
  *
  * Returns:
  * - MLN_STATUS_OK when the operation was accepted and out_operation_id was set.
  * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live,
- *   side_database_path is null, or out_operation_id is null.
+ *   side_database_path is null, does not identify an existing readable
+ *   database file, or out_operation_id is null.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.

--- a/mise.toml
+++ b/mise.toml
@@ -321,7 +321,7 @@ elif [[ "$usage_preset" == tvos-simulator-* ]]; then
   mise run //:apple-simulator:boot tvOS
 elif [[ "$usage_preset" == ohos-x64-egl || "$usage_preset" == android-x64-* ]]; then
   # An emulator target runs the suite through a device shell rather than ctest,
-  # so the tile fixtures ctest would name by absolute source path are staged
+  # so the fixtures ctest would name by absolute source path are staged
   # into a directory the runner pushes to the device.
   platform=${usage_preset%%-*}
   fixture_source="$MISE_MONOREPO_ROOT/third_party/maplibre-native/test/fixtures"
@@ -331,7 +331,11 @@ elif [[ "$usage_preset" == ohos-x64-egl || "$usage_preset" == android-x64-* ]]; 
     destination="$fixture_dir/$relative_path"
     mkdir -p "$(dirname "$destination")"
     install -m 644 "$fixture" "$destination"
-  done < <(find "$fixture_source" -type f -name '*.mlt' -print0)
+  done < <(
+    find "$fixture_source" -type f \
+      \( -name '*.mlt' -o \
+      -path "$fixture_source/offline_database/corrupt-immediate.db" \) -print0
+  )
   export MLN_FFI_TEST_FIXTURE_DIR="$fixture_dir"
   if [[ "$platform" == ohos ]]; then
     exec "$MISE_MONOREPO_ROOT/scripts/run-ohos-emulator-test.sh" \

--- a/src/c_api/tests/resources_abi.c
+++ b/src/c_api/tests/resources_abi.c
@@ -341,6 +341,25 @@ static void offline_database_merge_rejects_a_missing_file(void) {
   mln_test_destroy_runtime(runtime);
 }
 
+static void offline_database_merge_rejects_sqlite_pseudo_paths(void) {
+  static const char* const pseudo_paths[] = {"", ":memory:", "file::memory:"};
+  mln_runtime runtime = mln_test_create_runtime();
+
+  for (size_t index = 0; index < sizeof(pseudo_paths) / sizeof(pseudo_paths[0]);
+       ++index) {
+    mln_offline_operation_id operation_id = 123;
+    TEST_ASSERT_EQUAL_INT(
+      MLN_STATUS_INVALID_ARGUMENT,
+      mln_runtime_offline_regions_merge_database_start(
+        runtime, pseudo_paths[index], &operation_id
+      )
+    );
+    TEST_ASSERT_EQUAL_UINT64(0, operation_id);
+  }
+
+  mln_test_destroy_runtime(runtime);
+}
+
 static void offline_take_rejects_mismatched_result_kind(void) {
   mln_runtime runtime = mln_test_create_runtime();
   const uint8_t metadata[] = {1, 2, 3};
@@ -1182,6 +1201,7 @@ void run_resources_abi_tests(void) {
   RUN_TEST(offline_regions_reject_raw_invalid_descriptors);
   RUN_TEST(offline_database_merge_rejects_raw_null_path);
   RUN_TEST(offline_database_merge_rejects_a_missing_file);
+  RUN_TEST(offline_database_merge_rejects_sqlite_pseudo_paths);
   RUN_TEST(offline_take_rejects_mismatched_result_kind);
   RUN_TEST(resource_transform_rejects_raw_invalid_descriptors);
   RUN_TEST(http_header_transform_registration_follows_the_transport);

--- a/src/c_api/tests/resources_abi.c
+++ b/src/c_api/tests/resources_abi.c
@@ -5,6 +5,7 @@
 
 #include <stdatomic.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "abi_tests.h"
@@ -313,6 +314,30 @@ static void offline_database_merge_rejects_raw_null_path(void) {
     )
   );
   TEST_ASSERT_EQUAL_UINT64(0, operation_id);
+  mln_test_destroy_runtime(runtime);
+}
+
+static void offline_database_merge_rejects_a_missing_file(void) {
+  static const char missing_path[] = "mln-ffi-missing-offline-side-database.db";
+  (void)remove(missing_path);
+
+  mln_runtime runtime = mln_test_create_runtime();
+  mln_offline_operation_id operation_id = 123;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_runtime_offline_regions_merge_database_start(
+      runtime, missing_path, &operation_id
+    )
+  );
+  TEST_ASSERT_EQUAL_UINT64(0, operation_id);
+  FILE* unexpected = fopen(missing_path, "rb");
+  TEST_ASSERT_NULL_MESSAGE(
+    unexpected, "The rejected merge created its missing side database."
+  );
+  if (unexpected != NULL) {
+    fclose(unexpected);
+    (void)remove(missing_path);
+  }
   mln_test_destroy_runtime(runtime);
 }
 
@@ -1156,6 +1181,7 @@ void run_resources_abi_tests(void) {
   RUN_TEST(set_maximum_ambient_cache_size_rejects_raw_null_output);
   RUN_TEST(offline_regions_reject_raw_invalid_descriptors);
   RUN_TEST(offline_database_merge_rejects_raw_null_path);
+  RUN_TEST(offline_database_merge_rejects_a_missing_file);
   RUN_TEST(offline_take_rejects_mismatched_result_kind);
   RUN_TEST(resource_transform_rejects_raw_invalid_descriptors);
   RUN_TEST(http_header_transform_registration_follows_the_transport);

--- a/src/c_api/tests/runtime_events_abi.c
+++ b/src/c_api/tests/runtime_events_abi.c
@@ -20,7 +20,6 @@ static const uint64_t unknown_mask_bit = UINT64_C(1) << 63U;
 static const size_t style_pump_attempts = 200;
 static const int64_t park_timeout_milliseconds = 200;
 static const uint64_t park_floor_milliseconds = 100;
-static const char missing_database_path[] = "does-not-exist.db";
 static const size_t take_result_attempts = 5000;
 
 // The record layout every binding probes. A host reads a batch as two byte
@@ -645,10 +644,15 @@ static void the_message_arena_carries_one_range_per_event(void) {
 // the take-result diagnostic carries the same text as the completion event.
 static void a_take_result_reports_the_operations_failure_text(void) {
   mln_runtime runtime = mln_test_create_runtime();
+  char invalid_database_path[1024];
+  TEST_ASSERT_TRUE(mln_test_fixture_path(
+    "offline_database/corrupt-immediate.db", invalid_database_path,
+    sizeof(invalid_database_path)
+  ));
   mln_offline_operation_id operation_id = 0;
   TEST_ASSERT_EQUAL_INT(
     MLN_STATUS_OK, mln_runtime_offline_regions_merge_database_start(
-                     runtime, missing_database_path, &operation_id
+                     runtime, invalid_database_path, &operation_id
                    )
   );
   TEST_ASSERT_NOT_EQUAL(0, operation_id);
@@ -665,7 +669,7 @@ static void a_take_result_reports_the_operations_failure_text(void) {
     );
   }
   TEST_ASSERT_TRUE_MESSAGE(
-    completed, "Merging a missing database should report completion."
+    completed, "Merging an invalid database should report completion."
   );
   TEST_ASSERT_EQUAL_UINT64(
     operation_id, event.payload.offline_operation_completed.operation_id
@@ -697,7 +701,7 @@ static void a_take_result_reports_the_operations_failure_text(void) {
   operation_id = 0;
   TEST_ASSERT_EQUAL_INT(
     MLN_STATUS_OK, mln_runtime_offline_regions_merge_database_start(
-                     runtime, missing_database_path, &operation_id
+                     runtime, invalid_database_path, &operation_id
                    )
   );
   bool reported = false;

--- a/src/c_api/tests/test_support.c
+++ b/src/c_api/tests/test_support.c
@@ -196,10 +196,9 @@ void mln_test_destroy_map(mln_map map) {
   untrack_map(map);
 }
 
-uint8_t* mln_test_read_fixture(const char* relative_path, size_t* out_size) {
-  if (out_size != NULL) {
-    *out_size = 0;
-  }
+bool mln_test_fixture_path(
+  const char* relative_path, char* out_path, size_t out_path_capacity
+) {
 #if defined(__EMSCRIPTEN__)
   // The browser suite embeds its fixtures in the module at a fixed virtual
   // path.
@@ -212,10 +211,17 @@ uint8_t* mln_test_read_fixture(const char* relative_path, size_t* out_size) {
   );
 #endif
 
-  char path[1024];
   const int written =
-    snprintf(path, sizeof(path), "%s/%s", fixture_dir, relative_path);
-  if (written < 0 || (size_t)written >= sizeof(path)) {
+    snprintf(out_path, out_path_capacity, "%s/%s", fixture_dir, relative_path);
+  return written >= 0 && (size_t)written < out_path_capacity;
+}
+
+uint8_t* mln_test_read_fixture(const char* relative_path, size_t* out_size) {
+  if (out_size != NULL) {
+    *out_size = 0;
+  }
+  char path[1024];
+  if (!mln_test_fixture_path(relative_path, path, sizeof(path))) {
     return NULL;
   }
 

--- a/src/c_api/tests/test_support.h
+++ b/src/c_api/tests/test_support.h
@@ -44,9 +44,15 @@ void mln_test_destroy_runtime(mln_runtime runtime);
 void mln_test_destroy_map(mln_map map);
 void mln_test_sleep_millisecond(void);
 
-// Reads relative_path under the directory named by MLN_FFI_TEST_FIXTURE_DIR,
-// which ctest sets. Returns malloc'd bytes the caller frees and sets *out_size,
-// or null when the file cannot be read.
+// Resolves relative_path under the fixture directory into out_path. Returns
+// false when out_path is too small.
+bool mln_test_fixture_path(
+  const char* relative_path, char* out_path, size_t out_path_capacity
+);
+
+// Reads relative_path under the fixture directory. On success, returns bytes
+// that the caller frees and writes their length to out_size. Returns null when
+// the file cannot be read.
 uint8_t* mln_test_read_fixture(const char* relative_path, size_t* out_size);
 
 bool mln_test_render_fixture_create(

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -29,6 +29,7 @@
 #include <mbgl/storage/offline.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/storage/response.hpp>
+#include <mbgl/storage/sqlite3.hpp>
 #include <mbgl/util/client_options.hpp>
 #include <mbgl/util/expected.hpp>
 #include <mbgl/util/geo.hpp>
@@ -1906,13 +1907,22 @@ auto offline_regions_merge_database_start(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
+  const auto path = std::string{side_database_path};
+  const auto side_database =
+    mapbox::sqlite::Database::tryOpen(path, mapbox::sqlite::ReadOnly);
+  if (std::holds_alternative<mapbox::sqlite::Exception>(side_database)) {
+    set_thread_error(
+      "side database path must identify an existing readable database file"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
   auto database = database_source_for_runtime(live);
   if (database == nullptr) {
     set_thread_error("database file source is unavailable");
     return MLN_STATUS_NATIVE_ERROR;
   }
 
-  const auto path = std::string{side_database_path};
   return schedule_registered_offline_operation(
     live, MLN_OFFLINE_OPERATION_REGIONS_MERGE_DATABASE,
     MLN_OFFLINE_OPERATION_RESULT_REGION_LIST, out_operation_id,

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstring>
 #include <exception>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -1908,6 +1909,16 @@ auto offline_regions_merge_database_start(
   }
 
   const auto path = std::string{side_database_path};
+  std::error_code filesystem_error;
+  if (
+    path.empty() || path.front() == ':' || path.compare(0, 5, "file:") == 0 ||
+    !std::filesystem::is_regular_file(path, filesystem_error)
+  ) {
+    set_thread_error(
+      "side database path must identify an existing readable database file"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
   const auto side_database =
     mapbox::sqlite::Database::tryOpen(path, mapbox::sqlite::ReadOnly);
   if (std::holds_alternative<mapbox::sqlite::Exception>(side_database)) {


### PR DESCRIPTION
## Summary

Open offline merge sources read-only before scheduling, reject missing or unreadable files synchronously, and document the MapLibre database and MBTiles boundary.

## Test plan

Run `mise run test`, `cargo fmt --all --check`, `mise run //docs:check-snippets`, and `pnpm exec astro build`.

## AI assistance

- **Tools:** Codex
- **Context:** Codex helped inspect the upstream SQLite path, implement validation and tests, and edit the documentation.