### PR TITLE
Remove obsolete Rust entries from mise lockfile

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -1340,24 +1340,6 @@ components = "clippy,rust-src,rustfmt"
 profile = "minimal"
 targets = "aarch64-linux-android,aarch64-pc-windows-msvc,aarch64-unknown-linux-musl,aarch64-unknown-linux-ohos,armv7-linux-androideabi,wasm32-unknown-emscripten,x86_64-linux-android,x86_64-pc-windows-msvc,x86_64-unknown-linux-musl,x86_64-unknown-linux-ohos"
 
-[[tools.rust]]
-version = "1.95.0"
-backend = "core:rust"
-
-[tools.rust.options]
-components = "clippy,rust-src,rustfmt"
-profile = "minimal"
-targets = "aarch64-linux-android,aarch64-pc-windows-msvc,aarch64-unknown-linux-ohos,wasm32-unknown-emscripten,x86_64-linux-android,x86_64-pc-windows-msvc"
-
-[[tools.rust]]
-version = "1.95.0"
-backend = "core:rust"
-
-[tools.rust.options]
-components = "clippy,rust-src,rustfmt"
-profile = "minimal"
-targets = "aarch64-linux-android,aarch64-pc-windows-msvc,aarch64-unknown-linux-ohos,armv7-linux-androideabi,wasm32-unknown-emscripten,x86_64-linux-android,x86_64-pc-windows-msvc,x86_64-unknown-linux-ohos"
-
 [[tools.sccache]]
 version = "0.16.0"
 backend = "aqua:mozilla/sccache"


### PR DESCRIPTION
## Summary

Remove two obsolete Rust target configurations from `mise.lock` so setup preserves the committed lockfile.

## Test plan

Verified that `mise lock rust` and two `mise install rust` runs leave the lockfile byte-identical, that the remaining entry matches all configured Rust targets, and that pre-commit checks pass.

## AI assistance

- **Tools:** Codex
- **Context:** Investigated the setup diff, regenerated the Rust lock entry, validated stability, and drafted this PR.
