### PR TITLE
Route unconsumed log records to the platform logger on Android, Apple, and Windows

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,7 @@ Checks:
   - -readability-magic-numbers
 CheckOptions:
   - key: misc-include-cleaner.IgnoreHeaders
-    value: vulkan/.*
+    value: vulkan/.*;windows\.h;debugapi\.h
   - key: readability-braces-around-statements.ShortStatementLines
     value: 2
   - key: readability-identifier-length.IgnoredVariableNames

--- a/cmake/platform/android.cmake
+++ b/cmake/platform/android.cmake
@@ -1,5 +1,5 @@
 function(mln_ffi_configure_platform_dependencies target)
-  target_link_libraries(${target} INTERFACE android atomic z)
+  target_link_libraries(${target} INTERFACE android atomic log z)
   mln_ffi_bundle_clang_cxx_runtime(${target} "${CMAKE_ANDROID_NDK}/NOTICE")
   string(REGEX REPLACE "^android-" "" android_api_level "${ANDROID_PLATFORM}")
   # The emulator this repository boots runs x86_64 with SwiftShader drivers for
@@ -23,7 +23,7 @@ function(mln_ffi_configure_platform_dependencies target)
     ${target}
     PROPERTIES
       MLN_FFI_DEFAULT_LOGGING_STDERR
-      TRUE
+      FALSE
       MLN_FFI_DEFAULT_THREAD_LOCAL
       TRUE
       MLN_FFI_SHARED_SUPPORTED
@@ -58,6 +58,7 @@ function(mln_ffi_configure_platform target)
   set(MLN_FFI_ANDROID_SOURCES
       ${PROJECT_SOURCE_DIR}/src/platform/android/asset_file_source.cpp
       ${PROJECT_SOURCE_DIR}/src/platform/android/asset_manager.cpp
+      ${PROJECT_SOURCE_DIR}/src/platform/android/logging_logcat.cpp
       ${PROJECT_SOURCE_DIR}/src/platform/android/thread.cpp
       ${PROJECT_SOURCE_DIR}/src/platform/rust/http_file_source.cpp
       ${PROJECT_SOURCE_DIR}/src/platform/rust/image.cpp)

--- a/cmake/platform/apple.cmake
+++ b/cmake/platform/apple.cmake
@@ -47,7 +47,7 @@ function(mln_ffi_configure_platform_dependencies target)
   set_target_properties(
     ${target}
     PROPERTIES
-      MLN_FFI_DEFAULT_LOGGING_STDERR TRUE MLN_FFI_DEFAULT_THREAD_LOCAL TRUE
+      MLN_FFI_DEFAULT_LOGGING_STDERR FALSE MLN_FFI_DEFAULT_THREAD_LOCAL TRUE
       MLN_FFI_SHARED_SUPPORTED TRUE)
 
   mln_ffi_apple_is_simulator(MLN_FFI_APPLE_SIMULATOR)
@@ -133,6 +133,7 @@ function(mln_ffi_configure_platform target)
       ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../../src/platform/apple/http_file_source.mm
       ${MLN_FFI_SOURCE_DIR}/platform/darwin/core/image.mm
       ${MLN_FFI_SOURCE_DIR}/platform/darwin/core/local_glyph_rasterizer.mm
+      ${MLN_FFI_SOURCE_DIR}/platform/darwin/core/logging_nslog.mm
       ${MLN_FFI_SOURCE_DIR}/platform/darwin/core/native_apple_interface.m
       ${MLN_FFI_SOURCE_DIR}/platform/darwin/core/number_format.mm
       ${MLN_FFI_SOURCE_DIR}/platform/darwin/core/nsthread.mm

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -36,7 +36,7 @@ function(mln_ffi_configure_platform_dependencies target)
     ${target}
     PROPERTIES
       MLN_FFI_DEFAULT_LOGGING_STDERR
-      TRUE
+      FALSE
       MLN_FFI_DEFAULT_THREAD_LOCAL
       FALSE
       MLN_FFI_SHARED_SUPPORTED
@@ -88,7 +88,8 @@ function(mln_ffi_configure_platform target)
 
   set(MLN_FFI_WINDOWS_SOURCES
       ${PROJECT_SOURCE_DIR}/src/platform/rust/http_file_source.cpp
-      ${PROJECT_SOURCE_DIR}/src/platform/rust/image.cpp)
+      ${PROJECT_SOURCE_DIR}/src/platform/rust/image.cpp
+      ${PROJECT_SOURCE_DIR}/src/platform/windows/logging_debugger.cpp)
 
   mln_ffi_target_vendor_sources(${target} ${MLN_FFI_VENDOR_WINDOWS_SOURCES})
   mln_ffi_target_project_sources(${target} ${MLN_FFI_WINDOWS_SOURCES})

--- a/docs/src/content/docs/guides/capture-logs.mdx
+++ b/docs/src/content/docs/guides/capture-logs.mdx
@@ -10,8 +10,9 @@ import { region } from "../../../snippets";
 
 import logCallback from "../../../../snippets/c/log-callback.c?raw";
 
-MapLibre Native sends records to the platform logger by default. Android and
-Apple platforms use the system log; other platforms use the console. Install a
+MapLibre Native sends records to the platform logger by default: logcat on
+Android, the system log on Apple platforms, hilog on OpenHarmony, stderr and the
+debugger output stream on Windows, and stderr on Linux and Emscripten. Install a
 callback to send records to a host logger, file, crash reporter, or test.
 
 A record contains a severity, category, optional numeric code, and message. The

--- a/src/platform/android/logging_logcat.cpp
+++ b/src/platform/android/logging_logcat.cpp
@@ -1,9 +1,8 @@
 #include <string>
 
-#include <mbgl/util/enum.hpp>
-#include <mbgl/util/logging.hpp>
-
 #include <android/log.h>
+#include <mln/util/enum.hpp>
+#include <mln/util/logging.hpp>
 
 namespace mln {
 namespace {

--- a/src/platform/android/logging_logcat.cpp
+++ b/src/platform/android/logging_logcat.cpp
@@ -1,0 +1,39 @@
+#include <string>
+
+#include <mbgl/util/enum.hpp>
+#include <mbgl/util/logging.hpp>
+
+#include <android/log.h>
+
+namespace mln {
+namespace {
+
+constexpr char kMapLibreLogcatTag[] = "MapLibreNative";
+
+android_LogPriority logPriorityForSeverity(EventSeverity severity) {
+  switch (severity) {
+    case EventSeverity::Debug:
+      return ANDROID_LOG_DEBUG;
+    case EventSeverity::Info:
+      return ANDROID_LOG_INFO;
+    case EventSeverity::Warning:
+      return ANDROID_LOG_WARN;
+    case EventSeverity::Error:
+      return ANDROID_LOG_ERROR;
+    case EventSeverity::SeverityCount:
+      break;
+  }
+  return ANDROID_LOG_INFO;
+}
+
+}  // namespace
+
+void Log::platformRecord(EventSeverity severity, const std::string& msg) {
+  const auto message =
+    std::string("[") + Enum<EventSeverity>::toString(severity) + "] " + msg;
+  __android_log_write(
+    logPriorityForSeverity(severity), kMapLibreLogcatTag, message.c_str()
+  );
+}
+
+}  // namespace mln

--- a/src/platform/windows/logging_debugger.cpp
+++ b/src/platform/windows/logging_debugger.cpp
@@ -1,0 +1,28 @@
+#include <cstdio>
+#include <string>
+
+#include <mbgl/util/enum.hpp>
+#include <mbgl/util/logging.hpp>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
+namespace mln {
+
+// Console hosts read stderr, and GUI hosts have no console, so each record
+// also goes to the debugger output stream that Visual Studio and DebugView
+// show.
+void Log::platformRecord(EventSeverity severity, const std::string& msg) {
+  const auto message = std::string("[") +
+                       Enum<EventSeverity>::toString(severity) + "] " + msg +
+                       "\n";
+  std::fputs(message.c_str(), stderr);
+  OutputDebugStringA(message.c_str());
+}
+
+}  // namespace mln

--- a/src/platform/windows/logging_debugger.cpp
+++ b/src/platform/windows/logging_debugger.cpp
@@ -1,8 +1,8 @@
 #include <cstdio>
 #include <string>
 
-#include <mbgl/util/enum.hpp>
-#include <mbgl/util/logging.hpp>
+#include <mln/util/enum.hpp>
+#include <mln/util/logging.hpp>
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -13,6 +13,28 @@
 #include <windows.h>
 
 namespace mln {
+namespace {
+
+// The narrow debugger entry point decodes with the active code page, which
+// corrupts UTF-8 message text, so the record goes through the wide one.
+std::wstring utf16FromUtf8(const std::string& utf8) {
+  if (utf8.empty()) {
+    return {};
+  }
+  const int length = MultiByteToWideChar(
+    CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), nullptr, 0
+  );
+  if (length <= 0) {
+    return {};
+  }
+  std::wstring utf16(static_cast<size_t>(length), L'\0');
+  MultiByteToWideChar(
+    CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), utf16.data(), length
+  );
+  return utf16;
+}
+
+}  // namespace
 
 // Console hosts read stderr, and GUI hosts have no console, so each record
 // also goes to the debugger output stream that Visual Studio and DebugView
@@ -22,7 +44,7 @@ void Log::platformRecord(EventSeverity severity, const std::string& msg) {
                        Enum<EventSeverity>::toString(severity) + "] " + msg +
                        "\n";
   std::fputs(message.c_str(), stderr);
-  OutputDebugStringA(message.c_str());
+  OutputDebugStringW(utf16FromUtf8(message).c_str());
 }
 
 }  // namespace mln


### PR DESCRIPTION
## Summary

Unconsumed log records now go to logcat on Android, NSLog on Apple platforms, and stderr plus the debugger output stream on Windows instead of stderr everywhere, and the capture-logs guide states what each platform does. Fixes #679.

## Test plan

Built and tested the macOS host preset and built `android-arm64-vulkan` locally; the Windows sink was only syntax-checked on macOS, so the Windows CI job is the real verification.

## AI assistance

- **Tools:** Claude Code
- **Context:** Investigated the issue, implemented the Android and Apple sinks with subagents under adversarial review, and added the Windows sink; operated by @sargunv.