### PR TITLE
Add PR coverage tiers and platform opt-ins to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -20,15 +24,25 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  plan:
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    outputs:
+      tier: ${{ steps.plan.outputs.tier }}
+      expected: ${{ steps.plan.outputs.expected }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - id: plan
+        run: python3 .mise/tasks/ci/plan
+
   hygiene:
     name: hygiene
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -57,10 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -79,10 +90,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-linux-gnu-x64-egl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -169,10 +178,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-linux-gnu-x64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -261,10 +268,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-linux-gnu-arm64-egl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -351,10 +356,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-linux-gnu-arm64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -437,10 +440,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-linux-musl-x64-egl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -478,10 +479,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-linux-musl-x64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -519,10 +518,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-linux-musl-arm64-egl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -560,10 +557,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-linux-musl-arm64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -601,10 +596,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-emscripten-wasm32-webgl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -639,10 +632,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-emscripten-wasm32-webgpu'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -676,10 +667,8 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-macos-arm64-metal'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -762,10 +751,8 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-macos-arm64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -844,10 +831,8 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-macos-arm64-egl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -923,10 +908,8 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-ios-arm64-metal'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -971,10 +954,8 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-ios-simulator-arm64-metal'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1019,10 +1000,8 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-tvos-arm64-metal'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1061,10 +1040,8 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-tvos-simulator-arm64-metal'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1103,10 +1080,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-android-arm-egl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1157,10 +1132,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-android-arm-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1211,10 +1184,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-android-arm64-egl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1265,10 +1236,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-android-arm64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1319,10 +1288,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-android-x64-egl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1376,10 +1343,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-android-x64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1433,10 +1398,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-ohos-arm64-egl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1473,10 +1436,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-ohos-arm64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1513,10 +1474,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-ohos-x64-egl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1553,10 +1512,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-ohos-x64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1593,10 +1550,8 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-windows-x64-wgl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1670,10 +1625,8 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-windows-x64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1746,10 +1699,8 @@ jobs:
     runs-on: windows-11-arm
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-windows-arm64-wgl'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1804,10 +1755,8 @@ jobs:
     runs-on: windows-11-arm
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    needs: plan
+    if: fromJSON(needs.plan.outputs.expected)['target-windows-arm64-vulkan'] == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1861,11 +1810,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    if: fromJSON(needs.plan.outputs.expected)['android-multi'] == 'success'
     needs:
+      - plan
       - target-android-arm-egl
       - target-android-arm-vulkan
       - target-android-arm64-egl
@@ -1895,11 +1842,9 @@ jobs:
     permissions:
       actions: read
       contents: read
-    if: >-
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
+    if: fromJSON(needs.plan.outputs.expected)['kotlin-maven'] == 'success'
     needs:
+      - plan
       - target-linux-gnu-x64-egl
       - target-linux-gnu-x64-vulkan
       - target-linux-gnu-arm64-egl
@@ -1932,13 +1877,9 @@ jobs:
     name: ci-required
     runs-on: ubuntu-slim
     timeout-minutes: 5
-    if: >-
-      always() && (
-      github.event_name != 'pull_request'
-      || github.base_ref == 'main'
-      || github.event.pull_request.draft == false
-      )
+    if: always()
     needs:
+      - plan
       - hygiene
       - docs
       - target-linux-gnu-x64-egl
@@ -1975,9 +1916,18 @@ jobs:
       - android-multi
       - kotlin-maven
     steps:
-      - name: Fail if required jobs failed
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+      - name: Check selected job results
+        env:
+          EXPECTED: ${{ needs.plan.outputs.expected }}
+          RESULTS: ${{ toJSON(needs) }}
         run: |
-          echo '${{ toJSON(needs) }}'
-          exit 1
-      - run: "true"
+          echo "Needed job results: $RESULTS"
+          jq --exit-status --null-input \
+            --argjson expected "$EXPECTED" \
+            --argjson results "$RESULTS" '
+              ($expected.plan == "success")
+              and all($expected[]; . == "success" or . == "skipped")
+              and all($results[]; .result == "success" or .result == "skipped")
+              and (($expected | keys) == ($results | keys))
+              and all($expected | keys[]; $results[.].result == $expected[.])
+            '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,13 @@ jobs:
         with:
           persist-credentials: false
       - id: plan
-        run: python3 .mise/tasks/ci/plan
+        run: bash .mise/tasks/ci/plan
 
   hygiene:
     name: hygiene
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    needs: plan
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -71,7 +70,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    needs: plan
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -8,13 +8,12 @@ import pathlib
 import re
 import sys
 
-
 ROOT = pathlib.Path(__file__).resolve().parents[3]
 OUTPUT = ROOT / ".github" / "workflows" / "ci.yml"
 sys.path.insert(0, str(ROOT))
 
-from ci.action_pins import load_pins  # noqa: E402
-from ci.workflow import load_configuration, platform, target_rows  # noqa: E402
+from ci.action_pins import load_pins
+from ci.workflow import load_configuration, platform, target_rows
 
 # Pins come from `.github/workflows/action-pins.yml` so Dependabot updates them.
 PINS = load_pins(ROOT)
@@ -39,24 +38,9 @@ SCCACHE_ENVIRONMENT = (
     "    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}"
 )
 
-# Tall stacks put many pull requests in flight at once, so CI runs for pushes,
-# for pull requests that target `main`, and for pull requests that are ready for
-# review. A draft deeper in a stack waits until it retargets `main` or leaves
-# draft. Every event that reaches a gated-off job publishes a skipped
-# `ci-required` check, which counts as a satisfied required check, so the
-# trigger lists only events that create a pull request or move its head commit.
-GATE_CLAUSES = [
-    "github.event_name != 'pull_request'",
-    "|| github.base_ref == 'main'",
-    "|| github.event.pull_request.draft == false",
-]
 
-
-def gate(always: bool = False) -> list[str]:
-    clauses = [f"      {clause}" for clause in GATE_CLAUSES]
-    if always:
-        return ["    if: >-", "      always() && (", *clauses, "      )"]
-    return ["    if: >-", *clauses]
+def selected(job: str) -> str:
+    return f"    if: fromJSON(needs.plan.outputs.expected)['{job}'] == 'success'"
 
 
 def job_id(preset: str) -> str:
@@ -140,7 +124,8 @@ def target_job(row: dict[str, object]) -> list[str]:
         f"    runs-on: {row['runner']}",
         "    timeout-minutes: 120",
         SCCACHE_ENVIRONMENT,
-        *gate(),
+        "    needs: plan",
+        selected(job_id(preset)),
         "    steps:",
         *setup(
             preset,
@@ -216,17 +201,17 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "  push:",
         "    branches:",
         "      - main",
-        # No branch filter: a pull request stacked on another one bases on that
-        # branch rather than main, and a stack cannot be verified if only its
-        # first link runs CI. The job-level gate decides which of those links
-        # actually build, and `ready_for_review` lets a gated-off link start
-        # once it qualifies.
+        # Stacked PRs use the same readiness and label policy.
         "  pull_request:",
         "    types:",
         "      - opened",
         "      - synchronize",
         "      - reopened",
         "      - ready_for_review",
+        "      - converted_to_draft",
+        "      - labeled",
+        "      - unlabeled",
+        "  workflow_dispatch:",
         "",
         "permissions:",
         "  contents: read",
@@ -236,12 +221,25 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
         "",
         "jobs:",
+        "  plan:",
+        "    runs-on: ubuntu-slim",
+        "    timeout-minutes: 5",
+        "    outputs:",
+        "      tier: ${{ steps.plan.outputs.tier }}",
+        "      expected: ${{ steps.plan.outputs.expected }}",
+        "    steps:",
+        f"      - uses: {CHECKOUT}",
+        "        with:",
+        "          persist-credentials: false",
+        "      - id: plan",
+        "        run: python3 .mise/tasks/ci/plan",
+        "",
         "  hygiene:",
         "    name: hygiene",
         "    runs-on: ubuntu-latest",
         "    timeout-minutes: 30",
         SCCACHE_ENVIRONMENT,
-        *gate(),
+        "    needs: plan",
         "    steps:",
         *setup(gradle=False),
         "      - run: mise run ci:generate-workflow --check",
@@ -265,7 +263,7 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "    runs-on: ubuntu-latest",
         "    timeout-minutes: 60",
         SCCACHE_ENVIRONMENT,
-        *gate(),
+        "    needs: plan",
         "    steps:",
         # Dokka configures the Kotlin Multiplatform project, including the
         # Android target, so docs generation needs Gradle and an SDK platform.
@@ -286,8 +284,9 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
             "    runs-on: ubuntu-latest",
             "    timeout-minutes: 30",
             SCCACHE_ENVIRONMENT,
-            *gate(),
+            selected("android-multi"),
             "    needs:",
+            "      - plan",
             *[f"      - {job}" for job in android_package_ids],
             "    steps:",
             *setup("android-multi"),
@@ -320,8 +319,9 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
             "    permissions:",
             "      actions: read",
             "      contents: read",
-            *gate(),
+            selected("kotlin-maven"),
             "    needs:",
+            "      - plan",
             *[f"      - {job}" for job in kotlin_maven_needs],
             "    uses: ./.github/workflows/_kotlin-maven.yml",
             "    with:",
@@ -339,20 +339,30 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
             "    name: ci-required",
             "    runs-on: ubuntu-slim",
             "    timeout-minutes: 5",
-            *gate(always=True),
+            "    if: always()",
             "    needs:",
+            "      - plan",
             "      - hygiene",
             "      - docs",
             *[f"      - {job}" for job in target_ids],
             "      - android-multi",
             "      - kotlin-maven",
             "    steps:",
-            "      - name: Fail if required jobs failed",
-            "        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}",
+            "      - name: Check selected job results",
+            "        env:",
+            "          EXPECTED: ${{ needs.plan.outputs.expected }}",
+            "          RESULTS: ${{ toJSON(needs) }}",
             "        run: |",
-            "          echo '${{ toJSON(needs) }}'",
-            "          exit 1",
-            '      - run: "true"',
+            '          echo "Needed job results: $RESULTS"',
+            "          jq --exit-status --null-input \\",
+            '            --argjson expected "$EXPECTED" \\',
+            '            --argjson results "$RESULTS" \'',
+            '              ($expected.plan == "success")',
+            '              and all($expected[]; . == "success" or . == "skipped")',
+            '              and all($results[]; .result == "success" or .result == "skipped")',
+            "              and (($expected | keys) == ($results | keys))",
+            "              and all($expected | keys[]; $results[.].result == $expected[.])",
+            "            '",
             "",
         ]
     )

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -232,14 +232,13 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "        with:",
         "          persist-credentials: false",
         "      - id: plan",
-        "        run: python3 .mise/tasks/ci/plan",
+        "        run: bash .mise/tasks/ci/plan",
         "",
         "  hygiene:",
         "    name: hygiene",
         "    runs-on: ubuntu-latest",
         "    timeout-minutes: 30",
         SCCACHE_ENVIRONMENT,
-        "    needs: plan",
         "    steps:",
         *setup(gradle=False),
         "      - run: mise run ci:generate-workflow --check",
@@ -263,7 +262,6 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "    runs-on: ubuntu-latest",
         "    timeout-minutes: 60",
         SCCACHE_ENVIRONMENT,
-        "    needs: plan",
         "    steps:",
         # Dokka configures the Kotlin Multiplatform project, including the
         # Android target, so docs generation needs Gradle and an SDK platform.

--- a/.mise/tasks/ci/plan
+++ b/.mise/tasks/ci/plan
@@ -1,36 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/env bash
 # [MISE] description="Select CI coverage from the GitHub event."
-# [MISE] shell="python"
-
-import json
-import os
-import pathlib
-import sys
-
-ROOT = pathlib.Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(ROOT))
-
-from ci.pr_matrix import plan
-
-selection = plan(
-    os.environ["GITHUB_EVENT_NAME"],
-    json.loads(pathlib.Path(os.environ["GITHUB_EVENT_PATH"]).read_text()),
-)
-with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
-    for key, value in selection.items():
-        encoded = (
-            value
-            if isinstance(value, str)
-            else json.dumps(value, separators=(",", ":"))
-        )
-        print(f"{key}={encoded}", file=output)
-with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
-    print(f"CI tier: **{selection['tier']}**\n", file=summary)
-    print("Selected jobs (all required):\n", file=summary)
-    for job, result in selection["expected"].items():
-        if result == "success":
-            print(f"- `{job}`", file=summary)
-    print(
-        "\nPlatform labels expand coverage; `ci:full` includes all targets and packaging.",
-        file=summary,
-    )
+set -euo pipefail
+cd "${MISE_PROJECT_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+exec python3 -m ci.pr_matrix

--- a/.mise/tasks/ci/plan
+++ b/.mise/tasks/ci/plan
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# [MISE] description="Select CI coverage from the GitHub event."
+# [MISE] shell="python"
+
+import json
+import os
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+
+from ci.pr_matrix import plan
+
+selection = plan(
+    os.environ["GITHUB_EVENT_NAME"],
+    json.loads(pathlib.Path(os.environ["GITHUB_EVENT_PATH"]).read_text()),
+)
+with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+    for key, value in selection.items():
+        encoded = (
+            value
+            if isinstance(value, str)
+            else json.dumps(value, separators=(",", ":"))
+        )
+        print(f"{key}={encoded}", file=output)
+with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
+    print(f"CI tier: **{selection['tier']}**\n", file=summary)
+    print("Selected jobs (all required):\n", file=summary)
+    for job, result in selection["expected"].items():
+        if result == "success":
+            print(f"- `{job}`", file=summary)
+    print(
+        "\nPlatform labels expand coverage; `ci:full` includes all targets and packaging.",
+        file=summary,
+    )

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,28 @@ When you open a pull request, follow the repository PR template and write
 the PR description if more detail is needed. More context:
 [AI_POLICY.md](./AI_POLICY.md).
 
+Draft PRs run hygiene, docs, and the Linux x64 EGL/Vulkan targets with their
+binding suites. Ready PRs also run macOS Metal, Windows x64 WGL/Vulkan, Android
+x64 EGL/Vulkan, and browser WebGL/WebGPU. Main, manual runs, and
+Dependabot-authored PRs run every target and complete packaging verification.
+
+Use persistent PR labels to add coverage to either PR tier:
+
+| Label        | Additional coverage                                               |
+| ------------ | ----------------------------------------------------------------- |
+| `ci:apple`   | All macOS backends and iOS/tvOS device and simulator targets      |
+| `ci:android` | All Android ABIs/backends and multi-ABI packaging                 |
+| `ci:linux`   | Linux ARM64 and musl variants                                     |
+| `ci:windows` | Windows ARM64 variants                                            |
+| `ci:ohos`    | OpenHarmony targets and emulator tests                            |
+| `ci:full`    | Every target and complete packaging verification, including Maven |
+
+Labels combine and persist across pushes. Readiness and label changes start a
+new run. Every job selected by the planner must succeed for `ci-required` to
+pass; only jobs omitted by the plan may be skipped. For CI, ABI, shared
+toolchain, dependency, or publishing changes, request full coverage with
+`gh pr edit <number> --add-label 'ci:full'`.
+
 ## Project Invariants
 
 ### General

--- a/ci/pr_matrix.py
+++ b/ci/pr_matrix.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 import pathlib
 
 from ci.workflow import load_configuration, platform, preset_sets
@@ -62,3 +64,32 @@ def plan(event_name: str, event: dict) -> dict:
     )
     expected["kotlin-maven"] = "success" if tier == "full" else "skipped"
     return {"tier": tier, "expected": expected}
+
+
+def main() -> None:
+    selection = plan(
+        os.environ["GITHUB_EVENT_NAME"],
+        json.loads(pathlib.Path(os.environ["GITHUB_EVENT_PATH"]).read_text()),
+    )
+    with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+        for key, value in selection.items():
+            encoded = (
+                value
+                if isinstance(value, str)
+                else json.dumps(value, separators=(",", ":"))
+            )
+            print(f"{key}={encoded}", file=output)
+    with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
+        print(f"CI tier: **{selection['tier']}**\n", file=summary)
+        print("Selected jobs (all required):\n", file=summary)
+        for job, result in selection["expected"].items():
+            if result == "success":
+                print(f"- `{job}`", file=summary)
+        print(
+            "\nPlatform labels expand coverage; `ci:full` includes all targets and packaging.",
+            file=summary,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/pr_matrix.py
+++ b/ci/pr_matrix.py
@@ -1,0 +1,64 @@
+"""Select CI coverage from PR readiness and persistent platform labels."""
+
+from __future__ import annotations
+
+import pathlib
+
+from ci.workflow import load_configuration, platform, preset_sets
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DRAFT_TARGETS = {"linux-gnu-x64-egl", "linux-gnu-x64-vulkan"}
+READY_TARGETS = DRAFT_TARGETS | {
+    "macos-arm64-metal",
+    "windows-x64-wgl",
+    "windows-x64-vulkan",
+    "android-x64-egl",
+    "android-x64-vulkan",
+    "emscripten-wasm32-webgl",
+    "emscripten-wasm32-webgpu",
+}
+PLATFORM_GROUPS = {
+    "ci:apple": {"macos", "ios", "ios-simulator", "tvos", "tvos-simulator"},
+    "ci:android": {"android"},
+    "ci:linux": {"linux-gnu", "linux-musl"},
+    "ci:windows": {"windows"},
+    "ci:ohos": {"ohos"},
+}
+
+
+def plan(event_name: str, event: dict) -> dict:
+    if event_name not in {"pull_request", "push", "workflow_dispatch"}:
+        raise ValueError(f"Unsupported CI event: {event_name}")
+    tier = "full"
+    labels = set()
+    if event_name == "pull_request":
+        # Use authorship so maintainer label events preserve Dependabot coverage.
+        pr = event["pull_request"]
+        labels = {label["name"] for label in pr["labels"]}
+        if pr["user"]["login"] != "dependabot[bot]" and "ci:full" not in labels:
+            tier = "draft" if pr["draft"] else "ready"
+
+    _, presets = load_configuration(ROOT)
+    targets, _, _, _ = preset_sets(presets)
+    if not READY_TARGETS <= set(targets):
+        raise ValueError("CI coverage references an unknown native target")
+    selected = (
+        set(targets)
+        if tier == "full"
+        else set(DRAFT_TARGETS if tier == "draft" else READY_TARGETS)
+    )
+    for label in labels & PLATFORM_GROUPS.keys():
+        selected.update(t for t in targets if platform(t) in PLATFORM_GROUPS[label])
+
+    expected = dict.fromkeys(["plan", "hygiene", "docs"], "success")
+    expected.update(
+        {
+            f"target-{target}": "success" if target in selected else "skipped"
+            for target in targets
+        }
+    )
+    expected["android-multi"] = (
+        "success" if tier == "full" or "ci:android" in labels else "skipped"
+    )
+    expected["kotlin-maven"] = "success" if tier == "full" else "skipped"
+    return {"tier": tier, "expected": expected}

--- a/ci/tests/test_pr_matrix.py
+++ b/ci/tests/test_pr_matrix.py
@@ -8,7 +8,6 @@ import os
 import pathlib
 import re
 import subprocess
-import sys
 import tempfile
 import textwrap
 import unittest
@@ -105,6 +104,8 @@ class CoverageTest(unittest.TestCase):
             re.findall(r"^      - ([\w-]+)$", blocks["required"], re.MULTILINE)
         )
         self.assertEqual(required_needs, set(full))
+        for job in ("hygiene", "docs"):
+            self.assertNotIn("needs:", blocks[job])
         for count in range(len(PLATFORM_GROUPS) + 1):
             for labels in itertools.combinations(PLATFORM_GROUPS, count):
                 expected = plan("pull_request", pr(True, labels))["expected"]
@@ -142,16 +143,17 @@ class CoverageTest(unittest.TestCase):
             expected = plan("pull_request", pr(True, (label,)))["expected"]
             self.assertEqual(expected[f"target-{representative}"], "success")
 
-    def test_event_entrypoint_emits_the_plan_and_workflow_handles_tier_changes(self):
+    def test_entrypoint_runs_outside_checkout_and_emits_the_plan(self):
         event = pr(True, ("ci:apple", "ci:android"))
         with tempfile.TemporaryDirectory() as directory:
             root = pathlib.Path(directory)
             (root / "event").write_text(json.dumps(event))
             subprocess.run(
-                [sys.executable, str(ROOT / ".mise/tasks/ci/plan")],
+                ["bash", str(ROOT / ".mise/tasks/ci/plan")],
+                cwd=root,
                 check=True,
                 env={
-                    **os.environ,
+                    "PATH": os.environ["PATH"],
                     "GITHUB_EVENT_NAME": "pull_request",
                     "GITHUB_EVENT_PATH": str(root / "event"),
                     "GITHUB_OUTPUT": str(root / "output"),

--- a/ci/tests/test_pr_matrix.py
+++ b/ci/tests/test_pr_matrix.py
@@ -1,0 +1,240 @@
+"""Exercise coverage transitions, workflow dependencies, and the merge gate."""
+
+from __future__ import annotations
+
+import itertools
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+from ci.pr_matrix import PLATFORM_GROUPS, plan
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/ci.yml"
+
+
+def pr(draft=False, labels=(), author="contributor", action="synchronize"):
+    return {
+        "action": action,
+        "sender": {"login": "maintainer"},
+        "pull_request": {
+            "draft": draft,
+            "labels": [{"name": label} for label in labels],
+            "user": {"login": author},
+        },
+    }
+
+
+class CoverageTest(unittest.TestCase):
+    def test_readiness_and_labels_expand_and_restore_coverage(self):
+        draft = plan("pull_request", pr(True))["expected"]
+        ready = plan("pull_request", pr(action="ready_for_review"))["expected"]
+        draft_targets = {
+            k for k, v in draft.items() if k.startswith("target-") and v == "success"
+        }
+        ready_targets = {
+            k for k, v in ready.items() if k.startswith("target-") and v == "success"
+        }
+        self.assertEqual(
+            draft_targets, {"target-linux-gnu-x64-egl", "target-linux-gnu-x64-vulkan"}
+        )
+        self.assertEqual(
+            ready_targets - draft_targets,
+            {
+                "target-macos-arm64-metal",
+                "target-windows-x64-wgl",
+                "target-windows-x64-vulkan",
+                "target-android-x64-egl",
+                "target-android-x64-vulkan",
+                "target-emscripten-wasm32-webgl",
+                "target-emscripten-wasm32-webgpu",
+            },
+        )
+        for draft_state in (True, False):
+            for action in (
+                "labeled",
+                "synchronize",
+                "converted_to_draft",
+                "ready_for_review",
+            ):
+                full = plan(
+                    "pull_request", pr(draft_state, ("ci:full",), action=action)
+                )
+                self.assertEqual(full["tier"], "full")
+                self.assertEqual(set(full["expected"].values()), {"success"})
+            removed = plan(
+                "pull_request", pr(draft_state, ("unrelated",), action="unlabeled")
+            )
+            self.assertEqual(removed["expected"], draft if draft_state else ready)
+
+    def test_dependabot_authorship_main_and_manual_always_select_full(self):
+        for name, event in [
+            ("push", {}),
+            ("workflow_dispatch", {}),
+            ("pull_request", pr(True, author="dependabot[bot]", action="unlabeled")),
+            ("pull_request", pr(False, author="dependabot[bot]")),
+        ]:
+            selection = plan(name, event)
+            self.assertEqual(selection["tier"], "full")
+            self.assertEqual(set(selection["expected"].values()), {"success"})
+        event = pr(True)
+        event["sender"]["login"] = "dependabot[bot]"
+        self.assertEqual(plan("pull_request", event)["tier"], "draft")
+        for invalid in ({}, {"pull_request": {}}, {"pull_request": {"labels": []}}):
+            with self.assertRaises(KeyError):
+                plan("pull_request", invalid)
+
+    def test_platform_groups_combine_and_satisfy_packaging_dependencies(self):
+        workflow = WORKFLOW.read_text()
+        blocks = dict(
+            re.findall(
+                r"^  ([\w-]+):\n(.*?)(?=^  [\w-]+:|\Z)",
+                workflow.split("jobs:\n", 1)[1],
+                re.MULTILINE | re.DOTALL,
+            )
+        )
+        full = plan("push", {})["expected"]
+        self.assertEqual(set(full), set(blocks) - {"required"})
+        required_needs = set(
+            re.findall(r"^      - ([\w-]+)$", blocks["required"], re.MULTILINE)
+        )
+        self.assertEqual(required_needs, set(full))
+        for count in range(len(PLATFORM_GROUPS) + 1):
+            for labels in itertools.combinations(PLATFORM_GROUPS, count):
+                expected = plan("pull_request", pr(True, labels))["expected"]
+                for job, wanted in expected.items():
+                    block = blocks[job]
+                    if job.startswith("target-") or job in {
+                        "android-multi",
+                        "kotlin-maven",
+                    }:
+                        self.assertIn(
+                            f"if: fromJSON(needs.plan.outputs.expected)['{job}'] == 'success'",
+                            block,
+                        )
+                    if wanted == "success":
+                        for dependency in re.findall(
+                            r"^      - ([\w-]+)$", block, re.MULTILINE
+                        ):
+                            self.assertEqual(
+                                expected[dependency],
+                                "success",
+                                (labels, job, dependency),
+                            )
+                self.assertEqual(expected["kotlin-maven"], "skipped")
+                self.assertEqual(
+                    expected["android-multi"],
+                    "success" if "ci:android" in labels else "skipped",
+                )
+        for label, representative in {
+            "ci:apple": "tvos-simulator-arm64-metal",
+            "ci:android": "android-arm-egl",
+            "ci:linux": "linux-musl-arm64-vulkan",
+            "ci:windows": "windows-arm64-wgl",
+            "ci:ohos": "ohos-x64-egl",
+        }.items():
+            expected = plan("pull_request", pr(True, (label,)))["expected"]
+            self.assertEqual(expected[f"target-{representative}"], "success")
+
+    def test_event_entrypoint_emits_the_plan_and_workflow_handles_tier_changes(self):
+        event = pr(True, ("ci:apple", "ci:android"))
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "event").write_text(json.dumps(event))
+            subprocess.run(
+                [sys.executable, str(ROOT / ".mise/tasks/ci/plan")],
+                check=True,
+                env={
+                    **os.environ,
+                    "GITHUB_EVENT_NAME": "pull_request",
+                    "GITHUB_EVENT_PATH": str(root / "event"),
+                    "GITHUB_OUTPUT": str(root / "output"),
+                    "GITHUB_STEP_SUMMARY": str(root / "summary"),
+                },
+            )
+            outputs = dict(
+                line.split("=", 1)
+                for line in (root / "output").read_text().splitlines()
+            )
+            self.assertEqual(
+                json.loads(outputs["expected"]), plan("pull_request", event)["expected"]
+            )
+            self.assertIn("target-ios-arm64-metal", (root / "summary").read_text())
+        events = (
+            WORKFLOW.read_text()
+            .split("  pull_request:\n", 1)[1]
+            .split("  workflow_dispatch:", 1)[0]
+        )
+        for action in (
+            "opened",
+            "synchronize",
+            "reopened",
+            "ready_for_review",
+            "converted_to_draft",
+            "labeled",
+            "unlabeled",
+        ):
+            self.assertIn(f"      - {action}\n", events)
+
+
+class RequiredCheckTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        block = WORKFLOW.read_text().split(
+            "      - name: Check selected job results\n", 1
+        )[1]
+        cls.script = textwrap.dedent(block.split("        run: |\n", 1)[1])
+
+    def accepts(self, expected, results):
+        return (
+            subprocess.run(
+                ["bash", "-e", "-c", self.script],
+                env={
+                    **os.environ,
+                    "EXPECTED": json.dumps(expected),
+                    "RESULTS": json.dumps(results),
+                },
+                capture_output=True,
+                check=False,
+            ).returncode
+            == 0
+        )
+
+    def test_selected_jobs_must_succeed_and_only_planned_skips_pass(self):
+        for event in (
+            pr(True),
+            pr(),
+            pr(True, ("ci:full",)),
+            pr(True, tuple(PLATFORM_GROUPS)),
+        ):
+            expected = plan("pull_request", event)["expected"]
+            results = {job: {"result": wanted} for job, wanted in expected.items()}
+            self.assertTrue(self.accepts(expected, results))
+            for job, wanted in expected.items():
+                for outcome in ("success", "skipped", "failure", "cancelled"):
+                    if outcome != wanted:
+                        with self.subTest(job=job, wanted=wanted, outcome=outcome):
+                            self.assertFalse(
+                                self.accepts(
+                                    expected, {**results, job: {"result": outcome}}
+                                )
+                            )
+                self.assertFalse(
+                    self.accepts(
+                        expected, {k: v for k, v in results.items() if k != job}
+                    )
+                )
+            self.assertFalse(
+                self.accepts(expected, {**results, "unexpected": {"result": "success"}})
+            )
+            self.assertFalse(self.accepts({}, results))
+        self.assertFalse(self.accepts({}, {}))
+        self.assertFalse(
+            self.accepts({"plan": "skipped"}, {"plan": {"result": "skipped"}})
+        )


### PR DESCRIPTION
## Summary

Select CI coverage from PR readiness and persistent platform labels, with full target and packaging coverage for main, manual runs, Dependabot, or `ci:full`, and require every selected job to succeed.

## Test plan

All 15 CI tooling tests, workflow generation consistency, Actionlint, formatting, action-pin validation, and snapshot-scope checks passed locally.

## AI assistance

- **Tools:** Codex
- **Context:** Implemented the agreed coverage tiers and merge gate, following the approach in maplibre/maplibre-compose#1295.
