### PR TITLE
Fix invisible OpenGL features on SwiftShader

### DIFF
--- a/.mise/bin/sync-submodules
+++ b/.mise/bin/sync-submodules
@@ -63,6 +63,7 @@ mln_patches=(
   "$repo_root/patches/maplibre-native/0007-retain-active-on-demand-images.patch"
   "$repo_root/patches/maplibre-native/0009-synchronous-symbol-dependencies.patch"
   "$repo_root/patches/maplibre-native/0010-background-drawable-replacement.patch"
+  "$repo_root/patches/maplibre-native/0011-opengl-uniform-block-order.patch"
 )
 
 # A patch counts as applied when it reverses cleanly, which is also what makes

--- a/patches/maplibre-native/0011-opengl-uniform-block-order.patch
+++ b/patches/maplibre-native/0011-opengl-uniform-block-order.patch
@@ -1,0 +1,423 @@
+diff --git a/include/mln/shaders/gl/background_pattern.hpp b/include/mln/shaders/gl/background_pattern.hpp
+index f0f3eae..9d0c0eb 100644
+--- a/include/mln/shaders/gl/background_pattern.hpp
++++ b/include/mln/shaders/gl/background_pattern.hpp
+@@ -42,19 +42,7 @@ void main() {
+     v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_b * u_pattern_size_b, u_tile_units_to_pixels, a_pos);
+ }
+ )";
+-    static constexpr const char* fragment = R"(layout (std140) uniform GlobalPaintParamsUBO {
+-    highp vec2 u_pattern_atlas_texsize;
+-    highp vec2 u_units_to_pixels;
+-    highp vec2 u_world_size;
+-    highp float u_camera_to_center_distance;
+-    highp float u_symbol_fade_change;
+-    highp float u_aspect_ratio;
+-    highp float u_pixel_ratio;
+-    highp float u_map_zoom;
+-    lowp float global_pad1;
+-};
+-
+-layout (std140) uniform BackgroundPatternPropsUBO {
++    static constexpr const char* fragment = R"(layout (std140) uniform BackgroundPatternPropsUBO {
+     highp vec2 u_pattern_tl_a;
+     highp vec2 u_pattern_br_a;
+     highp vec2 u_pattern_tl_b;
+@@ -67,6 +55,18 @@ layout (std140) uniform BackgroundPatternPropsUBO {
+     highp float u_opacity;
+ };
+ 
++layout (std140) uniform GlobalPaintParamsUBO {
++    highp vec2 u_pattern_atlas_texsize;
++    highp vec2 u_units_to_pixels;
++    highp vec2 u_world_size;
++    highp float u_camera_to_center_distance;
++    highp float u_symbol_fade_change;
++    highp float u_aspect_ratio;
++    highp float u_pixel_ratio;
++    highp float u_map_zoom;
++    lowp float global_pad1;
++};
++
+ uniform sampler2D u_image;
+ 
+ in mediump vec2 v_pos_a;
+diff --git a/include/mln/shaders/gl/line_sdf.hpp b/include/mln/shaders/gl/line_sdf.hpp
+index 2b1c870..0833dc4 100644
+--- a/include/mln/shaders/gl/line_sdf.hpp
++++ b/include/mln/shaders/gl/line_sdf.hpp
+@@ -188,14 +188,7 @@ lowp float floorwidth = u_floorwidth;
+     v_width2 = vec2(outset, inset);
+ }
+ )";
+-    static constexpr const char* fragment = R"(layout (std140) uniform LineSDFTilePropsUBO {
+-    highp float u_sdfgamma;
+-    highp float u_mix;
+-    lowp float tileprops_pad1;
+-    lowp float tileprops_pad2;
+-};
+-
+-layout (std140) uniform LineEvaluatedPropsUBO {
++    static constexpr const char* fragment = R"(layout (std140) uniform LineEvaluatedPropsUBO {
+     highp vec4 u_color;
+     lowp float u_blur;
+     lowp float u_opacity;
+@@ -207,6 +200,13 @@ layout (std140) uniform LineEvaluatedPropsUBO {
+     lowp float props_pad2;
+ };
+ 
++layout (std140) uniform LineSDFTilePropsUBO {
++    highp float u_sdfgamma;
++    highp float u_mix;
++    lowp float tileprops_pad1;
++    lowp float tileprops_pad2;
++};
++
+ uniform sampler2D u_image;
+ 
+ in vec2 v_normal;
+diff --git a/include/mln/shaders/gl/symbol_icon.hpp b/include/mln/shaders/gl/symbol_icon.hpp
+index 194c200..e6b803a 100644
+--- a/include/mln/shaders/gl/symbol_icon.hpp
++++ b/include/mln/shaders/gl/symbol_icon.hpp
+@@ -148,13 +148,6 @@ lowp float opacity = u_opacity;
+ )";
+     static constexpr const char* fragment = R"(uniform sampler2D u_texture;
+ 
+-layout (std140) uniform SymbolTilePropsUBO {
+-    bool u_is_text;
+-    bool u_is_halo;
+-    highp float u_gamma_scale;
+-    lowp float tileprops_pad1;
+-};
+-
+ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     highp vec4 u_text_fill_color;
+     highp vec4 u_text_halo_color;
+@@ -170,6 +163,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     lowp float props_pad2;
+ };
+ 
++layout (std140) uniform SymbolTilePropsUBO {
++    bool u_is_text;
++    bool u_is_halo;
++    highp float u_gamma_scale;
++    lowp float tileprops_pad1;
++};
++
+ in vec2 v_tex;
+ in float v_fade_opacity;
+ 
+diff --git a/include/mln/shaders/gl/symbol_sdf.hpp b/include/mln/shaders/gl/symbol_sdf.hpp
+index 0e43733..6cbc7fd 100644
+--- a/include/mln/shaders/gl/symbol_sdf.hpp
++++ b/include/mln/shaders/gl/symbol_sdf.hpp
+@@ -205,13 +205,6 @@ lowp float halo_blur = u_halo_blur;
+ )";
+     static constexpr const char* fragment = R"(#define SDF_PX 8.0
+ 
+-layout (std140) uniform SymbolTilePropsUBO {
+-    bool u_is_text;
+-    bool u_is_halo;
+-    highp float u_gamma_scale;
+-    lowp float tileprops_pad1;
+-};
+-
+ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     highp vec4 u_text_fill_color;
+     highp vec4 u_text_halo_color;
+@@ -227,6 +220,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     lowp float props_pad2;
+ };
+ 
++layout (std140) uniform SymbolTilePropsUBO {
++    bool u_is_text;
++    bool u_is_halo;
++    highp float u_gamma_scale;
++    lowp float tileprops_pad1;
++};
++
+ uniform sampler2D u_texture;
+ 
+ in vec2 v_data0;
+diff --git a/include/mln/shaders/gl/symbol_text_and_icon.hpp b/include/mln/shaders/gl/symbol_text_and_icon.hpp
+index 27ceb07..89ad613 100644
+--- a/include/mln/shaders/gl/symbol_text_and_icon.hpp
++++ b/include/mln/shaders/gl/symbol_text_and_icon.hpp
+@@ -208,13 +208,6 @@ lowp float halo_blur = u_halo_blur;
+ #define SDF 1.0
+ #define ICON 0.0
+ 
+-layout (std140) uniform SymbolTilePropsUBO {
+-    bool u_is_text;
+-    bool u_is_halo;
+-    highp float u_gamma_scale;
+-    lowp float tileprops_pad1;
+-};
+-
+ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     highp vec4 u_text_fill_color;
+     highp vec4 u_text_halo_color;
+@@ -230,6 +223,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     lowp float props_pad2;
+ };
+ 
++layout (std140) uniform SymbolTilePropsUBO {
++    bool u_is_text;
++    bool u_is_halo;
++    highp float u_gamma_scale;
++    lowp float tileprops_pad1;
++};
++
+ uniform sampler2D u_texture;
+ uniform sampler2D u_texture_icon;
+ 
+diff --git a/shaders/background_pattern.fragment.glsl b/shaders/background_pattern.fragment.glsl
+index 8729d5d..d61a9d2 100644
+--- a/shaders/background_pattern.fragment.glsl
++++ b/shaders/background_pattern.fragment.glsl
+@@ -1,15 +1,3 @@
+-layout (std140) uniform GlobalPaintParamsUBO {
+-    highp vec2 u_pattern_atlas_texsize;
+-    highp vec2 u_units_to_pixels;
+-    highp vec2 u_world_size;
+-    highp float u_camera_to_center_distance;
+-    highp float u_symbol_fade_change;
+-    highp float u_aspect_ratio;
+-    highp float u_pixel_ratio;
+-    highp float u_map_zoom;
+-    lowp float global_pad1;
+-};
+-
+ layout (std140) uniform BackgroundPatternPropsUBO {
+     highp vec2 u_pattern_tl_a;
+     highp vec2 u_pattern_br_a;
+@@ -23,6 +11,18 @@ layout (std140) uniform BackgroundPatternPropsUBO {
+     highp float u_opacity;
+ };
+ 
++layout (std140) uniform GlobalPaintParamsUBO {
++    highp vec2 u_pattern_atlas_texsize;
++    highp vec2 u_units_to_pixels;
++    highp vec2 u_world_size;
++    highp float u_camera_to_center_distance;
++    highp float u_symbol_fade_change;
++    highp float u_aspect_ratio;
++    highp float u_pixel_ratio;
++    highp float u_map_zoom;
++    lowp float global_pad1;
++};
++
+ uniform sampler2D u_image;
+ 
+ in mediump vec2 v_pos_a;
+diff --git a/shaders/line_sdf.fragment.glsl b/shaders/line_sdf.fragment.glsl
+index 852f5f6..2e800e1 100644
+--- a/shaders/line_sdf.fragment.glsl
++++ b/shaders/line_sdf.fragment.glsl
+@@ -1,10 +1,3 @@
+-layout (std140) uniform LineSDFTilePropsUBO {
+-    highp float u_sdfgamma;
+-    highp float u_mix;
+-    lowp float tileprops_pad1;
+-    lowp float tileprops_pad2;
+-};
+-
+ layout (std140) uniform LineEvaluatedPropsUBO {
+     highp vec4 u_color;
+     lowp float u_blur;
+@@ -17,6 +10,13 @@ layout (std140) uniform LineEvaluatedPropsUBO {
+     lowp float props_pad2;
+ };
+ 
++layout (std140) uniform LineSDFTilePropsUBO {
++    highp float u_sdfgamma;
++    highp float u_mix;
++    lowp float tileprops_pad1;
++    lowp float tileprops_pad2;
++};
++
+ uniform sampler2D u_image;
+ 
+ in vec2 v_normal;
+diff --git a/shaders/symbol_icon.fragment.glsl b/shaders/symbol_icon.fragment.glsl
+index ce3a301..c39859f 100644
+--- a/shaders/symbol_icon.fragment.glsl
++++ b/shaders/symbol_icon.fragment.glsl
+@@ -1,12 +1,5 @@
+ uniform sampler2D u_texture;
+ 
+-layout (std140) uniform SymbolTilePropsUBO {
+-    bool u_is_text;
+-    bool u_is_halo;
+-    highp float u_gamma_scale;
+-    lowp float tileprops_pad1;
+-};
+-
+ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     highp vec4 u_text_fill_color;
+     highp vec4 u_text_halo_color;
+@@ -22,6 +15,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     lowp float props_pad2;
+ };
+ 
++layout (std140) uniform SymbolTilePropsUBO {
++    bool u_is_text;
++    bool u_is_halo;
++    highp float u_gamma_scale;
++    lowp float tileprops_pad1;
++};
++
+ in vec2 v_tex;
+ in float v_fade_opacity;
+ 
+diff --git a/shaders/symbol_sdf.fragment.glsl b/shaders/symbol_sdf.fragment.glsl
+index 76bfd36..c50ba67 100644
+--- a/shaders/symbol_sdf.fragment.glsl
++++ b/shaders/symbol_sdf.fragment.glsl
+@@ -1,12 +1,5 @@
+ #define SDF_PX 8.0
+ 
+-layout (std140) uniform SymbolTilePropsUBO {
+-    bool u_is_text;
+-    bool u_is_halo;
+-    highp float u_gamma_scale;
+-    lowp float tileprops_pad1;
+-};
+-
+ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     highp vec4 u_text_fill_color;
+     highp vec4 u_text_halo_color;
+@@ -22,6 +15,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     lowp float props_pad2;
+ };
+ 
++layout (std140) uniform SymbolTilePropsUBO {
++    bool u_is_text;
++    bool u_is_halo;
++    highp float u_gamma_scale;
++    lowp float tileprops_pad1;
++};
++
+ uniform sampler2D u_texture;
+ 
+ in vec2 v_data0;
+diff --git a/shaders/symbol_text_and_icon.fragment.glsl b/shaders/symbol_text_and_icon.fragment.glsl
+index ce5d120..1ada6fa 100644
+--- a/shaders/symbol_text_and_icon.fragment.glsl
++++ b/shaders/symbol_text_and_icon.fragment.glsl
+@@ -3,13 +3,6 @@
+ #define SDF 1.0
+ #define ICON 0.0
+ 
+-layout (std140) uniform SymbolTilePropsUBO {
+-    bool u_is_text;
+-    bool u_is_halo;
+-    highp float u_gamma_scale;
+-    lowp float tileprops_pad1;
+-};
+-
+ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     highp vec4 u_text_fill_color;
+     highp vec4 u_text_halo_color;
+@@ -25,6 +18,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
+     lowp float props_pad2;
+ };
+ 
++layout (std140) uniform SymbolTilePropsUBO {
++    bool u_is_text;
++    bool u_is_halo;
++    highp float u_gamma_scale;
++    lowp float tileprops_pad1;
++};
++
+ uniform sampler2D u_texture;
+ uniform sampler2D u_texture_icon;
+ 
+diff --git a/test/map/map.test.cpp b/test/map/map.test.cpp
+--- a/test/map/map.test.cpp
++++ b/test/map/map.test.cpp
+@@ -2096,6 +2096,83 @@
+     test::checkImage("test/fixtures/map/setFrustumOffset/after", test.frontend.render(test.map).image, 0.0006, 0.1);
+ }
+ 
++class UniformBlockOrderTest : public testing::TestWithParam<std::string> {};
++
++TEST_P(UniformBlockOrderTest, RendersPaintColors) {
++    const auto& kind = GetParam();
++    const bool withText = kind == "text" || kind == "mixed";
++    const bool withImage = kind == "icon" || kind == "mixed" || kind == "background";
++    MapTest<> test;
++    test.fileSource->glyphsResponse = makeResponse("glyphs.pbf");
++    test.map.getStyle().loadJSON(R"({
++        "version": 8,
++        "glyphs": "https://example.com/{fontstack}/{range}.pbf",
++        "sources": {},
++        "layers": [{"id": "background", "type": "background", "paint": {"background-color": "white"}}]
++    })");
++    if (withImage) {
++        PremultipliedImage icon({32, 32});
++        for (size_t i = 0; i < icon.bytes(); i += 4) {
++            icon.data[i] = 0;
++            icon.data[i + 1] = 0;
++            icon.data[i + 2] = 255;
++            icon.data[i + 3] = 255;
++        }
++        test.map.getStyle().addImage(std::make_unique<style::Image>("box", std::move(icon), 1.0f));
++    }
++    if (kind == "background") {
++        auto layer = std::make_unique<BackgroundLayer>("pattern");
++        layer->setBackgroundPattern({"box"s});
++        test.map.getStyle().addLayer(std::move(layer));
++    } else {
++        auto source = std::make_unique<GeoJSONSource>("geometry");
++        if (kind == "line") {
++            source->setGeoJSON(Geometry<double>{LineString<double>{{-20.0, 0.0}, {20.0, 0.0}}});
++        } else {
++            source->setGeoJSON(Geometry<double>{Point<double>{0.0, 0.0}});
++        }
++        test.map.getStyle().addSource(std::move(source));
++        if (kind == "line") {
++            auto layer = std::make_unique<LineLayer>("line", "geometry");
++            layer->setLineColor(Color::red());
++            layer->setLineWidth(16.0f);
++            layer->setLineDasharray(std::vector<float>{2.0f, 2.0f});
++            test.map.getStyle().addLayer(std::move(layer));
++        } else {
++            auto layer = std::make_unique<SymbolLayer>("symbol", "geometry");
++            if (withText) {
++                expression::Formatted text("AB");
++                if (withImage) text.sections.emplace_back(expression::Image("box"));
++                layer->setTextField(text);
++                layer->setTextFont(FontStack{"Open Sans Regular"});
++                layer->setTextSize(64.0f);
++                layer->setTextColor(Color::red());
++                layer->setTextAllowOverlap(true);
++            } else {
++                layer->setIconImage({"box"s});
++                layer->setIconAllowOverlap(true);
++            }
++            test.map.getStyle().addLayer(std::move(layer));
++        }
++    }
++    test.map.jumpTo(CameraOptions().withCenter(LatLng{0.0, 0.0}).withZoom(2.0));
++    const auto image = test.frontend.render(test.map).image;
++    size_t redPixels = 0;
++    size_t bluePixels = 0;
++    for (size_t i = 0; i < image.bytes(); i += 4) {
++        const auto* pixel = image.data.get() + i;
++        redPixels += pixel[0] > 200 && pixel[1] < 100 && pixel[2] < 100;
++        bluePixels += pixel[2] > 200 && pixel[0] < 100 && pixel[1] < 100;
++    }
++    if (withText || kind == "line") EXPECT_GT(redPixels, 100u);
++    if (withImage) EXPECT_GT(bluePixels, 100u);
++}
++
++INSTANTIATE_TEST_SUITE_P(Rendering,
++                         UniformBlockOrderTest,
++                         testing::Values("text", "icon", "mixed", "line", "background"),
++                         [](const testing::TestParamInfo<std::string>& info) { return info.param; });
++
+ // End-to-end: a feature-state change must alter the *rendered* output, not just
+ // the value read back through the API. A fill covering the viewport is colored
+ // by a data-driven expression on feature-state "active" (blue by default, red

--- a/patches/maplibre-native/README.md
+++ b/patches/maplibre-native/README.md
@@ -68,6 +68,8 @@ incorrect paint values and renders symbols, dashed lines, and patterned
 backgrounds transparently on Android x86_64. Native map pixel-readback
 regressions cover all five shaders using the existing glyph fixture. See
 [issue #713](https://github.com/maplibre/maplibre-native-ffi/issues/713).
+Upstream:
+[maplibre-native#4625](https://github.com/maplibre/maplibre-native/pull/4625).
 
 Drop a patch once the pin moves to a commit that carries it. The sync checks out
 the pinned commit with `--force`, so it discards whatever the last sync applied

--- a/patches/maplibre-native/README.md
+++ b/patches/maplibre-native/README.md
@@ -62,6 +62,13 @@ pixel-readback regression tests. See
 Upstream:
 [maplibre-native#4616](https://github.com/maplibre/maplibre-native/pull/4616).
 
+`0011-opengl-uniform-block-order.patch` declares shared uniform blocks before
+fragment-only blocks in five OpenGL shaders. SwiftShader otherwise reads
+incorrect paint values and renders symbols, dashed lines, and patterned
+backgrounds transparently on Android x86_64. Native map pixel-readback
+regressions cover all five shaders using the existing glyph fixture. See
+[issue #713](https://github.com/maplibre/maplibre-native-ffi/issues/713).
+
 Drop a patch once the pin moves to a commit that carries it. The sync checks out
 the pinned commit with `--force`, so it discards whatever the last sync applied
 before applying the list again. A pin bump, an edit to a patch, and a dropped


### PR DESCRIPTION
## Summary

Fix invisible symbols, dashed lines, and patterned backgrounds on Android SwiftShader by declaring shared uniform blocks first in five OpenGL shaders (fixes #713).

## Test plan

Verified five Native rendering regressions fail before and pass after on Android x86_64 SwiftShader under QEMU; all five pass on Metal, and the Android EGL build and hygiene checks pass.

## AI assistance

- **Tools:** Codex
- **Context:** Investigated #713, prepared the vendored shader patch and Native regressions, and ran the before/after rendering checks.
