### PR TITLE
Reduce image pixel copies across language bindings

### DIFF
--- a/bindings/dart/lib/src/runtime/runtime_native_conversions.dart
+++ b/bindings/dart/lib/src/runtime/runtime_native_conversions.dart
@@ -12,9 +12,7 @@ raw.mln_premultiplied_rgba8_image _premultipliedRgba8ImageToNative(
   result.byte_length = bytes.length;
   if (bytes.isNotEmpty) {
     final nativeBytes = allocator<Uint8>(bytes.length);
-    for (var index = 0; index < bytes.length; index += 1) {
-      nativeBytes[index] = bytes[index];
-    }
+    nativeBytes.asTypedList(bytes.length).setAll(0, bytes);
     result.pixels = nativeBytes;
   }
   return result;

--- a/bindings/dotnet/src/Maplibre.NativeFfi/Internal/Struct/StyleStructs.cs
+++ b/bindings/dotnet/src/Maplibre.NativeFfi/Internal/Struct/StyleStructs.cs
@@ -210,9 +210,9 @@ internal sealed unsafe class NativeGeoJsonSourceOptions : IDisposable
 
 internal sealed unsafe class NativeStyleImage : IDisposable
 {
-    private readonly nint pixels;
+    private GCHandle pixels;
 
-    private NativeStyleImage(mln_premultiplied_rgba8_image value, nint pixels)
+    private NativeStyleImage(mln_premultiplied_rgba8_image value, GCHandle pixels)
     {
         Value = value;
         this.pixels = pixels;
@@ -223,40 +223,35 @@ internal sealed unsafe class NativeStyleImage : IDisposable
     internal static NativeStyleImage From(PremultipliedRgba8Image image)
     {
         ArgumentNullException.ThrowIfNull(image);
-        var bytes = image.Bytes ?? [];
-        var pixels = bytes.Length == 0 ? 0 : (nint)NativeMemory.Alloc((nuint)bytes.Length);
+        var bytes = image.BytesTransit;
+        var pixels = bytes.Length == 0 ? default : GCHandle.Alloc(bytes, GCHandleType.Pinned);
         try
         {
-            if (pixels != 0)
-            {
-                Marshal.Copy(bytes, 0, pixels, bytes.Length);
-            }
-
             var info = image.Info;
             var native = NativeMethods.mln_premultiplied_rgba8_image_default();
             native.width = info.Width;
             native.height = info.Height;
             native.stride = info.Stride;
             native.byte_length = (nuint)bytes.Length;
-            native.pixels = (byte*)pixels;
+            native.pixels = pixels.IsAllocated ? (byte*)pixels.AddrOfPinnedObject() : null;
             var result = new NativeStyleImage(native, pixels);
-            pixels = 0;
+            pixels = default;
             return result;
         }
         finally
         {
-            if (pixels != 0)
+            if (pixels.IsAllocated)
             {
-                NativeMemory.Free((void*)pixels);
+                pixels.Free();
             }
         }
     }
 
     public void Dispose()
     {
-        if (pixels != 0)
+        if (pixels.IsAllocated)
         {
-            NativeMemory.Free((void*)pixels);
+            pixels.Free();
         }
     }
 }

--- a/bindings/dotnet/src/Maplibre.NativeFfi/Render/RenderTypes.cs
+++ b/bindings/dotnet/src/Maplibre.NativeFfi/Render/RenderTypes.cs
@@ -107,6 +107,8 @@ public sealed record PremultipliedRgba8Image
 
     public byte[] Bytes => (byte[])bytes.Clone();
 
+    internal byte[] BytesTransit => bytes;
+
     public TextureImageInfo Info { get; }
 
     public bool Equals(PremultipliedRgba8Image? other) =>

--- a/bindings/dotnet/tests/Maplibre.NativeFfi.Tests/ValueStructTests.cs
+++ b/bindings/dotnet/tests/Maplibre.NativeFfi.Tests/ValueStructTests.cs
@@ -1,11 +1,27 @@
 using Maplibre.NativeFfi.Internal.C;
 using Maplibre.NativeFfi.Internal.Struct;
+using Maplibre.NativeFfi.Render;
 using Xunit;
 
 namespace Maplibre.NativeFfi.Tests;
 
 public sealed unsafe class ValueStructTests
 {
+    [Fact]
+    public void StyleImageBorrowsBackingPixelsAcrossCompactingCollection()
+    {
+        var image = new PremultipliedRgba8Image([1, 2, 3, 4], new TextureImageInfo(1, 1, 4, 4));
+        using var native = NativeStyleImage.From(image);
+
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+        fixed (byte* expected = image.BytesTransit)
+        {
+            Assert.Equal((nint)expected, (nint)native.Value.pixels);
+            Assert.Equal([1, 2, 3, 4], new ReadOnlySpan<byte>(native.Value.pixels, 4).ToArray());
+        }
+    }
+
     [BindingSpecTest("BND-066")]
     [Fact]
     public void BufferIsDestroyedWhenCopyingBytesFails()

--- a/bindings/go/style.go
+++ b/bindings/go/style.go
@@ -782,26 +782,26 @@ type StyleImageInfo struct {
 }
 
 type cPremultipliedRGBA8Image struct {
-	raw        C.mln_premultiplied_rgba8_image
-	allocation unsafe.Pointer
+	raw    C.mln_premultiplied_rgba8_image
+	pinner runtime.Pinner
 }
 
-func newCPremultipliedRGBA8Image(image PremultipliedRGBA8Image) cPremultipliedRGBA8Image {
-	raw := C.mln_premultiplied_rgba8_image_default()
-	raw.width = C.uint32_t(image.Width)
-	raw.height = C.uint32_t(image.Height)
-	raw.stride = C.uint32_t(image.Stride)
-	var allocation unsafe.Pointer
+func newCPremultipliedRGBA8Image(image PremultipliedRGBA8Image) *cPremultipliedRGBA8Image {
+	result := &cPremultipliedRGBA8Image{raw: C.mln_premultiplied_rgba8_image_default()}
+	result.raw.width = C.uint32_t(image.Width)
+	result.raw.height = C.uint32_t(image.Height)
+	result.raw.stride = C.uint32_t(image.Stride)
 	if len(image.Pixels) > 0 {
-		allocation = C.CBytes(image.Pixels)
-		raw.pixels = (*C.uint8_t)(allocation)
+		// The descriptor contains a Go pointer, so pin its backing array until C returns.
+		result.pinner.Pin(&image.Pixels[0])
+		result.raw.pixels = (*C.uint8_t)(unsafe.Pointer(&image.Pixels[0]))
 	}
-	raw.byte_length = C.size_t(len(image.Pixels))
-	return cPremultipliedRGBA8Image{raw: raw, allocation: allocation}
+	result.raw.byte_length = C.size_t(len(image.Pixels))
+	return result
 }
 
-func (image cPremultipliedRGBA8Image) free() {
-	C.free(image.allocation)
+func (image *cPremultipliedRGBA8Image) free() {
+	image.pinner.Unpin()
 }
 
 func styleImageInfoFromC(info C.mln_style_image_info) StyleImageInfo {

--- a/bindings/go/style_images_test.go
+++ b/bindings/go/style_images_test.go
@@ -2,8 +2,23 @@ package maplibre
 
 import (
 	"errors"
+	"runtime"
 	"testing"
+	"unsafe"
 )
+
+func TestStyleImageBorrowsPixelsAcrossGC(t *testing.T) {
+	pixels := []byte{1, 2, 3, 4}
+	image := newCPremultipliedRGBA8Image(PremultipliedRGBA8Image{Width: 1, Height: 1, Stride: 4, Pixels: pixels})
+	defer image.free()
+	runtime.GC()
+	if unsafe.Pointer(image.raw.pixels) != unsafe.Pointer(&pixels[0]) {
+		t.Fatal("native image does not borrow the backing pixels")
+	}
+	if got := unsafe.Slice((*byte)(unsafe.Pointer(image.raw.pixels)), 4); got[0] != 1 || got[3] != 4 {
+		t.Fatalf("borrowed pixels after GC = %v", got)
+	}
+}
 
 func TestNinePatchStyleImageRoundTripsStretchContentAndTextFit(t *testing.T) {
 	lockOSThreadForTest(t)

--- a/bindings/kotlin/src/androidDeviceTest/kotlin/org/maplibre/nativeffi/map/ImageUploadTest.kt
+++ b/bindings/kotlin/src/androidDeviceTest/kotlin/org/maplibre/nativeffi/map/ImageUploadTest.kt
@@ -1,0 +1,47 @@
+package org.maplibre.nativeffi.map
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import org.maplibre.nativeffi.error.InvalidArgumentException
+import org.maplibre.nativeffi.render.PremultipliedRgba8Image
+import org.maplibre.nativeffi.runtime.RuntimeHandle
+import org.maplibre.nativeffi.runtime.RuntimeOptions
+import org.maplibre.nativeffi.style.StyleImageOptions
+
+class ImageUploadTest {
+  @Test
+  fun paddedStyleImagesSurviveArrayReleaseAndCollection() {
+    RuntimeHandle.create(RuntimeOptions()).use { runtime ->
+      MapHandle.create(runtime, MapOptions().apply { mapMode = MapMode.STATIC }).use { map ->
+        map.setStyleJson("""{"version":8,"sources":{},"layers":[]}""".encodeToByteArray())
+        for (width in listOf(2, 128)) {
+          val expected = uploadImage(map, width)
+          System.gc()
+          val copied = assertNotNull(map.copyStyleImagePremultipliedRgba8("image"))
+          assertContentEquals(expected, copied.image.pixels)
+        }
+      }
+    }
+  }
+
+  private fun uploadImage(map: MapHandle, width: Int): ByteArray {
+    val rowBytes = width * 4
+    val stride = rowBytes + 8
+    val pixels = ByteArray(stride * width) { 99 }
+    val expected = ByteArray(rowBytes * width)
+    for (y in 0 until width) {
+      for (x in 0 until width) {
+        val color = byteArrayOf(x.toByte(), y.toByte(), 0, 255.toByte())
+        color.copyInto(pixels, y * stride + x * 4)
+        color.copyInto(expected, y * rowBytes + x * 4)
+      }
+    }
+    val image = PremultipliedRgba8Image(width, width, stride, pixels)
+    assertFailsWith<InvalidArgumentException> { map.setStyleImage("", image, StyleImageOptions()) }
+    map.setStyleImage("image", image, StyleImageOptions())
+    assertContentEquals(pixels, image.pixels)
+    return expected
+  }
+}

--- a/bindings/kotlin/src/androidMain/java/org/maplibre/nativeffi/internal/javacpp/AndroidNativeBridge.java
+++ b/bindings/kotlin/src/androidMain/java/org/maplibre/nativeffi/internal/javacpp/AndroidNativeBridge.java
@@ -1,15 +1,43 @@
 package org.maplibre.nativeffi.internal.javacpp;
 
+import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.annotation.Cast;
 import org.bytedeco.javacpp.annotation.Name;
+import org.bytedeco.javacpp.annotation.Platform;
 import org.bytedeco.javacpp.annotation.Properties;
 import org.bytedeco.javacpp.annotation.Raw;
 
-/** Android-only JavaCPP helpers that need direct JNI call context. */
-@Properties(inherit = MaplibreNativeCConfig.class)
+/** Android-only JavaCPP helpers for JNI context and borrowed arrays. */
+@Properties(
+    inherit = MaplibreNativeCConfig.class,
+    value = @Platform(include = "android_image_bridge.h"))
 public final class AndroidNativeBridge {
   private AndroidNativeBridge() {}
 
   @Name("mln_android_init")
   public static native @Cast("mln_status") int initialize(@Raw(withEnv = true) Object context);
+
+  @Name("mln_android_set_style_image")
+  public static native @Cast("mln_status") int setStyleImage(
+      @Cast("mln_map") long map,
+      @Cast("const mln_buffer_view*") Pointer imageId,
+      @Cast("const mln_premultiplied_rgba8_image*") Pointer image,
+      @Cast("const uint8_t*") byte[] pixels,
+      @Cast("const mln_style_image_options*") Pointer options);
+
+  @Name("mln_android_add_image_source_image")
+  public static native @Cast("mln_status") int addImageSourceImage(
+      @Cast("mln_map") long map,
+      @Cast("const mln_buffer_view*") Pointer sourceId,
+      @Cast("const mln_lat_lng*") Pointer coordinates,
+      @Cast("size_t") long coordinateCount,
+      @Cast("const mln_premultiplied_rgba8_image*") Pointer image,
+      @Cast("const uint8_t*") byte[] pixels);
+
+  @Name("mln_android_set_image_source_image")
+  public static native @Cast("mln_status") int setImageSourceImage(
+      @Cast("mln_map") long map,
+      @Cast("const mln_buffer_view*") Pointer sourceId,
+      @Cast("const mln_premultiplied_rgba8_image*") Pointer image,
+      @Cast("const uint8_t*") byte[] pixels);
 }

--- a/bindings/kotlin/src/androidMain/javacpp/android_image_bridge.h
+++ b/bindings/kotlin/src/androidMain/javacpp/android_image_bridge.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <maplibre_native_c/style.h>
+
+// JavaCPP borrows each const byte array with GetByteArrayElements and releases
+// it with JNI_ABORT after the C API has copied the accepted pixels.
+inline mln_status mln_android_set_style_image(
+  mln_map map, const mln_buffer_view* image_id,
+  const mln_premultiplied_rgba8_image* image, const uint8_t* pixels,
+  const mln_style_image_options* options
+) {
+  auto borrowed = *image;
+  borrowed.pixels = pixels;
+  return mln_map_set_style_image(map, *image_id, &borrowed, options);
+}
+
+inline mln_status mln_android_add_image_source_image(
+  mln_map map, const mln_buffer_view* source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count, const mln_premultiplied_rgba8_image* image,
+  const uint8_t* pixels
+) {
+  auto borrowed = *image;
+  borrowed.pixels = pixels;
+  return mln_map_add_image_source_image(
+    map, *source_id, coordinates, coordinate_count, &borrowed
+  );
+}
+
+inline mln_status mln_android_set_image_source_image(
+  mln_map map, const mln_buffer_view* source_id,
+  const mln_premultiplied_rgba8_image* image, const uint8_t* pixels
+) {
+  auto borrowed = *image;
+  borrowed.pixels = pixels;
+  return mln_map_set_image_source_image(map, *source_id, &borrowed);
+}

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -22,6 +22,7 @@ import org.maplibre.nativeffi.geo.Quaternion
 import org.maplibre.nativeffi.geo.ScreenPoint
 import org.maplibre.nativeffi.geo.Vec3
 import org.maplibre.nativeffi.internal.callback.CallbackGate
+import org.maplibre.nativeffi.internal.javacpp.AndroidNativeBridge
 import org.maplibre.nativeffi.internal.javacpp.ByteArrayViewScope
 import org.maplibre.nativeffi.internal.javacpp.GeoJsonSourceOptionsScope
 import org.maplibre.nativeffi.internal.javacpp.JavaCppSupport
@@ -605,10 +606,11 @@ private constructor(private val runtime: RuntimeHandle, private val handleId: Lo
       PremultipliedImageScope(image).use { nativeImage ->
         StyleImageOptionsScope(options).use { nativeOptions ->
           Status.check(
-            MaplibreNativeC.mln_map_set_style_image(
+            AndroidNativeBridge.setStyleImage(
               requireLiveHandle(),
               nativeImageId.view,
               nativeImage.image,
+              image.pixelsTransit,
               nativeOptions.options,
             )
           )
@@ -722,12 +724,13 @@ private constructor(private val runtime: RuntimeHandle, private val handleId: Lo
       LatLngArrayScope(coordinates).use { nativeCoordinates ->
         PremultipliedImageScope(image).use { nativeImage ->
           Status.check(
-            MaplibreNativeC.mln_map_add_image_source_image(
+            AndroidNativeBridge.addImageSourceImage(
               requireLiveHandle(),
               nativeSourceId.view,
               nativeCoordinates.coordinates,
               nativeCoordinates.count,
               nativeImage.image,
+              image.pixelsTransit,
             )
           )
         }
@@ -755,10 +758,11 @@ private constructor(private val runtime: RuntimeHandle, private val handleId: Lo
     StringViewScope(sourceId).use { nativeSourceId ->
       PremultipliedImageScope(image).use { nativeImage ->
         Status.check(
-          MaplibreNativeC.mln_map_set_image_source_image(
+          AndroidNativeBridge.setImageSourceImage(
             requireLiveHandle(),
             nativeSourceId.view,
             nativeImage.image,
+            image.pixelsTransit,
           )
         )
       }
@@ -3060,24 +3064,18 @@ private class ProjectionModeOptionsScope(value: ProjectionModeOptions) : AutoClo
 }
 
 private class PremultipliedImageScope(value: PremultipliedRgba8Image) : AutoCloseable {
-  private val pixels: BytePointer
   val image: MaplibreNativeC.mln_premultiplied_rgba8_image =
     MaplibreNativeC.mln_premultiplied_rgba8_image_default()
 
   init {
-    val bytes = value.pixelsTransit
-    pixels = BytePointer(bytes.size.toLong())
-    pixels.put(bytes, 0, bytes.size)
     image.width(value.width)
     image.height(value.height)
     image.stride(value.stride)
-    image.pixels(pixels)
-    image.byte_length(bytes.size.toLong())
+    image.byte_length(value.pixelsTransit.size.toLong())
   }
 
   override fun close() {
     image.close()
-    pixels.close()
   }
 }
 

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -3065,7 +3065,7 @@ private class PremultipliedImageScope(value: PremultipliedRgba8Image) : AutoClos
     MaplibreNativeC.mln_premultiplied_rgba8_image_default()
 
   init {
-    val bytes = value.pixels
+    val bytes = value.pixelsTransit
     pixels = BytePointer(bytes.size.toLong())
     pixels.put(bytes, 0, bytes.size)
     image.width(value.width)

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/PremultipliedRgba8Image.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/PremultipliedRgba8Image.kt
@@ -14,6 +14,9 @@ public class PremultipliedRgba8Image(
   public val pixels: ByteArray
     get() = pixelBytes.copyOf()
 
+  internal val pixelsTransit: ByteArray
+    get() = pixelBytes
+
   init {
     Status.requireArgument(width > 0 && height > 0) { "width and height must be positive" }
     Status.requireArgument(stride >= 0) { "stride must be non-negative" }

--- a/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/render/NativeBufferTest.kt
+++ b/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/render/NativeBufferTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import org.maplibre.nativeffi.error.InvalidArgumentException
 
 class NativeBufferTest {
   // BND-166.
@@ -40,5 +41,10 @@ class NativeBufferTest {
     assertContentEquals(byteArrayOf(1, 2, 3, 4), first)
     first[0] = 8
     assertContentEquals(byteArrayOf(1, 2, 3, 4), image.pixels)
+  }
+
+  @Test
+  fun premultipliedImageRejectsEmptyPixels() {
+    assertFailsWith<InvalidArgumentException> { PremultipliedRgba8Image(1, 1, 4, byteArrayOf()) }
   }
 }

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/loader/NativeAccess.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/loader/NativeAccess.kt
@@ -4328,7 +4328,7 @@ internal object NativeAccess {
   }
 
   private fun premultipliedRgba8Image(arena: Arena, value: PremultipliedRgba8Image): MemorySegment {
-    val pixels = value.pixels
+    val pixels = value.pixelsTransit
     val segment = MapLibreNativeC.mln_premultiplied_rgba8_image_default(arena)
     mln_premultiplied_rgba8_image.width(segment, value.width)
     mln_premultiplied_rgba8_image.height(segment, value.height)

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/internal/struct/StyleStructs.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/internal/struct/StyleStructs.kt
@@ -4,13 +4,15 @@ import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.MemScope
+import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.cValue
 import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
-import kotlinx.cinterop.toCValues
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.usePinned
 import kotlinx.cinterop.value
 import org.maplibre.nativeffi.geo.CanonicalTileId
 import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_BUFFER
@@ -108,18 +110,22 @@ internal object StyleStructs {
   fun canonicalTileId(value: mln_canonical_tile_id): CanonicalTileId =
     CanonicalTileId(checkedInt(value.z, "canonical tile z"), value.x.toLong(), value.y.toLong())
 
-  fun premultipliedRgba8Image(
+  fun withPremultipliedRgba8Image(
     value: PremultipliedRgba8Image,
     scope: MemScope,
-  ): CPointer<mln_premultiplied_rgba8_image> {
-    val native = scope.alloc<mln_premultiplied_rgba8_image>()
-    mln_premultiplied_rgba8_image_default().place(native.ptr)
-    native.width = value.width.toUInt()
-    native.height = value.height.toUInt()
-    native.stride = value.stride.toUInt()
-    native.pixels = value.pixels.toUByteArray().toCValues().getPointer(scope)
-    native.byte_length = value.pixels.size.toCSize()
-    return native.ptr
+    block: (CPointer<mln_premultiplied_rgba8_image>) -> Unit,
+  ) {
+    val pixels = value.pixelsTransit
+    pixels.usePinned { pinnedPixels ->
+      val native = scope.alloc<mln_premultiplied_rgba8_image>()
+      mln_premultiplied_rgba8_image_default().place(native.ptr)
+      native.width = value.width.toUInt()
+      native.height = value.height.toUInt()
+      native.stride = value.stride.toUInt()
+      native.pixels = pinnedPixels.addressOf(0).reinterpret()
+      native.byte_length = pixels.size.toCSize()
+      block(native.ptr)
+    }
   }
 
   fun styleImageOptions(

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -702,14 +702,16 @@ private constructor(private val runtime: RuntimeHandle, handle: NativeMap) : Aut
     options: StyleImageOptions,
   ) {
     memScoped {
-      Status.check(
-        mln_map_set_style_image(
-          state.requireLive().rawHandleValue,
-          CoreStructs.stringView(imageId, this),
-          StyleStructs.premultipliedRgba8Image(image, this),
-          StyleStructs.styleImageOptions(options, this),
+      StyleStructs.withPremultipliedRgba8Image(image, this) { nativeImage ->
+        Status.check(
+          mln_map_set_style_image(
+            state.requireLive().rawHandleValue,
+            CoreStructs.stringView(imageId, this),
+            nativeImage,
+            StyleStructs.styleImageOptions(options, this),
+          )
         )
-      )
+      }
     }
   }
 
@@ -849,15 +851,17 @@ private constructor(private val runtime: RuntimeHandle, handle: NativeMap) : Aut
   ) {
     val coordinateSnapshot = coordinates.toList()
     memScoped {
-      Status.check(
-        mln_map_add_image_source_image(
-          state.requireLive().rawHandleValue,
-          CoreStructs.stringView(sourceId, this),
-          CoreStructs.latLngArray(coordinateSnapshot, this),
-          coordinateSnapshot.size.toCSize(),
-          StyleStructs.premultipliedRgba8Image(image, this),
+      StyleStructs.withPremultipliedRgba8Image(image, this) { nativeImage ->
+        Status.check(
+          mln_map_add_image_source_image(
+            state.requireLive().rawHandleValue,
+            CoreStructs.stringView(sourceId, this),
+            CoreStructs.latLngArray(coordinateSnapshot, this),
+            coordinateSnapshot.size.toCSize(),
+            nativeImage,
+          )
         )
-      )
+      }
     }
   }
 
@@ -875,13 +879,15 @@ private constructor(private val runtime: RuntimeHandle, handle: NativeMap) : Aut
 
   public actual fun setImageSourceImage(sourceId: String, image: PremultipliedRgba8Image) {
     memScoped {
-      Status.check(
-        mln_map_set_image_source_image(
-          state.requireLive().rawHandleValue,
-          CoreStructs.stringView(sourceId, this),
-          StyleStructs.premultipliedRgba8Image(image, this),
+      StyleStructs.withPremultipliedRgba8Image(image, this) { nativeImage ->
+        Status.check(
+          mln_map_set_image_source_image(
+            state.requireLive().rawHandleValue,
+            CoreStructs.stringView(sourceId, this),
+            nativeImage,
+          )
         )
-      )
+      }
     }
   }
 

--- a/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/internal/struct/StyleStructsTest.kt
+++ b/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/internal/struct/StyleStructsTest.kt
@@ -6,12 +6,15 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.pointed
 import kotlinx.cinterop.ptr
+import kotlinx.cinterop.rawValue
 import kotlinx.cinterop.set
 import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.usePinned
 import org.maplibre.nativeffi.error.MaplibreStatus
 import org.maplibre.nativeffi.geo.LatLng
 import org.maplibre.nativeffi.geo.LatLngBounds
@@ -34,6 +37,7 @@ import org.maplibre.nativeffi.internal.lifecycle.SyntheticHandles
 import org.maplibre.nativeffi.internal.lifecycle.rawHandleValue
 import org.maplibre.nativeffi.internal.memory.CSizeVar
 import org.maplibre.nativeffi.internal.memory.toCSize
+import org.maplibre.nativeffi.render.PremultipliedRgba8Image
 import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.SourceType
 import org.maplibre.nativeffi.style.StyleImageOptions
@@ -42,6 +46,20 @@ import org.maplibre.nativeffi.style.TileSourceOptions
 @OptIn(ExperimentalForeignApi::class)
 class StyleStructsTest : org.maplibre.nativeffi.NativeTestBase() {
   // BND-060, BND-061, BND-062, BND-066.
+
+  @Test
+  fun premultipliedImageBorrowsBackingPixelsForBlock() {
+    val image = PremultipliedRgba8Image(1, 1, 4, byteArrayOf(1, 2, 3, 4))
+
+    image.pixelsTransit.usePinned { expectedPixels ->
+      memScoped {
+        StyleStructs.withPremultipliedRgba8Image(image, this) { nativeImage ->
+          assertEquals(expectedPixels.addressOf(0).rawValue, nativeImage.pointed.pixels?.rawValue)
+          assertEquals(4.toCSize(), nativeImage.pointed.byte_length)
+        }
+      }
+    }
+  }
 
   @Test
   fun styleOptionsInitializeDefaultsAndPresentZeroMasks() {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -9,6 +9,7 @@ use maplibre_native_ffi_sys as sys;
 use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyBytes, PyDict, PyList};
+use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::ffi::{c_char, c_void};
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -3424,7 +3425,7 @@ impl MapHandle {
         width: u32,
         height: u32,
         stride: u32,
-        pixels: Vec<u8>,
+        pixels: Cow<'_, [u8]>,
         pixel_ratio: Option<f32>,
         sdf: Option<bool>,
         stretch_x: Option<Vec<(f32, f32)>>,
@@ -3613,7 +3614,7 @@ impl MapHandle {
         width: u32,
         height: u32,
         stride: u32,
-        pixels: Vec<u8>,
+        pixels: Cow<'_, [u8]>,
     ) -> PyResult<()> {
         let state = self.state();
         let source_id = maplibre_core::string::string_view(&source_id);
@@ -3650,7 +3651,7 @@ impl MapHandle {
         width: u32,
         height: u32,
         stride: u32,
-        pixels: Vec<u8>,
+        pixels: Cow<'_, [u8]>,
     ) -> PyResult<()> {
         let state = self.state();
         let source_id = maplibre_core::string::string_view(&source_id);


### PR DESCRIPTION
## Summary

Reduce image-upload copies by pinning Kotlin/Native, Go, and .NET pixel storage, borrowing Android arrays through JNI and Python bytes, removing redundant Kotlin JVM clones, and using a bulk copy in Dart.

## Test plan

Local validation passed Kotlin JVM/macOS tests, 29 Android 16 ARM64 emulator tests with R8 minification, Go tests with strict pointer checks and vet, 203 .NET tests, 167 Python tests with 17 skips, 71 Dart tests and analysis, and commit hooks.

## AI assistance

- **Tools:** Codex
- **Context:** Codex traced the StreetComplete iOS image-upload samples, implemented the Kotlin change and cross-binding follow-ups, added lifetime tests, and ran local validation.
