### PR TITLE
Fix background rendering after same-ID style replacement

### DIFF
--- a/.mise/bin/sync-submodules
+++ b/.mise/bin/sync-submodules
@@ -62,6 +62,7 @@ mln_patches=(
   "$repo_root/patches/maplibre-native/0006-process-lifetime-logging.patch"
   "$repo_root/patches/maplibre-native/0007-retain-active-on-demand-images.patch"
   "$repo_root/patches/maplibre-native/0009-synchronous-symbol-dependencies.patch"
+  "$repo_root/patches/maplibre-native/0010-background-drawable-replacement.patch"
 )
 
 # A patch counts as applied when it reverses cleanly, which is also what makes

--- a/patches/maplibre-native/0010-background-drawable-replacement.patch
+++ b/patches/maplibre-native/0010-background-drawable-replacement.patch
@@ -14,92 +14,66 @@ index b8f7fc1..8eadd64 100644
          layerGroup->addLayerTweaker(layerTweaker);
      }
 diff --git a/test/map/map.test.cpp b/test/map/map.test.cpp
-index 3efba23..f3fd2c0 100644
+index 3efba23..e1db62f 100644
 --- a/test/map/map.test.cpp
 +++ b/test/map/map.test.cpp
-@@ -1,3 +1,6 @@
-+#include <algorithm>
-+#include <array>
-+
- #include <gmock/gmock.h>
- 
- #include <mln/test/util.hpp>
-@@ -1945,6 +1948,80 @@ TEST(Map, ObserveTileLifecycle) {
+@@ -1945,6 +1945,61 @@ TEST(Map, ObserveTileLifecycle) {
      }
  }
  
-+class BackgroundDrawableTest : public testing::Test {
-+protected:
++TEST(BackgroundLayer, ImmediateStyleReplacementRetainsColor) {
 +    MapTest<> test;
-+
-+    void SetUp() override {
-+        test.frontend.setSize({64, 64});
-+        test.map.setSize({64, 64});
-+        loadBaseStyle();
-+    }
-+
-+    void loadBaseStyle() {
-+        // A layer below the tested background prevents the clear-color optimization.
++    for (int iteration = 0; iteration < 2; ++iteration) {
++        SCOPED_TRACE(iteration);
++        // The underlay keeps the tested background out of the clear-color optimization.
 +        test.map.getStyle().loadJSON(R"({
 +            "version": 8,
 +            "sources": {},
 +            "layers": [{"id": "underlay", "type": "background", "paint": {"background-color": "white"}}]
 +        })");
-+    }
-+
-+    BackgroundLayer& addBackground() {
 +        auto layer = std::make_unique<BackgroundLayer>("background");
 +        layer->setBackgroundColor(Color::red());
-+        auto& result = *layer;
 +        test.map.getStyle().addLayer(std::move(layer));
-+        return result;
-+    }
 +
-+    void expectColor(const std::array<uint8_t, 4>& expected) {
 +        const auto image = test.frontend.render(test.map).image;
-+        size_t matchingPixels = 0;
-+        for (size_t i = 0; i < image.bytes(); i += 4) {
-+            const auto* pixel = image.data.get() + i;
-+            matchingPixels += std::equal(expected.begin(), expected.end(), pixel);
-+        }
-+        EXPECT_EQ(matchingPixels, 64u * 64u);
-+    }
-+};
-+
-+TEST_F(BackgroundDrawableTest, ImmediateStyleReplacementRetainsColor) {
-+    for (int iteration = 0; iteration < 3; ++iteration) {
-+        SCOPED_TRACE(iteration);
-+        loadBaseStyle();
-+        addBackground();
-+        expectColor({255, 0, 0, 255});
++        const auto* pixel = image.data.get() + (image.size.height / 2) * image.stride() +
++                            (image.size.width / 2) * image.channels;
++        EXPECT_EQ(pixel[0], 255);
++        EXPECT_EQ(pixel[1], 0);
++        EXPECT_EQ(pixel[2], 0);
++        EXPECT_EQ(pixel[3], 255);
 +    }
 +}
 +
-+TEST_F(BackgroundDrawableTest, PaintChangesAndSameIDReinsertionRetainColor) {
-+    auto& layer = addBackground();
-+    expectColor({255, 0, 0, 255});
-+    layer.setBackgroundColor(Color::blue());
-+    expectColor({0, 0, 255, 255});
-+    test.map.getStyle().removeLayer("background");
-+    addBackground();
-+    expectColor({255, 0, 0, 255});
-+}
-+
-+TEST_F(BackgroundDrawableTest, SwitchesBetweenSolidAndPatternedDrawables) {
-+    PremultipliedImage pattern({2, 2});
-+    for (size_t i = 0; i < pattern.bytes(); i += 4) {
-+        pattern.data[i] = 0;
-+        pattern.data[i + 1] = 0;
-+        pattern.data[i + 2] = 255;
-+        pattern.data[i + 3] = 255;
-+    }
-+    test.map.getStyle().addImage(std::make_unique<style::Image>("blue", std::move(pattern), 1.0f));
-+    auto& layer = addBackground();
-+    expectColor({255, 0, 0, 255});
-+    layer.setBackgroundPattern({"blue"s});
-+    expectColor({0, 0, 255, 255});
-+    layer.setBackgroundPattern({});
-+    expectColor({255, 0, 0, 255});
++TEST(BackgroundLayer, SwitchesBetweenSolidAndPatternedDrawables) {
++    MapTest<> test;
++    // The underlay forces shader selection through the drawable path.
++    test.map.getStyle().loadJSON(R"({
++        "version": 8,
++        "sources": {},
++        "layers": [
++            {"id": "underlay", "type": "background", "paint": {"background-color": "white"}},
++            {"id": "background", "type": "background", "paint": {"background-color": "red"}}
++        ]
++    })");
++    const uint8_t blue[] = {0, 0, 255, 255};
++    test.map.getStyle().addImage(
++        std::make_unique<style::Image>("blue", PremultipliedImage({1, 1}, blue, sizeof(blue)), 1.0f));
++    auto* layer = static_cast<BackgroundLayer*>(test.map.getStyle().getLayer("background"));
++    const auto expectColor = [&](uint8_t red, uint8_t blueChannel) {
++        const auto image = test.frontend.render(test.map).image;
++        const auto* pixel = image.data.get() + (image.size.height / 2) * image.stride() +
++                            (image.size.width / 2) * image.channels;
++        EXPECT_EQ(pixel[0], red);
++        EXPECT_EQ(pixel[1], 0);
++        EXPECT_EQ(pixel[2], blueChannel);
++        EXPECT_EQ(pixel[3], 255);
++    };
++    expectColor(255, 0);
++    layer->setBackgroundPattern({"blue"s});
++    expectColor(0, 255);
++    layer->setBackgroundPattern({});
++    expectColor(255, 0);
 +}
 +
  TEST(BackgroundLayer, StyleUpdateZoomDependency) {

--- a/patches/maplibre-native/0010-background-drawable-replacement.patch
+++ b/patches/maplibre-native/0010-background-drawable-replacement.patch
@@ -1,0 +1,107 @@
+diff --git a/src/mln/renderer/layers/render_background_layer.cpp b/src/mln/renderer/layers/render_background_layer.cpp
+index b8f7fc1..8eadd64 100644
+--- a/src/mln/renderer/layers/render_background_layer.cpp
++++ b/src/mln/renderer/layers/render_background_layer.cpp
+@@ -164,6 +164,10 @@ void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
+     auto* tileLayerGroup = static_cast<TileLayerGroup*>(layerGroup.get());
+ 
+     if (!layerTweaker) {
++        // Background drawables have no source buckets to replace them after a
++        // style change. Rebuild them so the new tweaker populates the group's
++        // uniform buffers for every drawable.
++        removeAllDrawables();
+         layerTweaker = std::make_shared<BackgroundLayerTweaker>(getID(), evaluatedProperties);
+         layerGroup->addLayerTweaker(layerTweaker);
+     }
+diff --git a/test/map/map.test.cpp b/test/map/map.test.cpp
+index 3efba23..f3fd2c0 100644
+--- a/test/map/map.test.cpp
++++ b/test/map/map.test.cpp
+@@ -1,3 +1,6 @@
++#include <algorithm>
++#include <array>
++
+ #include <gmock/gmock.h>
+ 
+ #include <mln/test/util.hpp>
+@@ -1945,6 +1948,80 @@ TEST(Map, ObserveTileLifecycle) {
+     }
+ }
+ 
++class BackgroundDrawableTest : public testing::Test {
++protected:
++    MapTest<> test;
++
++    void SetUp() override {
++        test.frontend.setSize({64, 64});
++        test.map.setSize({64, 64});
++        loadBaseStyle();
++    }
++
++    void loadBaseStyle() {
++        // A layer below the tested background prevents the clear-color optimization.
++        test.map.getStyle().loadJSON(R"({
++            "version": 8,
++            "sources": {},
++            "layers": [{"id": "underlay", "type": "background", "paint": {"background-color": "white"}}]
++        })");
++    }
++
++    BackgroundLayer& addBackground() {
++        auto layer = std::make_unique<BackgroundLayer>("background");
++        layer->setBackgroundColor(Color::red());
++        auto& result = *layer;
++        test.map.getStyle().addLayer(std::move(layer));
++        return result;
++    }
++
++    void expectColor(const std::array<uint8_t, 4>& expected) {
++        const auto image = test.frontend.render(test.map).image;
++        size_t matchingPixels = 0;
++        for (size_t i = 0; i < image.bytes(); i += 4) {
++            const auto* pixel = image.data.get() + i;
++            matchingPixels += std::equal(expected.begin(), expected.end(), pixel);
++        }
++        EXPECT_EQ(matchingPixels, 64u * 64u);
++    }
++};
++
++TEST_F(BackgroundDrawableTest, ImmediateStyleReplacementRetainsColor) {
++    for (int iteration = 0; iteration < 3; ++iteration) {
++        SCOPED_TRACE(iteration);
++        loadBaseStyle();
++        addBackground();
++        expectColor({255, 0, 0, 255});
++    }
++}
++
++TEST_F(BackgroundDrawableTest, PaintChangesAndSameIDReinsertionRetainColor) {
++    auto& layer = addBackground();
++    expectColor({255, 0, 0, 255});
++    layer.setBackgroundColor(Color::blue());
++    expectColor({0, 0, 255, 255});
++    test.map.getStyle().removeLayer("background");
++    addBackground();
++    expectColor({255, 0, 0, 255});
++}
++
++TEST_F(BackgroundDrawableTest, SwitchesBetweenSolidAndPatternedDrawables) {
++    PremultipliedImage pattern({2, 2});
++    for (size_t i = 0; i < pattern.bytes(); i += 4) {
++        pattern.data[i] = 0;
++        pattern.data[i + 1] = 0;
++        pattern.data[i + 2] = 255;
++        pattern.data[i + 3] = 255;
++    }
++    test.map.getStyle().addImage(std::make_unique<style::Image>("blue", std::move(pattern), 1.0f));
++    auto& layer = addBackground();
++    expectColor({255, 0, 0, 255});
++    layer.setBackgroundPattern({"blue"s});
++    expectColor({0, 0, 255, 255});
++    layer.setBackgroundPattern({});
++    expectColor({255, 0, 0, 255});
++}
++
+ TEST(BackgroundLayer, StyleUpdateZoomDependency) {
+     using namespace mln::style::expression::dsl;
+ 

--- a/patches/maplibre-native/README.md
+++ b/patches/maplibre-native/README.md
@@ -8,33 +8,41 @@ only until it lands there.
 `0002-windows-local-file-urls.patch` removes the URI-only leading slash from
 canonical Windows drive paths and opens UTF-8 filenames through wide filesystem
 APIs. This lets the local file source load percent-encoded `file:///C:/...`
-resources whose paths contain spaces or non-ASCII characters.
+resources whose paths contain spaces or non-ASCII characters. Upstream:
+[maplibre-native#4572](https://github.com/maplibre/maplibre-native/pull/4572).
 
 `0003-run-loop-process-gate.patch` adds an optional gate callback to
 `RunLoop::process()`, consulted before each queued task is dequeued. The C API
 uses it to bound one pump's drain; the budget logic stays on the C API side, and
-an unset gate keeps upstream behavior.
+an unset gate keeps upstream behavior. Upstream:
+[maplibre-native#4577](https://github.com/maplibre/maplibre-native/pull/4577).
+The upstream proposal uses a deadline budget in place of the gate callback.
 
 `0004-opengl-valid-api-calls.patch` allocates storage before copying a uniform
 buffer and isolates allocation errors from earlier OpenGL calls. This prevents
 strict implementations and the API 26 Android emulator from turning stale errors
-into false allocation failures.
+into false allocation failures. Upstream:
+[maplibre-native#4578](https://github.com/maplibre/maplibre-native/pull/4578).
 
 `0005-unwrapped-unprojection.patch` adds wrap-mode overloads to map and
 standalone projection coordinate conversion. The C API uses them to expose
 continuous longitudes while the existing overloads keep wrapped behavior.
+Upstream:
+[maplibre-native#4573](https://github.com/maplibre/maplibre-native/pull/4573).
 
 `0006-process-lifetime-logging.patch` gives the global logger, its observer,
 mutex, severity settings, and scheduler process lifetime. This prevents static
 destruction from joining a logging worker whose thread-local cleanup must detach
 from an already shut down host VM. Explicit observer replacement and removal
-still release the previous observer.
+still release the previous observer. Upstream:
+[maplibre-native#4574](https://github.com/maplibre/maplibre-native/pull/4574).
 
 `0007-retain-active-on-demand-images.patch` keeps present on-demand images
 registered to their requestor when the same request also needs missing images.
 This prevents cache cleanup from evicting active tile dependencies. The patch
 includes an ImageManager regression test for retention, delivery, and
-reclamation after the requestor releases its images.
+reclamation after the requestor releases its images. Upstream:
+[maplibre-native#4575](https://github.com/maplibre/maplibre-native/pull/4575).
 
 `0009-synchronous-symbol-dependencies.patch` registers glyph and image
 dependencies before requesting either set. Cached glyphs can return inline for
@@ -42,6 +50,17 @@ synchronous GeoJSON tiles; layout must wait for the images too. The patch
 includes a Native map regression test that checks icon and label pixels across
 zoom changes with a cached glyph range. See
 [issue #698](https://github.com/maplibre/maplibre-native-ffi/issues/698).
+Upstream:
+[maplibre-native#4580](https://github.com/maplibre/maplibre-native/pull/4580).
+
+`0010-background-drawable-replacement.patch` recreates background drawables when
+a style change replaces their property updater. This keeps the drawables and
+their uniform buffers associated with the same updater after same-ID layer
+replacement, paint changes, and solid/pattern changes. The patch includes Native
+pixel-readback regression tests. See
+[issue #709](https://github.com/maplibre/maplibre-native-ffi/issues/709).
+Upstream:
+[maplibre-native#4616](https://github.com/maplibre/maplibre-native/pull/4616).
 
 Drop a patch once the pin moves to a commit that carries it. The sync checks out
 the pinned commit with `--force`, so it discards whatever the last sync applied


### PR DESCRIPTION
## Summary

Vendor the background drawable fix from maplibre/maplibre-native#4616 and link every carried Native patch to its upstream PR; fixes #709.

## Test plan

The macOS Metal C API suite, three Native background tests, six desktop scenarios, patch reverse/idempotence checks, and hygiene checks pass, and both new regressions fail without the fix.

## AI assistance

- **Tools:** Codex (GPT-6).
- **Context:** AI-assisted root-cause investigation, vendored fix, Native regression tests, upstream PR lookup, documentation, and draft descriptions under the user's direction.

