### PR TITLE
Release an owner thread that exits with a live runtime

### DIFF
--- a/docs/src/content/docs/concepts.md
+++ b/docs/src/content/docs/concepts.md
@@ -16,8 +16,8 @@ The runtime owns scheduler state and event storage for one owner thread. The
 host creates the runtime on the thread that will pump it. Runtime work and
 events flow through that thread.
 
-Each owner thread has at most one live runtime. Pumping advances MapLibre Native
-and collects completed work.
+Each owner thread has at most one live runtime, and destroys it before the
+thread exits. Pumping advances MapLibre Native and collects completed work.
 
 The host sets the pace. A display-paced host pumps once per frame. A host with a
 dedicated pump thread parks that thread until the runtime has work. Other host

--- a/docs/src/content/docs/development/c-conventions.md
+++ b/docs/src/content/docs/development/c-conventions.md
@@ -194,13 +194,16 @@ Objects that cross the C boundary are retained rather than autoreleased, which
 keeps them valid after the entry point that produced them returns.
 
 MapLibre's `RunLoop` is owner-thread scheduler state. Each owner thread may hold
-one live runtime. `mln_runtime_pump()` advances that runtime: it parks the owner
-thread when asked, then drains the queued tasks, expired timers, and ready I/O
-it finds, including work enqueued while it runs. The budget bounds one pump's
-drain at a task boundary: the first queued task always runs, a task runs to
-completion once started, and tasks left behind re-arm the wake flag so the next
-pump continues them without parking. Document a budgeted pump as bounding the
-task queues alone, because timers and ready I/O are serviced regardless.
+one live runtime, and destroys it before the thread exits. A runtime that
+outlives its owner thread is orphaned: the C API releases the thread's identity
+for later runtimes, and every call on the orphaned handle reports an
+invalid-state status. `mln_runtime_pump()` advances that runtime: it parks the
+owner thread when asked, then drains the queued tasks, expired timers, and ready
+I/O it finds, including work enqueued while it runs. The budget bounds one
+pump's drain at a task boundary: the first queued task always runs, a task runs
+to completion once started, and tasks left behind re-arm the wake flag so the
+next pump continues them without parking. Document a budgeted pump as bounding
+the task queues alone, because timers and ready I/O are serviced regardless.
 
 One entry point carries both cadence sources: the timeout selects the cadence,
 with zero for hosts driven by a callback they do not own and a positive value

--- a/docs/src/content/docs/development/c-conventions.md
+++ b/docs/src/content/docs/development/c-conventions.md
@@ -194,16 +194,14 @@ Objects that cross the C boundary are retained rather than autoreleased, which
 keeps them valid after the entry point that produced them returns.
 
 MapLibre's `RunLoop` is owner-thread scheduler state. Each owner thread may hold
-one live runtime, and destroys it before the thread exits. A runtime that
-outlives its owner thread is orphaned: the C API releases the thread's identity
-for later runtimes, and every call on the orphaned handle reports an
-invalid-state status. `mln_runtime_pump()` advances that runtime: it parks the
-owner thread when asked, then drains the queued tasks, expired timers, and ready
-I/O it finds, including work enqueued while it runs. The budget bounds one
-pump's drain at a task boundary: the first queued task always runs, a task runs
-to completion once started, and tasks left behind re-arm the wake flag so the
-next pump continues them without parking. Document a budgeted pump as bounding
-the task queues alone, because timers and ready I/O are serviced regardless.
+one live runtime, and destroys it before the thread exits. `mln_runtime_pump()`
+advances that runtime: it parks the owner thread when asked, then drains the
+queued tasks, expired timers, and ready I/O it finds, including work enqueued
+while it runs. The budget bounds one pump's drain at a task boundary: the first
+queued task always runs, a task runs to completion once started, and tasks left
+behind re-arm the wake flag so the next pump continues them without parking.
+Document a budgeted pump as bounding the task queues alone, because timers and
+ready I/O are serviced regardless.
 
 One entry point carries both cadence sources: the timeout selects the cadence,
 with zero for hosts driven by a callback they do not own and a positive value

--- a/include/maplibre_native_c/runtime.h
+++ b/include/maplibre_native_c/runtime.h
@@ -858,7 +858,13 @@ MLN_API mln_runtime_options mln_runtime_options_default(void) MLN_NOEXCEPT;
  * Creates a runtime handle.
  *
  * The creating thread becomes the runtime owner thread. Each owner thread may
- * hold one live runtime.
+ * hold one live runtime, and destroys it before the thread exits.
+ *
+ * A runtime that outlives its owner thread is orphaned. The thread's identity
+ * is released, so a later thread that the platform gives the same identity can
+ * create a runtime of its own. The orphaned handle stays allocated for the life
+ * of the process, and every call that takes it returns
+ * MLN_STATUS_INVALID_STATE.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -1181,7 +1187,8 @@ MLN_API mln_status mln_runtime_offline_operation_discard(
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not a live runtime
  *   handle.
- * - MLN_STATUS_INVALID_STATE when runtime still owns live maps.
+ * - MLN_STATUS_INVALID_STATE when runtime still owns live maps, or when its
+ *   owner thread exited.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the creating
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.

--- a/include/maplibre_native_c/runtime.h
+++ b/include/maplibre_native_c/runtime.h
@@ -859,8 +859,8 @@ MLN_API mln_runtime_options mln_runtime_options_default(void) MLN_NOEXCEPT;
  *
  * The creating thread becomes the runtime owner thread. Each owner thread may
  * hold one live runtime, and destroys it before the thread exits. A runtime
- * that outlives its owner thread is orphaned: every later call that takes it
- * returns MLN_STATUS_INVALID_STATE.
+ * that outlives its owner thread is orphaned: no thread can call or destroy
+ * it, and its handle stays allocated.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -1183,8 +1183,7 @@ MLN_API mln_status mln_runtime_offline_operation_discard(
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not a live runtime
  *   handle.
- * - MLN_STATUS_INVALID_STATE when runtime still owns live maps, or when its
- *   owner thread exited.
+ * - MLN_STATUS_INVALID_STATE when runtime still owns live maps.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the creating
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.

--- a/include/maplibre_native_c/runtime.h
+++ b/include/maplibre_native_c/runtime.h
@@ -858,13 +858,9 @@ MLN_API mln_runtime_options mln_runtime_options_default(void) MLN_NOEXCEPT;
  * Creates a runtime handle.
  *
  * The creating thread becomes the runtime owner thread. Each owner thread may
- * hold one live runtime, and destroys it before the thread exits.
- *
- * A runtime that outlives its owner thread is orphaned. The thread's identity
- * is released, so a later thread that the platform gives the same identity can
- * create a runtime of its own. The orphaned handle stays allocated for the life
- * of the process, and every call that takes it returns
- * MLN_STATUS_INVALID_STATE.
+ * hold one live runtime, and destroys it before the thread exits. A runtime
+ * that outlives its owner thread is orphaned: every later call that takes it
+ * returns MLN_STATUS_INVALID_STATE.
  *
  * Returns:
  * - MLN_STATUS_OK on success.

--- a/src/c_api/tests/core_abi.c
+++ b/src/c_api/tests/core_abi.c
@@ -208,8 +208,8 @@ static void diagnostics_are_thread_local(void) {
   mln_test_destroy_runtime(runtime);
 }
 
-// The native identity of the calling thread, which is what the runtime's
-// owner-thread check compares.
+// The native identity of the calling thread, which platforms recycle once the
+// thread exits.
 static uintptr_t current_thread_id(void) {
 #if defined(_WIN32)
   return (uintptr_t)GetCurrentThreadId();
@@ -218,35 +218,51 @@ static uintptr_t current_thread_id(void) {
 #endif
 }
 
+static const char* const orphaned_runtime_message =
+  "runtime is orphaned: its owner thread exited without destroying it";
+
 typedef struct leaked_runtime_probe {
   uintptr_t thread_id;
   mln_runtime runtime;
+  mln_map map;
   mln_status create_status;
+  mln_status map_status;
 } leaked_runtime_probe;
 
-// Exits with its runtime live, which is the leak under test.
+// Exits with its runtime and map live, which is the leak under test.
 static void leak_runtime_entry(void* argument) {
   leaked_runtime_probe* probe = argument;
   probe->thread_id = current_thread_id();
   const mln_runtime_options options = mln_runtime_options_default();
   probe->create_status = mln_runtime_create(&options, &probe->runtime);
+  if (probe->create_status != MLN_STATUS_OK) {
+    return;
+  }
+  mln_map_options map_options = mln_map_options_default();
+  map_options.width = 64;
+  map_options.height = 64;
+  probe->map_status = mln_map_create(probe->runtime, &map_options, &probe->map);
 }
 
 typedef struct reused_thread_probe {
-  uintptr_t wanted_thread_id;
+  const leaked_runtime_probe* leaked;
   atomic_bool* release;
   atomic_bool reported;
   bool matched;
   mln_status create_status;
   mln_status destroy_status;
+  mln_status pump_status;
+  mln_status map_status;
+  char pump_message[128];
 } reused_thread_probe;
 
-// A thread that reuses the exited owner's identity creates a runtime; any other
-// thread stays alive until released, so the next thread cannot take its
-// identity and the platform hands out the exited owner's in turn.
+// A thread that reuses the exited owner's identity exercises the orphaned
+// handles and creates a runtime of its own; any other thread stays alive until
+// released, so the next thread cannot take its identity and the platform hands
+// out the exited owner's in turn.
 static void reused_thread_entry(void* argument) {
   reused_thread_probe* probe = argument;
-  probe->matched = current_thread_id() == probe->wanted_thread_id;
+  probe->matched = current_thread_id() == probe->leaked->thread_id;
   if (!probe->matched) {
     atomic_store(&probe->reported, true);
     while (!atomic_load(probe->release)) {
@@ -254,6 +270,17 @@ static void reused_thread_entry(void* argument) {
     }
     return;
   }
+
+  probe->pump_status = mln_runtime_pump(probe->leaked->runtime, 0, -1);
+  strncpy(
+    probe->pump_message, mln_thread_last_error_message(),
+    sizeof(probe->pump_message) - 1
+  );
+  uint32_t width = 0;
+  uint32_t height = 0;
+  double scale_factor = 0.0;
+  probe->map_status =
+    mln_map_get_size(probe->leaked->map, &width, &height, &scale_factor);
 
   mln_runtime runtime = MLN_HANDLE_NULL;
   const mln_runtime_options options = mln_runtime_options_default();
@@ -264,42 +291,80 @@ static void reused_thread_entry(void* argument) {
   atomic_store(&probe->reported, true);
 }
 
+#if defined(_WIN32)
+typedef HANDLE probe_thread;
+static DWORD WINAPI reused_thread_trampoline(LPVOID argument) {
+  reused_thread_entry(argument);
+  return 0;
+}
+static bool start_probe_thread(
+  probe_thread* thread, reused_thread_probe* probe
+) {
+  *thread = CreateThread(NULL, 0, reused_thread_trampoline, probe, 0, NULL);
+  return *thread != NULL;
+}
+static void join_probe_thread(probe_thread thread) {
+  WaitForSingleObject(thread, INFINITE);
+  CloseHandle(thread);
+}
+#else
+typedef pthread_t probe_thread;
+static void* reused_thread_trampoline(void* argument) {
+  reused_thread_entry(argument);
+  return NULL;
+}
+static bool start_probe_thread(
+  probe_thread* thread, reused_thread_probe* probe
+) {
+  return pthread_create(thread, NULL, reused_thread_trampoline, probe) == 0;
+}
+static void join_probe_thread(probe_thread thread) {
+  pthread_join(thread, NULL);
+}
+#endif
+
 enum { thread_reuse_attempts = 32 };
 
 // Only the owner thread can destroy a runtime, so a runtime whose owner thread
-// exited can never leave the C API. Its thread identity must not leave with
-// it: platforms reuse thread identities, and a later thread that gets this one
-// creates a runtime of its own.
+// exited can never leave the C API. Platforms reuse thread identities, and a
+// later thread that gets this one must neither pass as the owner of the leaked
+// handles nor be blocked from creating a runtime of its own.
 static void a_runtime_that_outlives_its_owner_thread_releases_the_thread(void) {
   leaked_runtime_probe leaked = {0};
   mln_test_thread_join(mln_test_thread_start(leak_runtime_entry, &leaked));
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, leaked.create_status);
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, leaked.map_status);
 
-  // The orphaned handle reports the leak, on any thread, ahead of the
-  // owner-thread check that would otherwise name this thread as the problem.
+  // The orphaned handle names the leak rather than this thread.
   TEST_ASSERT_EQUAL_INT(
-    MLN_STATUS_INVALID_STATE, mln_runtime_pump(leaked.runtime, 0, -1)
+    MLN_STATUS_WRONG_THREAD, mln_runtime_pump(leaked.runtime, 0, -1)
   );
   TEST_ASSERT_EQUAL_STRING(
-    "runtime is orphaned: its owner thread exited without destroying it",
-    mln_thread_last_error_message()
+    orphaned_runtime_message, mln_thread_last_error_message()
   );
   TEST_ASSERT_EQUAL_INT(
-    MLN_STATUS_INVALID_STATE, mln_runtime_destroy(leaked.runtime)
+    MLN_STATUS_WRONG_THREAD, mln_runtime_destroy(leaked.runtime)
+  );
+  TEST_ASSERT_EQUAL_STRING(
+    orphaned_runtime_message, mln_thread_last_error_message()
   );
 
   atomic_bool release;
   atomic_init(&release, false);
   reused_thread_probe probes[thread_reuse_attempts] = {0};
-  mln_test_thread* threads[thread_reuse_attempts] = {0};
+  probe_thread threads[thread_reuse_attempts] = {0};
   size_t started = 0;
   size_t matched = thread_reuse_attempts;
+  bool start_failed = false;
   while (started < thread_reuse_attempts && matched == thread_reuse_attempts) {
     reused_thread_probe* probe = &probes[started];
-    probe->wanted_thread_id = leaked.thread_id;
+    probe->leaked = &leaked;
     probe->release = &release;
     atomic_init(&probe->reported, false);
-    threads[started] = mln_test_thread_start(reused_thread_entry, probe);
+    if (!start_probe_thread(&threads[started], probe)) {
+      start_failed = true;
+      break;
+    }
     started += 1;
     while (!atomic_load(&probe->reported)) {
       mln_test_sleep_millisecond();
@@ -308,18 +373,25 @@ static void a_runtime_that_outlives_its_owner_thread_releases_the_thread(void) {
       matched = started - 1;
     }
   }
+  // Every started thread is released and joined before any assertion can
+  // unwind the state they read.
   atomic_store(&release, true);
   for (size_t index = 0; index < started; index += 1) {
-    mln_test_thread_join(threads[index]);
+    join_probe_thread(threads[index]);
   }
+  TEST_ASSERT_FALSE_MESSAGE(start_failed, "Could not start a probe thread.");
 
   if (matched == thread_reuse_attempts) {
     // The platform decides when it reuses a thread identity, and the test has
     // no way to make it do so.
     TEST_IGNORE_MESSAGE("No thread reused the exited owner's identity.");
   }
-  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, probes[matched].create_status);
-  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, probes[matched].destroy_status);
+  const reused_thread_probe* reused = &probes[matched];
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_WRONG_THREAD, reused->pump_status);
+  TEST_ASSERT_EQUAL_STRING(orphaned_runtime_message, reused->pump_message);
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_WRONG_THREAD, reused->map_status);
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, reused->create_status);
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, reused->destroy_status);
 }
 
 void run_core_abi_tests(void) {

--- a/src/c_api/tests/core_abi.c
+++ b/src/c_api/tests/core_abi.c
@@ -1,7 +1,6 @@
 // Raw C ABI coverage: core runtime/map/style/event/diagnostic tests for unsafe
 // inputs, stale handles, and thread-local diagnostics hidden by bindings.
 
-#include <stdlib.h>
 #include <string.h>
 
 #if defined(_WIN32)
@@ -240,7 +239,6 @@ typedef struct reused_thread_probe {
   bool matched;
   mln_status create_status;
   mln_status destroy_status;
-  char create_message[160];
 } reused_thread_probe;
 
 // A thread that reuses the exited owner's identity creates a runtime; any other
@@ -260,17 +258,13 @@ static void reused_thread_entry(void* argument) {
   mln_runtime runtime = MLN_HANDLE_NULL;
   const mln_runtime_options options = mln_runtime_options_default();
   probe->create_status = mln_runtime_create(&options, &runtime);
-  strncpy(
-    probe->create_message, mln_thread_last_error_message(),
-    sizeof(probe->create_message) - 1
-  );
   if (probe->create_status == MLN_STATUS_OK) {
     probe->destroy_status = mln_runtime_destroy(runtime);
   }
   atomic_store(&probe->reported, true);
 }
 
-#define MLN_TEST_THREAD_REUSE_ATTEMPTS 32
+enum { thread_reuse_attempts = 32 };
 
 // Only the owner thread can destroy a runtime, so a runtime whose owner thread
 // exited can never leave the C API. Its thread identity must not leave with
@@ -296,17 +290,11 @@ static void a_runtime_that_outlives_its_owner_thread_releases_the_thread(void) {
 
   atomic_bool release;
   atomic_init(&release, false);
-  reused_thread_probe* probes =
-    calloc(MLN_TEST_THREAD_REUSE_ATTEMPTS, sizeof(*probes));
-  mln_test_thread** threads =
-    calloc(MLN_TEST_THREAD_REUSE_ATTEMPTS, sizeof(*threads));
-  TEST_ASSERT_NOT_NULL(probes);
-  TEST_ASSERT_NOT_NULL(threads);
-
+  reused_thread_probe probes[thread_reuse_attempts] = {0};
+  mln_test_thread* threads[thread_reuse_attempts] = {0};
   size_t started = 0;
-  size_t matched = MLN_TEST_THREAD_REUSE_ATTEMPTS;
-  while (started < MLN_TEST_THREAD_REUSE_ATTEMPTS &&
-         matched == MLN_TEST_THREAD_REUSE_ATTEMPTS) {
+  size_t matched = thread_reuse_attempts;
+  while (started < thread_reuse_attempts && matched == thread_reuse_attempts) {
     reused_thread_probe* probe = &probes[started];
     probe->wanted_thread_id = leaked.thread_id;
     probe->release = &release;
@@ -325,30 +313,13 @@ static void a_runtime_that_outlives_its_owner_thread_releases_the_thread(void) {
     mln_test_thread_join(threads[index]);
   }
 
-  const bool found = matched < MLN_TEST_THREAD_REUSE_ATTEMPTS;
-  mln_status create_status = MLN_STATUS_OK;
-  mln_status destroy_status = MLN_STATUS_OK;
-  char create_message[sizeof(probes->create_message)] = {0};
-  if (found) {
-    create_status = probes[matched].create_status;
-    destroy_status = probes[matched].destroy_status;
-    memcpy(
-      create_message, probes[matched].create_message, sizeof(create_message)
-    );
-  }
-  free(threads);
-  free(probes);
-
-  if (!found) {
+  if (matched == thread_reuse_attempts) {
     // The platform decides when it reuses a thread identity, and the test has
     // no way to make it do so.
-    TEST_IGNORE_MESSAGE(
-      "No thread reused the exited owner's identity within "
-      "MLN_TEST_THREAD_REUSE_ATTEMPTS threads."
-    );
+    TEST_IGNORE_MESSAGE("No thread reused the exited owner's identity.");
   }
-  TEST_ASSERT_EQUAL_INT_MESSAGE(MLN_STATUS_OK, create_status, create_message);
-  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, destroy_status);
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, probes[matched].create_status);
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, probes[matched].destroy_status);
 }
 
 void run_core_abi_tests(void) {

--- a/src/c_api/tests/core_abi.c
+++ b/src/c_api/tests/core_abi.c
@@ -1,6 +1,7 @@
 // Raw C ABI coverage: core runtime/map/style/event/diagnostic tests for unsafe
 // inputs, stale handles, and thread-local diagnostics hidden by bindings.
 
+#include <stdlib.h>
 #include <string.h>
 
 #if defined(_WIN32)
@@ -208,6 +209,148 @@ static void diagnostics_are_thread_local(void) {
   mln_test_destroy_runtime(runtime);
 }
 
+// The native identity of the calling thread, which is what the runtime's
+// owner-thread check compares.
+static uintptr_t current_thread_id(void) {
+#if defined(_WIN32)
+  return (uintptr_t)GetCurrentThreadId();
+#else
+  return (uintptr_t)pthread_self();
+#endif
+}
+
+typedef struct leaked_runtime_probe {
+  uintptr_t thread_id;
+  mln_runtime runtime;
+  mln_status create_status;
+} leaked_runtime_probe;
+
+// Exits with its runtime live, which is the leak under test.
+static void leak_runtime_entry(void* argument) {
+  leaked_runtime_probe* probe = argument;
+  probe->thread_id = current_thread_id();
+  const mln_runtime_options options = mln_runtime_options_default();
+  probe->create_status = mln_runtime_create(&options, &probe->runtime);
+}
+
+typedef struct reused_thread_probe {
+  uintptr_t wanted_thread_id;
+  atomic_bool* release;
+  atomic_bool reported;
+  bool matched;
+  mln_status create_status;
+  mln_status destroy_status;
+  char create_message[160];
+} reused_thread_probe;
+
+// A thread that reuses the exited owner's identity creates a runtime; any other
+// thread stays alive until released, so the next thread cannot take its
+// identity and the platform hands out the exited owner's in turn.
+static void reused_thread_entry(void* argument) {
+  reused_thread_probe* probe = argument;
+  probe->matched = current_thread_id() == probe->wanted_thread_id;
+  if (!probe->matched) {
+    atomic_store(&probe->reported, true);
+    while (!atomic_load(probe->release)) {
+      mln_test_sleep_millisecond();
+    }
+    return;
+  }
+
+  mln_runtime runtime = MLN_HANDLE_NULL;
+  const mln_runtime_options options = mln_runtime_options_default();
+  probe->create_status = mln_runtime_create(&options, &runtime);
+  strncpy(
+    probe->create_message, mln_thread_last_error_message(),
+    sizeof(probe->create_message) - 1
+  );
+  if (probe->create_status == MLN_STATUS_OK) {
+    probe->destroy_status = mln_runtime_destroy(runtime);
+  }
+  atomic_store(&probe->reported, true);
+}
+
+#define MLN_TEST_THREAD_REUSE_ATTEMPTS 32
+
+// Only the owner thread can destroy a runtime, so a runtime whose owner thread
+// exited can never leave the C API. Its thread identity must not leave with
+// it: platforms reuse thread identities, and a later thread that gets this one
+// creates a runtime of its own.
+static void a_runtime_that_outlives_its_owner_thread_releases_the_thread(void) {
+  leaked_runtime_probe leaked = {0};
+  mln_test_thread_join(mln_test_thread_start(leak_runtime_entry, &leaked));
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, leaked.create_status);
+
+  // The orphaned handle reports the leak, on any thread, ahead of the
+  // owner-thread check that would otherwise name this thread as the problem.
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_STATE, mln_runtime_pump(leaked.runtime, 0, -1)
+  );
+  TEST_ASSERT_EQUAL_STRING(
+    "runtime is orphaned: its owner thread exited without destroying it",
+    mln_thread_last_error_message()
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_STATE, mln_runtime_destroy(leaked.runtime)
+  );
+
+  atomic_bool release;
+  atomic_init(&release, false);
+  reused_thread_probe* probes =
+    calloc(MLN_TEST_THREAD_REUSE_ATTEMPTS, sizeof(*probes));
+  mln_test_thread** threads =
+    calloc(MLN_TEST_THREAD_REUSE_ATTEMPTS, sizeof(*threads));
+  TEST_ASSERT_NOT_NULL(probes);
+  TEST_ASSERT_NOT_NULL(threads);
+
+  size_t started = 0;
+  size_t matched = MLN_TEST_THREAD_REUSE_ATTEMPTS;
+  while (started < MLN_TEST_THREAD_REUSE_ATTEMPTS &&
+         matched == MLN_TEST_THREAD_REUSE_ATTEMPTS) {
+    reused_thread_probe* probe = &probes[started];
+    probe->wanted_thread_id = leaked.thread_id;
+    probe->release = &release;
+    atomic_init(&probe->reported, false);
+    threads[started] = mln_test_thread_start(reused_thread_entry, probe);
+    started += 1;
+    while (!atomic_load(&probe->reported)) {
+      mln_test_sleep_millisecond();
+    }
+    if (probe->matched) {
+      matched = started - 1;
+    }
+  }
+  atomic_store(&release, true);
+  for (size_t index = 0; index < started; index += 1) {
+    mln_test_thread_join(threads[index]);
+  }
+
+  const bool found = matched < MLN_TEST_THREAD_REUSE_ATTEMPTS;
+  mln_status create_status = MLN_STATUS_OK;
+  mln_status destroy_status = MLN_STATUS_OK;
+  char create_message[sizeof(probes->create_message)] = {0};
+  if (found) {
+    create_status = probes[matched].create_status;
+    destroy_status = probes[matched].destroy_status;
+    memcpy(
+      create_message, probes[matched].create_message, sizeof(create_message)
+    );
+  }
+  free(threads);
+  free(probes);
+
+  if (!found) {
+    // The platform decides when it reuses a thread identity, and the test has
+    // no way to make it do so.
+    TEST_IGNORE_MESSAGE(
+      "No thread reused the exited owner's identity within "
+      "MLN_TEST_THREAD_REUSE_ATTEMPTS threads."
+    );
+  }
+  TEST_ASSERT_EQUAL_INT_MESSAGE(MLN_STATUS_OK, create_status, create_message);
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, destroy_status);
+}
+
 void run_core_abi_tests(void) {
   UnitySetTestFile(__FILE__);
   RUN_TEST(runtime_rejects_invalid_arguments);
@@ -218,4 +361,5 @@ void run_core_abi_tests(void) {
   RUN_TEST(style_functions_reject_null_inputs);
   RUN_TEST(failing_status_sets_and_successful_status_clears_diagnostics);
   RUN_TEST(diagnostics_are_thread_local);
+  RUN_TEST(a_runtime_that_outlives_its_owner_thread_releases_the_thread);
 }

--- a/src/handles/owner_thread.hpp
+++ b/src/handles/owner_thread.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace mln::core {
+
+// Identifies the thread that owns a handle. The platform recycles thread ids,
+// so a runtime, map, or render session that outlives its owner thread would
+// otherwise accept calls from a later thread with the same id. This token is
+// unique for the life of the process instead.
+using OwnerThreadToken = std::uint64_t;
+
+// Zero is the token of no thread, so a handle whose owner was never recorded
+// matches no caller.
+inline constexpr OwnerThreadToken kNoOwnerThread = 0;
+
+inline auto current_owner_thread() noexcept -> OwnerThreadToken {
+  static std::atomic<OwnerThreadToken> next{1};
+  thread_local const OwnerThreadToken token =
+    next.fetch_add(1, std::memory_order_relaxed);
+  return token;
+}
+
+}  // namespace mln::core

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -18,7 +18,6 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
@@ -85,6 +84,7 @@
 #include "geojson/geojson.hpp"
 #include "geojson/geojson_source_data.hpp"
 #include "handles/handle_table.hpp"
+#include "handles/owner_thread.hpp"
 #include "map/feature_state.hpp"
 #include "maplibre_native_c.h"
 #include "runtime/runtime.hpp"
@@ -3243,7 +3243,7 @@ namespace mln::core {
 
 struct MapObject {
   mln_runtime runtime = MLN_HANDLE_NULL;
-  std::thread::id owner_thread;
+  OwnerThreadToken owner_thread = kNoOwnerThread;
   uint32_t map_mode = MLN_MAP_MODE_CONTINUOUS;
   double scale_factor = default_scale_factor;
   bool still_image_request_pending = false;
@@ -3361,7 +3361,7 @@ auto validate_map_locked(mln_map map, MapObject*& out_map) -> mln_status {
   if (status != MLN_STATUS_OK) {
     return status;
   }
-  if (out_map->owner_thread != std::this_thread::get_id()) {
+  if (out_map->owner_thread != current_owner_thread()) {
     set_thread_error("map call must be made on its owner thread");
     return MLN_STATUS_WRONG_THREAD;
   }
@@ -3707,7 +3707,7 @@ auto create_map(
   // already resolves.
   const auto handle = handle_table<MapObject>().insert(owned_map);
   owned_map->runtime = runtime;
-  owned_map->owner_thread = std::this_thread::get_id();
+  owned_map->owner_thread = current_owner_thread();
   owned_map->map_mode = effective.map_mode;
   owned_map->scale_factor = effective.scale_factor;
   owned_map->event_state = std::move(event_state);

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -9,7 +9,6 @@
 #include <optional>
 #include <span>
 #include <string>
-#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -951,7 +950,7 @@ auto validate_render_session(
   if (out_session == nullptr) {
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  if (out_session->owner_thread != std::this_thread::get_id()) {
+  if (out_session->owner_thread != current_owner_thread()) {
     set_thread_error(
       "render session call must be made on the thread that attached it"
     );
@@ -997,7 +996,7 @@ auto attach_render_session(
 
   // The attaching thread owns the session for its whole lifetime, and need not
   // be the map's thread.
-  session->owner_thread = std::this_thread::get_id();
+  session->owner_thread = current_owner_thread();
 
   const auto map = session->map;
   auto* handle = session.get();

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -9,7 +9,6 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
 #include <unordered_set>
 #include <vector>
 
@@ -22,6 +21,7 @@
 #include <mln/util/size.hpp>
 
 #include "diagnostics/diagnostics.hpp"
+#include "handles/owner_thread.hpp"
 #include "map/feature_state.hpp"
 #include "maplibre_native_c.h"
 #include "render/discard_present.hpp"
@@ -480,7 +480,7 @@ struct mln_render_session_object {
   mln_map map = MLN_HANDLE_NULL;
   // The thread that attached the session, fixed for its lifetime. Set before
   // the session is registered.
-  std::thread::id owner_thread;
+  mln::core::OwnerThreadToken owner_thread = mln::core::kNoOwnerThread;
   uint32_t width = 0;
   uint32_t height = 0;
   uint32_t physical_width = 0;

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -237,15 +237,12 @@ constexpr auto kOrphanedRuntimeError =
   "runtime is orphaned: its owner thread exited without destroying it";
 
 // Releases an owner thread that exits with its runtime still live. Only the
-// owner thread can destroy a runtime, so that runtime can never leave
-// live_runtime_threads() through the API, and its id would otherwise reject
-// runtime creation on every later thread the platform gives the same id. The
-// runtime stays in the handle table, marked orphaned, so a thread with the
-// reused id cannot pump a run loop that belongs to a thread that no longer
-// exists.
+// owner thread can destroy a runtime, so that runtime would otherwise hold the
+// thread's id in live_runtime_threads() forever and reject runtime creation on
+// every later thread the platform gives the same id. The runtime stays in the
+// handle table, marked orphaned, so that thread cannot pump it either.
 struct OwnerThreadGuard {
   mln_runtime runtime = MLN_HANDLE_NULL;
-  std::thread::id owner_thread;
 
   ~OwnerThreadGuard() {
     if (runtime == MLN_HANDLE_NULL) {
@@ -260,12 +257,12 @@ struct OwnerThreadGuard {
       }
     }
     const std::scoped_lock lock(live_runtime_threads_mutex());
-    live_runtime_threads().erase(owner_thread);
+    live_runtime_threads().erase(std::this_thread::get_id());
   }
 };
 
 // Runtime creation and destruction are owner-thread calls, so the calling
-// thread's guard is always the one that tracks the runtime in question.
+// thread's guard always tracks the runtime in question.
 auto owner_thread_guard() -> OwnerThreadGuard& {
   thread_local OwnerThreadGuard value;
   return value;
@@ -1240,9 +1237,6 @@ auto create_runtime(
   // the runtime while unwinding.
   auto* const platform_context = reserve_platform_context();
   published->platform_context = platform_context;
-  // The first touch registers the guard's thread-exit destructor, which can
-  // allocate, so it also happens before this thread is marked.
-  auto& guard = owner_thread_guard();
   {
     const std::scoped_lock lock(live_runtime_threads_mutex());
     live_runtime_threads().insert(owner_thread);
@@ -1262,8 +1256,7 @@ auto create_runtime(
     throw;
   }
   published->self = *out_runtime;
-  guard.runtime = *out_runtime;
-  guard.owner_thread = owner_thread;
+  owner_thread_guard().runtime = *out_runtime;
   bind_platform_context(platform_context, *out_runtime);
   return MLN_STATUS_OK;
 }

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -15,7 +15,6 @@
 #include <shared_mutex>
 #include <stdexcept>
 #include <string>
-#include <thread>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -216,31 +215,14 @@ auto runtime_from_platform_context(void* platform_context) noexcept
   return found == registry.end() ? MLN_HANDLE_NULL : found->second;
 }
 
-auto live_runtime_threads_mutex() -> std::mutex& {
-  static std::mutex value;
-  return value;
-}
-
-// Mirrors the owner thread of every live runtime, so runtime creation can
-// reject a thread that already owns one. The handle table does not iterate.
-auto live_runtime_threads() -> std::unordered_set<std::thread::id>& {
-  static std::unordered_set<std::thread::id> value;
-  return value;
-}
-
-auto owner_thread_has_live_runtime(std::thread::id owner_thread) -> bool {
-  const std::scoped_lock lock(live_runtime_threads_mutex());
-  return live_runtime_threads().contains(owner_thread);
-}
-
 constexpr auto kOrphanedRuntimeError =
   "runtime is orphaned: its owner thread exited without destroying it";
 
-// Releases an owner thread that exits with its runtime still live. Only the
-// owner thread can destroy a runtime, so that runtime would otherwise hold the
-// thread's id in live_runtime_threads() forever and reject runtime creation on
-// every later thread the platform gives the same id. The runtime stays in the
-// handle table, marked orphaned, so that thread cannot pump it either.
+// Holds the calling thread's live runtime, so runtime creation can reject a
+// thread that already owns one. Only the owner thread can destroy a runtime,
+// so one that is still live when the thread exits can never be destroyed: the
+// destructor marks it orphaned, so later calls on it name the leak rather than
+// the wrong thread.
 struct OwnerThreadGuard {
   mln_runtime runtime = MLN_HANDLE_NULL;
 
@@ -248,16 +230,12 @@ struct OwnerThreadGuard {
     if (runtime == MLN_HANDLE_NULL) {
       return;
     }
-    {
-      auto& table = mln::core::handle_table<mln::core::RuntimeObject>();
-      const std::scoped_lock lock(table.mutex());
-      auto* live = table.try_resolve_locked(runtime);
-      if (live != nullptr) {
-        live->owner_thread_exited.store(true, std::memory_order_relaxed);
-      }
+    auto& table = mln::core::handle_table<mln::core::RuntimeObject>();
+    const std::scoped_lock lock(table.mutex());
+    auto* live = table.try_resolve_locked(runtime);
+    if (live != nullptr) {
+      live->owner_thread_exited.store(true, std::memory_order_relaxed);
     }
-    const std::scoped_lock lock(live_runtime_threads_mutex());
-    live_runtime_threads().erase(std::this_thread::get_id());
   }
 };
 
@@ -1124,15 +1102,12 @@ auto validate_runtime(mln_runtime runtime, RuntimeObject*& out_runtime)
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
-  // Checked before the thread, so a thread that reuses the exited owner's id
-  // hears about the leak rather than passing as the owner.
-  if (out_runtime->owner_thread_exited.load(std::memory_order_relaxed)) {
-    set_thread_error(kOrphanedRuntimeError);
-    return MLN_STATUS_INVALID_STATE;
-  }
-
-  if (out_runtime->owner_thread != std::this_thread::get_id()) {
-    set_thread_error("runtime call must be made on its owner thread");
+  if (out_runtime->owner_thread != current_owner_thread()) {
+    set_thread_error(
+      out_runtime->owner_thread_exited.load(std::memory_order_relaxed)
+        ? kOrphanedRuntimeError
+        : "runtime call must be made on its owner thread"
+    );
     return MLN_STATUS_WRONG_THREAD;
   }
 
@@ -1157,8 +1132,8 @@ auto create_runtime(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
-  const auto owner_thread = std::this_thread::get_id();
-  if (owner_thread_has_live_runtime(owner_thread)) {
+  auto& guard = owner_thread_guard();
+  if (guard.runtime != MLN_HANDLE_NULL) {
     set_thread_error("owner thread already has a live runtime");
     return MLN_STATUS_INVALID_STATE;
   }
@@ -1168,7 +1143,7 @@ auto create_runtime(
   }
 
   auto owned_runtime = std::make_shared<RuntimeObject>();
-  owned_runtime->owner_thread = owner_thread;
+  owned_runtime->owner_thread = current_owner_thread();
   owned_runtime->wake_state = std::make_shared<WakeState>();
   // The mask cell exists before the run loop, so every producer this runtime
   // can reach reads a live cell.
@@ -1231,32 +1206,22 @@ auto create_runtime(
   owned_runtime->resource_provider_state =
     std::make_shared<ResourceProviderState>();
   auto* published = owned_runtime.get();
-  // Reserving the token allocates, so it happens before this thread is marked
-  // as owning a runtime. The failure path below reads the local, not the
-  // object: the insert takes the shared_ptr by value, so a throw there destroys
-  // the runtime while unwinding.
+  // The failure path below reads the local, not the object: the insert takes
+  // the shared_ptr by value, so a throw there destroys the runtime while
+  // unwinding.
   auto* const platform_context = reserve_platform_context();
   published->platform_context = platform_context;
-  {
-    const std::scoped_lock lock(live_runtime_threads_mutex());
-    live_runtime_threads().insert(owner_thread);
-  }
   try {
     *out_runtime =
       handle_table<RuntimeObject>().insert(std::move(owned_runtime));
   } catch (...) {
-    // The caller receives no handle, so it has no way to give the owner thread
-    // back. Releasing it here keeps a failed creation from rejecting every
-    // later one on the same thread.
-    {
-      const std::scoped_lock lock(live_runtime_threads_mutex());
-      live_runtime_threads().erase(owner_thread);
-    }
     unregister_platform_context(platform_context);
     throw;
   }
   published->self = *out_runtime;
-  owner_thread_guard().runtime = *out_runtime;
+  // Marked as owning a runtime only once the caller holds the handle that
+  // gives the thread back.
+  guard.runtime = *out_runtime;
   bind_platform_context(platform_context, *out_runtime);
   return MLN_STATUS_OK;
 }
@@ -2926,7 +2891,6 @@ auto destroy_runtime(mln_runtime runtime) -> mln_status {
   // process-global table lock before any teardown step that can block on a
   // native callback. The waits below then stall this runtime alone.
   std::shared_ptr<RuntimeObject> owned_runtime;
-  auto owner_thread = std::thread::id{};
   {
     auto& table = handle_table<RuntimeObject>();
     const std::scoped_lock lock(table.mutex());
@@ -2935,13 +2899,12 @@ auto destroy_runtime(mln_runtime runtime) -> mln_status {
       return MLN_STATUS_INVALID_ARGUMENT;
     }
 
-    if (live->owner_thread_exited.load(std::memory_order_relaxed)) {
-      set_thread_error(kOrphanedRuntimeError);
-      return MLN_STATUS_INVALID_STATE;
-    }
-
-    if (live->owner_thread != std::this_thread::get_id()) {
-      set_thread_error("runtime must be destroyed on its owner thread");
+    if (live->owner_thread != current_owner_thread()) {
+      set_thread_error(
+        live->owner_thread_exited.load(std::memory_order_relaxed)
+          ? kOrphanedRuntimeError
+          : "runtime must be destroyed on its owner thread"
+      );
       return MLN_STATUS_WRONG_THREAD;
     }
 
@@ -2950,12 +2913,7 @@ auto destroy_runtime(mln_runtime runtime) -> mln_status {
       return MLN_STATUS_INVALID_STATE;
     }
 
-    owner_thread = live->owner_thread;
     owned_runtime = table.remove_locked(runtime);
-  }
-  {
-    const std::scoped_lock lock(live_runtime_threads_mutex());
-    live_runtime_threads().erase(owner_thread);
   }
   owner_thread_guard().runtime = MLN_HANDLE_NULL;
   unregister_platform_context(owned_runtime->platform_context);

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -233,6 +233,44 @@ auto owner_thread_has_live_runtime(std::thread::id owner_thread) -> bool {
   return live_runtime_threads().contains(owner_thread);
 }
 
+constexpr auto kOrphanedRuntimeError =
+  "runtime is orphaned: its owner thread exited without destroying it";
+
+// Releases an owner thread that exits with its runtime still live. Only the
+// owner thread can destroy a runtime, so that runtime can never leave
+// live_runtime_threads() through the API, and its id would otherwise reject
+// runtime creation on every later thread the platform gives the same id. The
+// runtime stays in the handle table, marked orphaned, so a thread with the
+// reused id cannot pump a run loop that belongs to a thread that no longer
+// exists.
+struct OwnerThreadGuard {
+  mln_runtime runtime = MLN_HANDLE_NULL;
+  std::thread::id owner_thread;
+
+  ~OwnerThreadGuard() {
+    if (runtime == MLN_HANDLE_NULL) {
+      return;
+    }
+    {
+      auto& table = mln::core::handle_table<mln::core::RuntimeObject>();
+      const std::scoped_lock lock(table.mutex());
+      auto* live = table.try_resolve_locked(runtime);
+      if (live != nullptr) {
+        live->owner_thread_exited.store(true, std::memory_order_relaxed);
+      }
+    }
+    const std::scoped_lock lock(live_runtime_threads_mutex());
+    live_runtime_threads().erase(owner_thread);
+  }
+};
+
+// Runtime creation and destruction are owner-thread calls, so the calling
+// thread's guard is always the one that tracks the runtime in question.
+auto owner_thread_guard() -> OwnerThreadGuard& {
+  thread_local OwnerThreadGuard value;
+  return value;
+}
+
 // Leases the resource transform registration for a MapLibre-owned thread. Only
 // a reference count increment happens under the handle table lock; the caller
 // takes the returned state's lock after this returns, so a writer waiting on
@@ -1089,6 +1127,13 @@ auto validate_runtime(mln_runtime runtime, RuntimeObject*& out_runtime)
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
+  // Checked before the thread, so a thread that reuses the exited owner's id
+  // hears about the leak rather than passing as the owner.
+  if (out_runtime->owner_thread_exited.load(std::memory_order_relaxed)) {
+    set_thread_error(kOrphanedRuntimeError);
+    return MLN_STATUS_INVALID_STATE;
+  }
+
   if (out_runtime->owner_thread != std::this_thread::get_id()) {
     set_thread_error("runtime call must be made on its owner thread");
     return MLN_STATUS_WRONG_THREAD;
@@ -1195,6 +1240,9 @@ auto create_runtime(
   // the runtime while unwinding.
   auto* const platform_context = reserve_platform_context();
   published->platform_context = platform_context;
+  // The first touch registers the guard's thread-exit destructor, which can
+  // allocate, so it also happens before this thread is marked.
+  auto& guard = owner_thread_guard();
   {
     const std::scoped_lock lock(live_runtime_threads_mutex());
     live_runtime_threads().insert(owner_thread);
@@ -1214,6 +1262,8 @@ auto create_runtime(
     throw;
   }
   published->self = *out_runtime;
+  guard.runtime = *out_runtime;
+  guard.owner_thread = owner_thread;
   bind_platform_context(platform_context, *out_runtime);
   return MLN_STATUS_OK;
 }
@@ -2892,6 +2942,11 @@ auto destroy_runtime(mln_runtime runtime) -> mln_status {
       return MLN_STATUS_INVALID_ARGUMENT;
     }
 
+    if (live->owner_thread_exited.load(std::memory_order_relaxed)) {
+      set_thread_error(kOrphanedRuntimeError);
+      return MLN_STATUS_INVALID_STATE;
+    }
+
     if (live->owner_thread != std::this_thread::get_id()) {
       set_thread_error("runtime must be destroyed on its owner thread");
       return MLN_STATUS_WRONG_THREAD;
@@ -2909,6 +2964,7 @@ auto destroy_runtime(mln_runtime runtime) -> mln_status {
     const std::scoped_lock lock(live_runtime_threads_mutex());
     live_runtime_threads().erase(owner_thread);
   }
+  owner_thread_guard().runtime = MLN_HANDLE_NULL;
   unregister_platform_context(owned_runtime->platform_context);
 
   // A resource transform callback that entered `invoke_resource_transform()`

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -12,7 +12,6 @@
 #include <optional>
 #include <shared_mutex>
 #include <string>
-#include <thread>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -21,6 +20,7 @@
 #include <mln/util/run_loop.hpp>
 
 #include "handles/handle_table.hpp"
+#include "handles/owner_thread.hpp"
 #include "maplibre_native_c.h"
 
 namespace mln {
@@ -179,7 +179,7 @@ struct RuntimeObject {
   mln_runtime self = MLN_HANDLE_NULL;
   // The token this runtime hands to mbgl as its opaque platform context.
   void* platform_context = nullptr;
-  std::thread::id owner_thread;
+  OwnerThreadToken owner_thread = kNoOwnerThread;
   // Set once, by the owner thread's exit, when the runtime outlived it. Read
   // by validation on any thread, so it is atomic rather than table-guarded.
   std::atomic<bool> owner_thread_exited{false};

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -180,6 +180,9 @@ struct RuntimeObject {
   // The token this runtime hands to mbgl as its opaque platform context.
   void* platform_context = nullptr;
   std::thread::id owner_thread;
+  // Set once, by the owner thread's exit, when the runtime outlived it. Read
+  // by validation on any thread, so it is atomic rather than table-guarded.
+  std::atomic<bool> owner_thread_exited{false};
   std::unique_ptr<mln::util::RunLoop> run_loop;
   std::string asset_path;
   std::string cache_path;


### PR DESCRIPTION
## Summary

Fixes #691: owner threads are identified by a process-unique token instead of a recyclable `std::thread::id`, so a runtime, map, or render session that outlives its thread never matches a later thread with the same id, the live-runtime set becomes a thread-local slot, and calls on the orphaned runtime keep returning wrong-thread with a message that names the leak.

## Test plan

A new C API test leaks a runtime and map on a thread, asserts the orphaned handle names the leak, then starts threads until one reuses the exited thread's identity and asserts that it is rejected on the leaked handles and creates a runtime of its own; `mise run test` and the Rust binding tests pass on macOS Metal.

## AI assistance

- **Tools:** Claude Code
- **Context:** Implemented from the fix options in #691, then reworked to the token design after the bot review flagged that the orphan's maps still validated on a recycled thread id.