### PR TITLE
Fix JVM exit deadlock in native logging

### DIFF
--- a/.mise/bin/sync-submodules
+++ b/.mise/bin/sync-submodules
@@ -59,6 +59,7 @@ mln_patches=(
   "$repo_root/patches/maplibre-native/0003-run-loop-process-gate.patch"
   "$repo_root/patches/maplibre-native/0004-opengl-valid-api-calls.patch"
   "$repo_root/patches/maplibre-native/0005-unwrapped-unprojection.patch"
+  "$repo_root/patches/maplibre-native/0006-process-lifetime-logging.patch"
 )
 
 # A patch counts as applied when it reverses cleanly, which is also what makes

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -279,8 +279,14 @@ tasks.configureEach {
 
 val hostNativeInstallConfigured = providers.gradleProperty("maplibreNativeCInstallDir").isPresent
 
+class TestClasspathArguments(@get:Classpath val classpath: FileCollection) :
+  CommandLineArgumentProvider {
+  override fun asArguments() = listOf("-Dorg.maplibre.nativeffi.test.classpath=${classpath.asPath}")
+}
+
 tasks.named<Test>("jvmTest") {
   jvmArgs("--enable-native-access=ALL-UNNAMED")
+  jvmArgumentProviders.add(TestClasspathArguments(classpath))
   systemProperty("org.maplibre.nativeffi.library.path", maplibreNativeC.libraryPath.absolutePath)
   systemProperty(
     "org.maplibre.nativeffi.library.dirs",

--- a/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/log/LogProcessExitTest.kt
+++ b/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/log/LogProcessExitTest.kt
@@ -1,0 +1,105 @@
+package org.maplibre.nativeffi.log
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.system.exitProcess
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.maplibre.nativeffi.Maplibre
+import org.maplibre.nativeffi.map.MapHandle
+import org.maplibre.nativeffi.map.MapOptions
+import org.maplibre.nativeffi.runtime.RuntimeHandle
+import org.maplibre.nativeffi.runtime.RuntimeOptions
+
+class LogProcessExitTest {
+  @Test fun jvmExitsWithNativeLogCallbackInstalled() = assertProcessExits("installed")
+
+  @Test fun jvmExitsAfterClearingNativeLogCallback() = assertProcessExits("cleared")
+
+  private fun assertProcessExits(callbackState: String) {
+    val outputFile = Files.createTempFile("maplibre-log-exit-", ".log")
+    try {
+      val javaExecutable =
+        if (System.getProperty("os.name").startsWith("Windows")) "java.exe" else "java"
+      val command =
+        mutableListOf(
+          Path.of(System.getProperty("java.home"), "bin", javaExecutable).toString(),
+          "--enable-native-access=ALL-UNNAMED",
+          "-cp",
+          requireNotNull(System.getProperty("org.maplibre.nativeffi.test.classpath")),
+        )
+      for (property in
+        listOf("org.maplibre.nativeffi.library.path", "org.maplibre.nativeffi.library.dirs")) {
+        System.getProperty(property)?.let { command += "-D$property=$it" }
+      }
+      command += listOf(LogProcessExitProbe::class.java.name, callbackState)
+      val process =
+        ProcessBuilder(command)
+          .redirectErrorStream(true)
+          .redirectOutput(outputFile.toFile())
+          .start()
+      try {
+        val exited = process.waitFor(20, TimeUnit.SECONDS)
+        val output = Files.readString(outputFile)
+        assertTrue(
+          output.lineSequence().any { it == READY_TO_EXIT },
+          "Child did not finish the asynchronous log callback and cleanup ($callbackState):\n$output",
+        )
+        assertTrue(exited, "JVM did not exit after native logging ($callbackState):\n$output")
+        assertEquals(0, process.exitValue(), output)
+      } finally {
+        if (process.isAlive) {
+          process.destroyForcibly()
+          check(process.waitFor(10, TimeUnit.SECONDS)) {
+            "Could not stop log test child ${process.pid()}"
+          }
+        }
+      }
+    } finally {
+      Files.deleteIfExists(outputFile)
+    }
+  }
+}
+
+object LogProcessExitProbe {
+  @JvmStatic
+  fun main(args: Array<String>) {
+    val callbackState = args.single()
+    require(callbackState == "installed" || callbackState == "cleared")
+    val caller = Thread.currentThread()
+    val callbackThread = AtomicReference<Thread>()
+    val received = CountDownLatch(1)
+    Maplibre.loadNativeLibrary()
+    Maplibre.setAsyncLogSeverities(setOf(LogSeverity.WARNING))
+    Maplibre.setLogCallback(
+      LogCallback { record ->
+        if (record.event == LogEvent.PARSE_STYLE && record.severity == LogSeverity.WARNING) {
+          callbackThread.set(Thread.currentThread())
+          received.countDown()
+        }
+        true
+      }
+    )
+    RuntimeHandle.create(RuntimeOptions()).use { runtime ->
+      MapHandle.create(runtime, MapOptions()).use { map ->
+        // An invalid center emits a native parser warning without network or rendering work.
+        map.setStyleJson(
+          """{"version":8,"center":false,"sources":{},"layers":[]}""".encodeToByteArray()
+        )
+        check(received.await(10, TimeUnit.SECONDS)) { "Native parser warning never reached Java" }
+        check(callbackThread.get() !== caller) { "Log callback ran synchronously" }
+      }
+    }
+    if (callbackState == "cleared") {
+      Maplibre.clearLogCallback()
+    }
+    println(READY_TO_EXIT)
+    exitProcess(0)
+  }
+}
+
+private const val READY_TO_EXIT = "Native log callback observed; requesting JVM exit"

--- a/patches/maplibre-native/0006-process-lifetime-logging.patch
+++ b/patches/maplibre-native/0006-process-lifetime-logging.patch
@@ -1,0 +1,84 @@
+diff --git a/src/mln/util/logging.cpp b/src/mln/util/logging.cpp
+--- a/src/mln/util/logging.cpp
++++ b/src/mln/util/logging.cpp
+@@ -5,6 +5,7 @@
+ #include <mln/util/platform.hpp>
+ #include <mln/util/traits.hpp>
+ 
++#include <atomic>
+ #include <cstdio>
+ #include <cstdarg>
+ #include <exception>
+@@ -15,15 +16,16 @@
+ 
+ namespace {
+ 
+-std::unique_ptr<Log::Observer> currentObserver;
+ constexpr auto SeverityCount = underlying_type(EventSeverity::SeverityCount);
+-std::atomic<bool> useThread[SeverityCount] = {true, true, true, false};
+-std::mutex mutex;
+ 
+ } // namespace
+ 
+ class Log::Impl {
+ public:
++    std::unique_ptr<Observer> observer;
++    std::atomic<bool> useThread[SeverityCount] = {true, true, true, false};
++    std::mutex mutex;
++
+     Impl()
+         : scheduler(Scheduler::GetSequenced()) {}
+ 
+@@ -53,13 +55,16 @@
+ Log::~Log() = default;
+ 
+ Log* Log::get() noexcept {
+-    static Log instance;
+-    return &instance;
++    // Keep the worker and the state it accesses alive until process termination.
++    // Joining it during static destruction can deadlock after a host VM shuts down
++    // because native thread-local cleanup may need to detach from that VM.
++    static auto* const instance = new Log();
++    return instance;
+ }
+ 
+ void Log::useLogThread(bool enable, std::optional<EventSeverity> severity) {
+     if (severity) {
+-        useThread[underlying_type(*severity)] = enable;
++        get()->impl->useThread[underlying_type(*severity)] = enable;
+     } else {
+         useLogThread(enable, EventSeverity::Debug);
+         useLogThread(enable, EventSeverity::Info);
+@@ -69,14 +74,16 @@
+ }
+ 
+ void Log::setObserver(std::unique_ptr<Observer> observer) {
+-    std::scoped_lock lock(mutex);
+-    currentObserver = std::move(observer);
++    auto& state = *get()->impl;
++    std::scoped_lock lock(state.mutex);
++    state.observer = std::move(observer);
+ }
+ 
+ std::unique_ptr<Log::Observer> Log::removeObserver() {
+-    std::scoped_lock lock(mutex);
++    auto& state = *get()->impl;
++    std::scoped_lock lock(state.mutex);
+     std::unique_ptr<Observer> observer;
+-    std::swap(observer, currentObserver);
++    std::swap(observer, state.observer);
+     return observer;
+ }
+ 
+@@ -93,8 +100,9 @@
+                  int64_t code,
+                  const std::string& msg,
+                  const std::optional<std::string>& threadName) {
+-    std::scoped_lock lock(mutex);
+-    if (currentObserver && severity != EventSeverity::Debug && currentObserver->onRecord(severity, event, code, msg)) {
++    auto& state = *get()->impl;
++    std::scoped_lock lock(state.mutex);
++    if (state.observer && severity != EventSeverity::Debug && state.observer->onRecord(severity, event, code, msg)) {
+         return;
+     }
+ 

--- a/patches/maplibre-native/README.md
+++ b/patches/maplibre-native/README.md
@@ -25,6 +25,12 @@ failures.
 standalone projection coordinate conversion. The C API uses them to expose
 continuous longitudes while the existing overloads keep wrapped behavior.
 
+`0006-process-lifetime-logging.patch` gives the global logger, its observer,
+mutex, severity settings, and scheduler process lifetime. This prevents static
+destruction from joining a logging worker whose thread-local cleanup must detach
+from an already shut down host VM. Explicit observer replacement and removal
+still release the previous observer.
+
 Drop a patch once the pin moves to a commit that carries it. The sync checks out
 the pinned commit with `--force`, so it discards whatever the last sync applied
 before applying the list again. A pin bump, an edit to a patch, and a dropped


### PR DESCRIPTION
## Summary

Keep native logging state alive for the process lifetime so JVM shutdown cannot deadlock while joining an FFM-attached logging worker.

## Test plan

Verified that both exit regressions fail before the fix and pass afterward, plus all 212 JVM tests, the C API suite, and targeted checks on macOS ARM64 Metal.

## AI assistance

- **Tools:** Codex
- **Context:** Audited the supplied diagnosis, implemented the logging lifetime patch and subprocess tests, and ran local validation under maintainer direction.
